### PR TITLE
Fixed Issue 301 - news and unit test included

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,9 @@
 
 * `step_interact` will no longer fail if an interaction contains an interaction using column that has been previously filtered from the data. A warning is issued when this happens and no interaction terms will be created.
 
-* `step_corr` was made more fault tolerant for cases where the data contain a zero-variance column or columns with missing values. 
+* `step_corr` was made more fault tolerant for cases where the data contain a zero-variance column or columns with missing values.
+
+* Set the embedded environment to NULL in `prep.step_dummy` to reduce the file size of serialized recipe class objects when using `saveRDS`.
  
 ## Breaking Changes
 

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -191,6 +191,7 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     ## in `bake.step_dummy` just prior to calling `model.matrix`
     attr(levels[[i]], "values") <-
       levels(getElement(training, col_names[i]))
+    attr(levels[[i]], ".Environment") <- NULL
   }
 
   step_dummy_new(

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -194,7 +194,28 @@ test_that('new levels', {
   )
 })
 
+test_that('tests for issue #301', {
 
+  rec <- recipe(~ Species, data = iris)
+  dummies <- rec %>% step_dummy(Species)
+  dummies <- prep(dummies, training = iris)
+  expect_equal(NULL, attr(dummies$steps[[1]]$levels$Species, ".Environment"))
+
+  saved_recipe <- tempfile()
+  saveRDS(dummies, file = saved_recipe)
+  read_recipe <- readRDS(file = saved_recipe)
+  unlink(saved_recipe)
+  expect_equal(bake(dummies, new_data = iris), bake(read_recipe, new_data = iris))
+
+  saved_dummies <- dummies
+  saved_recipe <- tempfile()
+  save(saved_dummies, file = saved_recipe)
+  rm(saved_dummies)
+  load(file = saved_recipe)
+  unlink(saved_recipe)
+  expect_equal(bake(dummies, new_data = iris), bake(saved_dummies, new_data = iris))
+
+})
 
 
 


### PR DESCRIPTION
in prep.step_dummy, the terms object has an embedded environment. Setting it NULL results in significant reduction in serialized recipes size when using save, saveRDS or other save methods.