### PR TITLE
Include example using imp_vars

### DIFF
--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -83,6 +83,23 @@
 #'
 #' tidy(impute_rec, number = 1)
 #' tidy(imp_models, number = 1)
+#'
+#' ## Specifying which variables to imputate with
+#'
+#'  impute_rec <- rec %>%
+#'   step_bagimpute(Status, Home, Marital, Job, Income, Assets, Debt,
+#'                  impute_with = imp_vars(Time, Age, Expenses))
+#'
+#' imp_models <- prep(impute_rec, training = credit_tr)
+#'
+#' imputed_te <- bake(imp_models, newdata = credit_te, everything())
+#'
+#' credit_te[missing_examples,]
+#' imputed_te[missing_examples, names(credit_te)]
+#'
+#' tidy(impute_rec, number = 1)
+#' tidy(imp_models, number = 1)
+#'
 
 step_bagimpute <-
   function(recipe,

--- a/man/step_bagimpute.Rd
+++ b/man/step_bagimpute.Rd
@@ -118,6 +118,23 @@ imputed_te[missing_examples, names(credit_te)]
 
 tidy(impute_rec, number = 1)
 tidy(imp_models, number = 1)
+
+## Specifying which variables to imputate with
+
+ impute_rec <- rec \%>\%
+  step_bagimpute(Status, Home, Marital, Job, Income, Assets, Debt,
+                 impute_with = imp_vars(Time, Age, Expenses))
+
+imp_models <- prep(impute_rec, training = credit_tr)
+
+imputed_te <- bake(imp_models, newdata = credit_te, everything())
+
+credit_te[missing_examples,]
+imputed_te[missing_examples, names(credit_te)]
+
+tidy(impute_rec, number = 1)
+tidy(imp_models, number = 1)
+
 }
 \references{
 Kuhn, M. and Johnson, K. (2013). \emph{Applied


### PR DESCRIPTION
I found it a little puzzling that imp_vars was included in the documentation but wasn't used in the examples. So I added a example showing how to use `imp_vars`.