### PR TITLE
Added condition to `nn_ind` to capture K

### DIFF
--- a/R/knn_imp.R
+++ b/R/knn_imp.R
@@ -206,7 +206,7 @@ bake.step_knnimpute <- function(object, new_data, ...) {
         imp_var_complete <- !is.na(object$ref_data[[imp_var]])
         nn_ind <- nn_index(object$ref_data[imp_var_complete,],
                            imp_data, preds,
-                           object$neighbors)
+                           ifelse(!is.null(object$K), object$K, object$neighbors))
         pred_vals <-
           apply(nn_ind, 2, nn_pred, dat = object$ref_data[imp_var_complete, imp_var])
         new_data[missing_rows, imp_var] <- pred_vals


### PR DESCRIPTION
I added a condition to capture old `K` arguments supplied to step_knnimpute(). I encountered the error "$ Operator is invalid for atomic vectors" since object$neighbors did not exist for a recipe I prepped prior to the implementation of https://github.com/tidymodels/recipes/issues/177. It would be a hassle to completely retrain the data. I was able to informally fix the issue with: model$recipe$steps[[2]]$neighbors <- 5, but this proposed change makes it more formal.