### PR TITLE
fixed issue 301

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -191,6 +191,7 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     ## in `bake.step_dummy` just prior to calling `model.matrix`
     attr(levels[[i]], "values") <-
       levels(getElement(training, col_names[i]))
+    attr(levels[[i]], ".Environment") <- NULL
   }
 
   step_dummy_new(


### PR DESCRIPTION
in prep.step_dummy, the terms object has an embedded environment. Setting it NULL results in significant reduction in serialized recipes size when using save, saveRDS or other save methods.