### PR TITLE
Ensure that `juice()` always returns the same number of rows as the template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Other Changes
 
+ * When using a selector that returns no columns, `juice()` and `bake()` will now return a tibble with as many rows as the original template data or the `new_data` respectively. This is more consistent with how selectors work in dplyr ([#411](https://github.com/tidymodels/recipes/issues/411)).
+ 
  * Code was added to explicitly register `tunable` methods when `recipes` is loaded. This is required because of changes occurring in R 4.0. 
  
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -758,7 +758,7 @@ juice <- function(object, ..., composition = "tibble") {
         new_data <- strings2factors(new_data, var_levels)
     }
   } else {
-    new_data <- tibble()
+    new_data <- tibble(.rows = nrow(object$template))
   }
 
   if (composition == "dgCMatrix") {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -579,7 +579,7 @@ bake.recipe <- function(object, new_data = NULL, ..., composition = "tibble") {
         new_data <- strings2factors(new_data, var_levels)
     }
   } else {
-    new_data <- tibble()
+    new_data <- tibble(.rows = nrow(new_data))
   }
 
   if (composition == "dgCMatrix") {

--- a/tests/testthat/test-juice.R
+++ b/tests/testthat/test-juice.R
@@ -1,9 +1,0 @@
-test_that("`juice()` returns a 0 column / N row tibble when a selection returns no columns", {
-  rec <- recipe(~ ., data = iris)
-  rec <- prep(rec, iris)
-
-  expect_equal(
-    juice(rec, all_outcomes()),
-    tibble(.rows = nrow(iris))
-  )
-})

--- a/tests/testthat/test-juice.R
+++ b/tests/testthat/test-juice.R
@@ -1,0 +1,9 @@
+test_that("`juice()` returns a 0 column / N row tibble when a selection returns no columns", {
+  rec <- recipe(~ ., data = iris)
+  rec <- prep(rec, iris)
+
+  expect_equal(
+    juice(rec, all_outcomes()),
+    tibble(.rows = nrow(iris))
+  )
+})

--- a/tests/testthat/test_basics.R
+++ b/tests/testthat/test_basics.R
@@ -122,13 +122,22 @@ test_that("bake without newdata", {
   expect_error(bake(rec, newdata = biomass))
 })
 
+test_that("`juice()` returns a 0 column / N row tibble when a selection returns no columns", {
+  rec <- recipe(~ ., data = iris)
+  rec <- prep(rec, iris)
 
-test_that("no outcomes", {
-  rec <-  recipe(~ ., data = biomass) %>%
-    step_center(all_numeric()) %>%
-    step_scale(all_numeric()) %>%
-    prep(training = biomass, retain = TRUE)
+  expect_equal(
+    juice(rec, all_outcomes()),
+    tibble(.rows = nrow(iris))
+  )
+})
 
-  expect_equal(juice(rec, all_outcomes()), tibble::tibble())
-  expect_equal(bake(rec, new_data = head(biomass), all_outcomes()), tibble::tibble())
+test_that("`bake()` returns a 0 column / N row tibble when a selection returns no columns", {
+  rec <- recipe(~ ., data = iris)
+  rec <- prep(rec, iris)
+
+  expect_equal(
+    bake(rec, iris, all_outcomes()),
+    tibble(.rows = nrow(iris))
+  )
 })


### PR DESCRIPTION
Closes #411 