### PR TITLE
Fix/more robust selector parser

### DIFF
--- a/R/selections.R
+++ b/R/selections.R
@@ -128,6 +128,8 @@ selectors <-
 element_check <- function(x, allowed = selectors) {
   funs <- fun_calls(x)
   funs <- funs[!(funs %in% c("~", "+", "-"))]
+  # i.e. tidyselect::matches()
+  funs <- funs[!(funs %in% c("::", "tidyselect", "dplyr"))]
   if (!is.null(allowed)) {
     # when called from a step
     not_good <- funs[!(funs %in% allowed)]

--- a/tests/testthat/test_downsample.R
+++ b/tests/testthat/test_downsample.R
@@ -14,10 +14,10 @@ rec <- recipe( ~ ., data = iris2)
 
 test_that('basic usage', {
   rec1 <- rec %>%
-    step_downsample(matches("Species$"), id = "")
+    step_downsample(tidyselect::matches("Species$"), id = "")
 
   untrained <- tibble(
-    terms = "matches(\"Species$\")",
+    terms = "tidyselect::matches(\"Species$\")",
     id = ""
   )
 
@@ -46,7 +46,7 @@ test_that('basic usage', {
 
 test_that('ratio value', {
   rec2 <- rec %>%
-    step_downsample(matches("Species$"), ratio = 2)
+    step_downsample(tidyselect::matches("Species$"), ratio = 2)
 
   rec2_p <- prep(rec2, training = iris2, retain = TRUE)
 
@@ -62,7 +62,7 @@ test_that('ratio value', {
 
 test_that('no skipping', {
   rec3 <- rec %>%
-    step_downsample(matches("Species$"), skip = FALSE)
+    step_downsample(tidyselect::matches("Species$"), skip = FALSE)
 
   rec3_p <- prep(rec3, training = iris2, retain = TRUE)
 

--- a/tests/testthat/test_select_terms.R
+++ b/tests/testthat/test_select_terms.R
@@ -105,5 +105,14 @@ test_that('combinations', {
   )
 })
 
-
+test_that('namespaced selectors', {
+  expect_equal(
+    terms_select(info = info1, quos(tidyselect::matches("e$"))),
+    terms_select(info = info1, quos(matches("e$")))
+  )
+  expect_equal(
+    terms_select(info = info1, quos(dplyr::matches("e$"))),
+    terms_select(info = info1, quos(matches("e$")))
+  )
+})
 


### PR DESCRIPTION
* Allow `tidyselect::matches()` and `dplyr::matches()` rather than just `matches()`