### PR TITLE
Remove warnings generated by change in tidyr::nest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,3 +56,5 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
+Remotes:
+    tidyverse/tidyr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     rlang (>= 0.4.0),
     stats,
     tibble,
-    tidyr,
+    tidyr (>= 0.8.3.9000),
     tidyselect (>= 0.2.5),
     timeDate,
     utils,

--- a/R/selections.R
+++ b/R/selections.R
@@ -191,7 +191,7 @@ terms_select <- function(terms, info, empty_fun = abort_selection) {
   lapply(terms, element_check)
 
   # Set current_info so available to helpers
-  nested_info <- tidyr::nest(info, -variable)
+  nested_info <- tidyr::nest(info, data = -variable)
   old_info <- set_current_info(nested_info)
   on.exit(set_current_info(old_info), add = TRUE)
 


### PR DESCRIPTION
Reference: https://github.com/tidyverse/tidyr/blob/4bd80e2293e63823796e3db3712244e179e5911d/R/nest.R#L28

will no longer print 
```
All elements of `...` must be named.
Did you want `data = c(type, role, source)`?
```
 when dev **tidyr** is installed.

Will close #341.