### PR TITLE
printing of variables names in step_range when printing recipe object

### DIFF
--- a/R/range.R
+++ b/R/range.R
@@ -135,7 +135,7 @@ bake.step_range <- function(object, newdata, ...) {
 print.step_range <-
   function(x, width = max(20, options()$width - 30), ...) {
     cat("Range scaling to [", x$min, ",", x$max, "] for ", sep = "")
-    printer(names(x$ranges), x$terms, x$trained, width = width)
+    printer(colnames(x$ranges), x$terms, x$trained, width = width)
     invisible(x)
   }
 


### PR DESCRIPTION
When printing a recipe object containing a `step_range`, the output didn't list the names of the variables to which the transformation was applied, possibly giving the false impression that nothing was done.
