### PR TITLE
Modify threshold argument for step_other

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@ Release driven by changes in `rlang`.
  
 ## Other Changes:
 
+* If `threshold` argument of `step_other` is greater than one then it specifies the minimum sample size before the levels of the factor are collapsed into the "other" category. [#289](https://github.com/tidymodels/recipes/issues/289)
+
+
  * `step_knnimpute()` can now pass two options to the underlying knn code, including the number of threads ([#323](https://github.com/tidymodels/recipes/issues/323)). 
 
 * Due to changes by CRAN, `step_nnmf()` only works on versions of R >= 3.6.0 due to dependency issues. 

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -26,9 +26,11 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{threshold}{A single numeric value between 0 (inclusive)
-and 1 for pooling. Factor levels whose rate of occurrence in
-the training set are below \code{threshold} will be "othered".}
+\item{threshold}{A numeric value between 0 and 1 or an integer greater or
+equal to one.  If it's less than one then factor levels whose rate of
+occurrence in the training set are below \code{threshold} will be "othered". If
+it's greater or equal to one then it's treated as a frequency and factor
+levels that occur less then \code{threshold} times will be "othered".}
 
 \item{other}{A single character value for the "other" category.}
 
@@ -60,9 +62,10 @@ step that will potentially pool infrequently occurring values
 into an "other" category.
 }
 \details{
-The overall proportion of the categories are computed. The "other"
-category is used in place of any categorical levels whose individual
-proportion in the training set is less than \code{threshold}.
+The overall proportion (or total counts) of the categories are
+computed. The "other" category is used in place of any categorical levels
+whose individual proportion (or frequency) in the training set is less than
+\code{threshold}.
 
 If no pooling is done the data are unmodified (although character data may
 be changed to factors based on the value of \code{strings_as_factors} in
@@ -107,6 +110,18 @@ tidy(rec, number = 1)
 tahiti <- okc[1,]
 tahiti$location <- "a magical place"
 bake(rec, tahiti)
+
+# threshold as a frequency
+rec <- recipe(~ diet + location, data = okc_tr)
+
+rec <- rec \%>\%
+  step_other(diet, location, threshold = 2000, other = "other values")
+rec <- prep(rec, training = okc_tr)
+
+tidy(rec, number = 1)
+# compare it to
+# okc_tr \%>\% count(diet, sort = TRUE) \%>\% top_n(4)
+# okc_tr \%>\% count(location, sort = TRUE) \%>\% top_n(3)
 }
 \seealso{
 \code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},

--- a/tests/testthat/test_other.R
+++ b/tests/testthat/test_other.R
@@ -203,3 +203,59 @@ test_that('printing', {
   expect_output(prep(rec, training = okc_tr, verbose = TRUE))
 })
 
+test_that(
+  desc = "if threshold argument is an integer greater than one
+          then it's treated as a frequency",
+  code = {
+    others <- rec %>% step_other(diet, location, threshold = 3000, other = "another", id = "")
+
+    tidy_exp_un <- tibble(
+      terms = c("diet", "location"),
+      retained = rep(NA_character_, 2),
+      id = ""
+    )
+
+    expect_equal(tidy_exp_un, tidy(others, number = 1))
+
+    others <- prep(others, training = okc_tr)
+
+    tidy_exp_tr <- tibble(
+      terms = rep(c("diet", "location"), c(4, 3)),
+      retained = c(
+        "anything", "mostly anything", "mostly vegetarian",
+        "strictly anything", "berkeley",
+        "oakland", "san francisco"),
+      id = ""
+    )
+    expect_equal(tidy_exp_tr, tidy(others, number = 1))
+  }
+)
+
+test_that(
+  desc = "if the threshold argument is greather than one then it should be
+          an integer(ish)",
+  code = {
+    expect_error(rec %>% step_other(diet, location, threshold = 3.14))
+  }
+)
+
+test_that(
+  desc = "if threshold is equal to 1 then the function removes every factor
+          level that is not present in the data",
+  code = {
+    fake_data <- data.frame(
+      test_factor = factor(c("A", "B"), levels = c("A", "B", "C"))
+    )
+
+    rec <- recipe(~ test_factor, data = fake_data)
+    others <- rec %>% step_other(test_factor, threshold = 1, id = "") %>% prep()
+
+    tidy_exp_tr <- tibble(
+      terms = rep("test_factor", 2),
+      retained = c("A", "B"),
+      id = ""
+    )
+    expect_equal(tidy_exp_tr, tidy(others, number = 1))
+  }
+)
+


### PR DESCRIPTION
Modify threshold argument of step_other in two ways: 

1) the prop argument is now named threshold; 
2) if threshold is an integer greater or equal than 1 then it specifies the minimum sample size before the factor levels are collapsed into the "other" category. If threshold is exactly equal to 1 then it removes the unused level of the factor. 

 Should close #289. 