### PR TITLE
Add option to return a tibble containing matrices

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -604,6 +604,8 @@ bake.recipe <- function(object, new_data = NULL, ..., composition = "tibble") {
     new_data <- base::as.data.frame(new_data)
   } else if (composition == 'tibble_of_matrix') {
     new_data <- convert_tibble_of_matrices(new_data, object$term_info)
+  } else if (composition == 'data.frame_of_matrix') {
+    new_data <- convert_df_of_matrices(new_data, object$term_info)
   }
 
   new_data
@@ -775,11 +777,13 @@ juice <- function(object, ..., composition = "tibble") {
     new_data <- base::as.data.frame(new_data)
   } else if (composition == 'tibble_of_matrix') {
     new_data <- convert_tibble_of_matrices(new_data, object$term_info)
+  } else if (composition == 'data.frame_of_matrix') {
+    new_data <- convert_df_of_matrices(new_data, object$term_info)
   }
 
   new_data
 }
 
-formats <- c("tibble", "dgCMatrix", "matrix", "data.frame", 'tibble_of_matrix')
+formats <- c("tibble", "dgCMatrix", "matrix", "data.frame", 'tibble_of_matrix', 'data.frame_of_matrix')
 
 utils::globalVariables(c("number"))

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -602,6 +602,8 @@ bake.recipe <- function(object, new_data = NULL, ..., composition = "tibble") {
     new_data <- convert_matrix(new_data, sparse = FALSE)
   } else if (composition == "data.frame") {
     new_data <- base::as.data.frame(new_data)
+  } else if (composition == 'tibble_of_matrix') {
+    new_data <- convert_tibble_of_matrices(new_data, object$term_info)
   }
 
   new_data
@@ -771,11 +773,13 @@ juice <- function(object, ..., composition = "tibble") {
     new_data <- convert_matrix(new_data, sparse = FALSE)
   } else if (composition == "data.frame") {
     new_data <- base::as.data.frame(new_data)
+  } else if (composition == 'tibble_of_matrix') {
+    new_data <- convert_tibble_of_matrices(new_data, object$term_info)
   }
 
   new_data
 }
 
-formats <- c("tibble", "dgCMatrix", "matrix", "data.frame")
+formats <- c("tibble", "dgCMatrix", "matrix", "data.frame", 'tibble_of_matrix')
 
 utils::globalVariables(c("number"))

--- a/R/sparsity.R
+++ b/R/sparsity.R
@@ -32,14 +32,34 @@ convert_matrix <- function(x, sparse = TRUE) {
 }
 
 
+
+
+to_list_of_matrix <- function(col_group, x, is_df = FALSE) {
+
+  if (is_df) {
+    return(I(convert_matrix(select(x, col_group), sparse = FALSE)))
+  } else {
+    return(convert_matrix(select(x, col_group), sparse = FALSE))
+  }
+
+}
+
+
+
 convert_tibble_of_matrices <- function(x, term_info) {
 
-  grps <- split(term_info$variable, term_info$role)
+  role_group <- split(term_info$variable, term_info$role)
 
-  as_tibble(lapply(grps, function(col_groups) {
-    convert_matrix(select(x, col_groups), sparse = FALSE)
-  }))
+  as_tibble(lapply(role_group, to_list_of_matrix, x = x, is_df = FALSE))
 
+
+}
+
+convert_df_of_matrices <- function(x, term_info) {
+
+  role_group <- split(term_info$variable, term_info$role)
+
+  as.data.frame(lapply(role_group, to_list_of_matrix, x = x, is_df = TRUE))
 
 }
 

--- a/R/sparsity.R
+++ b/R/sparsity.R
@@ -31,3 +31,15 @@ convert_matrix <- function(x, sparse = TRUE) {
   res
 }
 
+
+convert_tibble_of_matrices <- function(x, term_info) {
+
+  grps <- split(term_info$variable, term_info$role)
+
+  as_tibble(lapply(grps, function(col_groups) {
+    as.matrix(select(x, col_groups))
+  }))
+
+
+}
+

--- a/R/sparsity.R
+++ b/R/sparsity.R
@@ -37,7 +37,7 @@ convert_tibble_of_matrices <- function(x, term_info) {
   grps <- split(term_info$variable, term_info$role)
 
   as_tibble(lapply(grps, function(col_groups) {
-    as.matrix(select(x, col_groups))
+    convert_matrix(select(x, col_groups), sparse = FALSE)
   }))
 
 

--- a/vignettes/articles/Multivariate_PLS.Rmd
+++ b/vignettes/articles/Multivariate_PLS.Rmd
@@ -23,7 +23,7 @@ _Multivariate Analysis_ usually refers to the situation where multiple _outcomes
 lm(cbind(y1, y2) ~ ., data = dat)
 ```
 
-The `cbind` is pretty awkward and is a consequence of how the traditional formula infrastructure works. `recipes` is a lot easter to work with and this document shows an example to illustrate how to use multiple outcomes.   
+The `cbind` is pretty awkward and is a consequence of how the traditional formula infrastructure works. `recipes` is a lot easier to work with and this document shows an example to illustrate how to use multiple outcomes.   
 
 The data that we'll use has three outcomes. From `?tecator`:
 
@@ -48,7 +48,7 @@ colnames(absorp) <- names0(ncol(absorp))
 tecator <- cbind(endpoints, absorp) %>%
   as.data.frame()
 ```
-The three outcomes have fairly high correlations also. If the outcomes can be predicted using a linear model, partial least squares (PLS) is an idea method. PLS models the data as a function of a set of unobserved _latent_ variables that are derived in a manner similar to principal component analysis (PCA). 
+The three outcomes have fairly high correlations also. If the outcomes can be predicted using a linear model, partial least squares (PLS) is an ideal method. PLS models the data as a function of a set of unobserved _latent_ variables that are derived in a manner similar to principal component analysis (PCA). 
 
 PLS, unlike PCA, also incorporates the outcome data when creating the PLS components. Like PCA it tries to maximize the variance of the predictors that are explained by the components but also tries to simultaneously maximize the correlation between those components and the outcomes. In this way, PLS _chases_ variation of the predictors and outcomes. 
 


### PR DESCRIPTION
Group regressors by **role** into matrices.  These matrices are then put into a tibble. This allows one to specify the matrix column of the tibble in model calls.  For example, after baking a recipe one can now say lm(outcome~lag_variable, rec) where rec is a tibble containing matrices where outcome is a matrix of one or more columns and lag_variable is a matrix column of one more than one columns. This also simplifies **predict** when **type = 'terms'** when we want our regressor output grouped (ie each regressor matrix yields one predict column).

Additional changes:
- added a couple of tests
- fixed two typos in Multivariate Analysis using Partial Least Squares vignette



