### PR TITLE
updates for devel tibble and vctrs versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 #  `recipes` 0.1.7.9001
 
+## Breaking Changes
+
+ * The imputation steps do not change the data type being imputed now. Previously, if the data were integer, the data would be changed to numeric (for some step types). The change is breaking since the underlying data of imputed values are now saved as a list instead of a vector (for some step types). 
+
 ## Other Changes
 
  * When using a selector that returns no columns, `juice()` and `bake()` will now return a tibble with as many rows as the original template data or the `new_data` respectively. This is more consistent with how selectors work in dplyr ([#411](https://github.com/tidymodels/recipes/issues/411)).
@@ -8,10 +12,11 @@
  
 * `check_class()` checks if a variable is of the designated class. Class is either learned from the train set or provided in the check. (contributed by Edwin Thoen)
 
+* `step_normalize()` and `step_scale()` gained a `factor` argument with values of 1 or 2 that can scale the standard deviations used to transform the data. ([#380](https://github.com/tidymodels/recipes/issues/380))
+
 #  `recipes` 0.1.7
 
 Release driven by changes in `tidyr` (v 1.0.0). 
-
 
 ## Breaking Changes
 

--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -1,63 +1,54 @@
 #' Imputation via Bagged Trees
 #'
-#'   `step_bagimpute` creates a *specification* of a
-#'  recipe step that will create bagged tree models to impute
-#'  missing data.
+#' `step_bagimpute` creates a *specification* of a recipe step that will
+#'  create bagged tree models to impute missing data.
+
 #'
 #' @inheritParams step_center
 #' @inherit step_center return
-#' @param ... One or more selector functions to choose variables.
-#'  For `step_bagimpute`, this indicates the variables to be
-#'  imputed. When used with `imp_vars`, the dots indicates
-#'  which variables are used to predict the missing data in each
-#'  variable. See [selections()] for more details. For the
+#' @param ... One or more selector functions to choose variables. For
+#'  `step_bagimpute`, this indicates the variables to be imputed. When used with
+#'  `imp_vars`, the dots indicates which variables are used to predict the
+#'  missing data in each variable. See [selections()] for more details. For the
 #'  `tidy` method, these are not currently used.
-#' @param role Not used by this step since no new variables are
-#'  created.
-#' @param impute_with A call to `imp_vars` to specify which
-#'  variables are used to impute the variables that can include
-#'  specific variable names separated by commas or different
-#'  selectors (see [selections()]). If a column is
-#'  included in both lists to be imputed and to be an imputation
-#'  predictor, it will be removed from the latter and not used to
-#'  impute itself.
+#' @param role Not used by this step since no new variables are created.
+
+#' @param impute_with A call to `imp_vars` to specify which variables are used
+#'  to impute the variables that can include specific variable names separated
+#'  by commas or different selectors (see [selections()]). If a column is
+#'  included in both lists to be imputed and to be an imputation predictor, it
+#'  will be removed from the latter and not used to impute itself.
 #' @param trees An integer for the number bagged trees to use in each model.
-#' @param options A list of options to
-#'  [ipred::ipredbagg()]. Defaults are set for the
-#'  arguments `nbagg` and `keepX` but others can be passed
-#'  in. **Note** that the arguments `X` and `y` should
-#'  not be passed here.
-#' @param seed_val A integer used to create reproducible models.
-#'  The same seed is used across all imputation models.
-#' @param models The [ipred::ipredbagg()] objects are
-#'  stored here once this bagged trees have be trained by
-#'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any). For the
-#'  `tidy` method, a tibble with columns `terms` (the
-#'  selectors or variables selected) and `model` (the bagged
-#'  tree object).
+#' @param options A list of options to [ipred::ipredbagg()]. Defaults are set
+#'  for the arguments `nbagg` and `keepX` but others can be passed in. **Note**
+#'  that the arguments `X` and `y` should not be passed here.
+#' @param seed_val A integer used to create reproducible models. The same seed
+#'  is used across all imputation models.
+#' @param models The [ipred::ipredbagg()] objects are stored here once this
+#'  bagged trees have be trained by [prep.recipe()].
+#' @return An updated version of `recipe` with the new step added to the
+#'  sequence of existing steps (if any). For the `tidy` method, a tibble with
+#'  columns `terms` (the selectors or variables selected) and `model` (the
+#'  bagged tree object).
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
 #' @export
-#' @details For each variables requiring imputation, a bagged tree
-#'  is created where the outcome is the variable of interest and the
-#'  predictors are any other variables listed in the
-#'  `impute_with` formula. One advantage to the bagged tree is
-#'  that is can accept predictors that have missing values
-#'  themselves. This imputation method can be used when the variable
-#'  of interest (and predictors) are numeric or categorical. Imputed
-#'  categorical variables will remain categorical.
+#' @details For each variables requiring imputation, a bagged tree is created
+#'  where the outcome is the variable of interest and the predictors are any
+#'  other variables listed in the `impute_with` formula. One advantage to the
+#'  bagged tree is that is can accept predictors that have missing values
+#'  themselves. This imputation method can be used when the variable of interest
+#'  (and predictors) are numeric or categorical. Imputed categorical variables
+#'  will remain categorical. Also, integers will be imputed to integer too.
 #'
-#' Note that if a variable that is to be imputed is also in
-#'  `impute_with`, this variable will be ignored.
+#'   Note that if a variable that is to be imputed is also in `impute_with`,
+#'  this variable will be ignored.
 #'
-#' It is possible that missing values will still occur after
-#'  imputation if a large majority (or all) of the imputing
-#'  variables are also missing.
-#' @references Kuhn, M. and Johnson, K. (2013). *Applied
-#'  Predictive Modeling*. Springer Verlag.
+#'   It is possible that missing values will still occur after imputation if a
+#'  large majority (or all) of the imputing variables are also missing.
+#' @references Kuhn, M. and Johnson, K. (2013). *Applied Predictive Modeling*.
+#'  Springer Verlag.
 #' @examples
 #' data("credit_data")
 #'
@@ -227,13 +218,14 @@ bake.step_bagimpute <- function(object, new_data, ...) {
     imp_var <- names(object$models)[i]
     missing_rows <- !complete.cases(new_data[, imp_var])
     if (any(missing_rows)) {
-      preds <- object$models[[i]]$..imp_vars
+      preds <- object$models[[imp_var]]$..imp_vars
       pred_data <- old_data[missing_rows, preds, drop = FALSE]
       ## do a better job of checking this:
       if (all(is.na(pred_data))) {
         warning("All predictors are missing; cannot impute", call. = FALSE)
       } else {
-        pred_vals <- predict(object$models[[i]], pred_data)
+        pred_vals <- predict(object$models[[imp_var]], pred_data)
+        pred_vals <- cast(pred_vals, new_data[[imp_var]])
         new_data[missing_rows, imp_var] <- pred_vals
       }
     }

--- a/R/center.R
+++ b/R/center.R
@@ -120,8 +120,7 @@ prep.step_center <- function(x, training, info = NULL, ...) {
 bake.step_center <- function(object, new_data, ...) {
   res <-
     sweep(as.matrix(new_data[, names(object$means)]), 2, object$means, "-")
-  if (is.matrix(res) && ncol(res) == 1)
-    res <- res[, 1]
+  res <- tibble::as_tibble(res)
   new_data[, names(object$means)] <- res
   as_tibble(new_data)
 }

--- a/R/knn_imp.R
+++ b/R/knn_imp.R
@@ -1,62 +1,53 @@
 #' Imputation via K-Nearest Neighbors
 #'
-#' `step_knnimpute` creates a *specification* of a
-#'  recipe step that will impute missing data using nearest
-#'  neighbors.
+#' `step_knnimpute` creates a *specification* of a recipe step that will
+#'  impute missing data using nearest neighbors.
 #'
 #' @inheritParams step_center
 #' @inherit step_center return
-#' @param ... One or more selector functions to choose variables.
-#'  For `step_knnimpute`, this indicates the variables to be
-#'  imputed. When used with `imp_vars`, the dots indicates
-#'  which variables are used to predict the missing data in each
-#'  variable. See [selections()] for more details. For the
+#' @param ... One or more selector functions to choose variables. For
+#'  `step_knnimpute`, this indicates the variables to be imputed. When used with
+#'  `imp_vars`, the dots indicates which variables are used to predict the
+#'  missing data in each variable. See [selections()] for more details. For the
 #'  `tidy` method, these are not currently used.
-#' @param role Not used by this step since no new variables are
-#'  created.
-#' @param impute_with A call to `imp_vars` to specify which
-#'  variables are used to impute the variables that can include
-#'  specific variable names separated by commas or different
-#'  selectors (see [selections()]). If a column is
-#'  included in both lists to be imputed and to be an imputation
-#'  predictor, it will be removed from the latter and not used to
-#'  impute itself.
+#' @param role Not used by this step since no new variables are created.
+#' @param impute_with A call to `imp_vars` to specify which variables are used
+#'  to impute the variables that can include specific variable names separated
+#'  by commas or different selectors (see [selections()]). If a column is
+#'  included in both lists to be imputed and to be an imputation predictor, it
+#'  will be removed from the latter and not used to impute itself.
 #' @param neighbors The number of neighbors.
 #' @param options A named list of options to pass to [gower::gower_topn()].
 #'  Available options are currently `nthread` and `eps`.
-#' @param ref_data A tibble of data that will reflect the data
-#'  preprocessing done up to the point of this imputation step. This
-#'  is `NULL` until the step is trained by
-#'  [prep.recipe()].
-#' @param columns The column names that will be imputed and used
-#'  for imputation. This is `NULL` until the step is trained by
-#'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any). For the
-#'  `tidy` method, a tibble with columns `terms` (the
-#'  selectors or variables for imputation), `predictors`
+#' @param ref_data A tibble of data that will reflect the data preprocessing
+#'  done up to the point of this imputation step. This is `NULL` until the step
+#'  is trained by [prep.recipe()].
+#' @param columns The column names that will be imputed and used for
+#'  imputation. This is `NULL` until the step is trained by [prep.recipe()].
+#' @return An updated version of `recipe` with the new step added to the
+#'  sequence of existing steps (if any). For the `tidy` method, a tibble with
+#'  columns `terms` (the selectors or variables for imputation), `predictors`
 #'  (those variables used to impute), and `neighbors`.
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
 #' @export
-#' @details The step uses the training set to impute any other
-#'  data sets. The only distance function available is Gower's
-#'  distance which can be used for mixtures of nominal and numeric
-#'  data.
+#' @details The step uses the training set to impute any other data sets. The
+#'  only distance function available is Gower's distance which can be used for
+#'  mixtures of nominal and numeric data.
 #'
-#'   Once the nearest neighbors are determined, the mode is used to
-#'  predictor nominal variables and the mean is used for numeric
-#'  data.
+#' Once the nearest neighbors are determined, the mode is used to predictor
+#'  nominal variables and the mean is used for numeric data. Note that, if the
+#'  underlying data are integer, the mean will be converted to an integer too.
 #'
-#'   Note that if a variable that is to be imputed is also in
-#'  `impute_with`, this variable will be ignored.
+#' Note that if a variable that is to be imputed is also in `impute_with`,
+#'  this variable will be ignored.
 #'
-#'   It is possible that missing values will still occur after
-#'  imputation if a large majority (or all) of the imputing
-#'  variables are also missing.
-#' @references Gower, C. (1971) "A general coefficient of
-#'  similarity and some of its properties," Biometrics, 857-871.
+#' It is possible that missing values will still occur after imputation if a
+#'  large majority (or all) of the imputing variables are also missing.
+#'
+#' @references Gower, C. (1971) "A general coefficient of similarity and some
+#'  of its properties," Biometrics, 857-871.
 #' @examples
 #' library(recipes)
 #' data(biomass)
@@ -232,6 +223,7 @@ bake.step_knnimpute <- function(object, new_data, ...) {
                            object$options)
         pred_vals <-
           apply(nn_ind, 2, nn_pred, dat = object$ref_data[imp_var_complete, imp_var])
+        pred_vals <- cast(pred_vals, object$ref_data[[imp_var]])
         new_data[missing_rows, imp_var] <- pred_vals
       }
     }

--- a/R/misc.R
+++ b/R/misc.R
@@ -595,3 +595,20 @@ tidyr_new_interface <- function() {
   utils::packageVersion("tidyr") > "0.8.99"
 }
 
+# ------------------------------------------------------------------------------
+# For all imputation functions that substitute elements into an existing vector:
+# vctrs's cast functions would be better but we'll deal with the known cases
+# to avoid a dependency.
+
+cast <- function(x, ref) {
+  if (is.factor(ref)) {
+    x <- factor(x, levels = levels(ref), ordered = is.ordered(ref))
+  } else {
+    if (is.integer(ref) & !is.factor(ref)) {
+      x <- as.integer(round(x, 0))
+    }
+  }
+  x
+}
+
+

--- a/R/misc.R
+++ b/R/misc.R
@@ -198,19 +198,24 @@ get_levels <- function(x) {
   out
 }
 
-has_lvls <- function(info)
+has_lvls <- function(info) {
   !vapply(info, function(x) all(is.na(x$values)), c(logic = TRUE))
+}
 
 strings2factors <- function(x, info) {
   check_lvls <- has_lvls(info)
-  if (!any(check_lvls))
+  if (!any(check_lvls)) {
     return(x)
+  }
   info <- info[check_lvls]
+  vars <- names(info)
+  info <- info[vars %in% names(x)]
   for (i in seq_along(info)) {
     lcol <- names(info)[i]
-    x[, lcol] <- factor(as.character(getElement(x, lcol)),
-                        levels = info[[i]]$values,
-                        ordered = info[[i]]$ordered)
+    x[, lcol] <-
+      factor(as.character(x[[lcol]]),
+             levels = info[[i]]$values,
+             ordered = info[[i]]$ordered)
   }
   x
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -444,7 +444,7 @@ is_trained <- function(x)
 #' @keywords internal
 #' @rdname recipes-internal
 sel2char <- function(x) {
-  map_chr(x, to_character)
+  unname(map_chr(x, to_character))
 }
 
 to_character <- function(x) {

--- a/R/modeimpute.R
+++ b/R/modeimpute.R
@@ -104,8 +104,10 @@ prep.step_modeimpute <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_modeimpute <- function(object, new_data, ...) {
   for (i in names(object$modes)) {
-    if (any(is.na(new_data[, i])))
-      new_data[is.na(new_data[, i]), i] <- object$modes[i]
+    if (any(is.na(new_data[, i]))) {
+      mode_val <- cast(object$modes[[i]], new_data[[i]])
+      new_data[is.na(new_data[[i]]), i] <- mode_val
+    }
   }
   as_tibble(new_data)
 }

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -116,8 +116,7 @@ prep.step_normalize <- function(x, training, info = NULL, ...) {
 bake.step_normalize <- function(object, new_data, ...) {
   res <- sweep(as.matrix(new_data[, names(object$means)]), 2, object$means, "-")
   res <- sweep(res, 2, object$sds, "/")
-  if (is.matrix(res) && ncol(res) == 1)
-    res <- res[, 1]
+  res <- tibble::as_tibble(res)
   new_data[, names(object$sds)] <- res
   as_tibble(new_data)
 }

--- a/R/range.R
+++ b/R/range.R
@@ -124,8 +124,7 @@ bake.step_range <- function(object, new_data, ...) {
   tmp[tmp < object$min] <- object$min
   tmp[tmp > object$max] <- object$max
 
-  if (is.matrix(tmp) && ncol(tmp) == 1)
-    tmp <- tmp[, 1]
+  tmp <- tibble::as_tibble(tmp)
   new_data[, colnames(object$ranges)] <- tmp
   as_tibble(new_data)
 }

--- a/R/scale.R
+++ b/R/scale.R
@@ -104,7 +104,7 @@ prep.step_scale <- function(x, training, info = NULL, ...) {
   col_names <- terms_select(x$terms, info = info)
   check_type(training[, col_names])
 
-  if (x$factor != 1 | x$factor != 2) {
+  if (x$factor != 1 & x$factor != 2) {
     warning("Scaling `factor` should take either a value of 1 or 2", call. = FALSE)
   }
 
@@ -129,8 +129,7 @@ prep.step_scale <- function(x, training, info = NULL, ...) {
 bake.step_scale <- function(object, new_data, ...) {
   res <-
     sweep(as.matrix(new_data[, names(object$sds)]), 2, object$sds, "/")
-  if (is.matrix(res) && ncol(res) == 1)
-    res <- res[, 1]
+  res <- tibble::as_tibble(res)
   new_data[, names(object$sds)] <- res
   as_tibble(new_data)
 }

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -116,11 +116,13 @@ prep.step_spatialsign <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_spatialsign <- function(object, new_data, ...) {
   col_names <- object$columns
-  ss <- function(x, na_rm)
+  ss <- function(x, na_rm) {
     x / sqrt(sum(x ^ 2, na.rm = na_rm))
-  new_data[, col_names] <-
-    t(apply(as.matrix(new_data[, col_names]), 1, ss, na_rm = object$na_rm))
-  as_tibble(new_data)
+  }
+  res <- t(apply(as.matrix(new_data[, col_names]), 1, ss, na_rm = object$na_rm))
+  res <- tibble::as_tibble(res)
+  new_data[, col_names] <- res
+  tibble::as_tibble(new_data)
 }
 
 print.step_spatialsign <-

--- a/man/step_bagimpute.Rd
+++ b/man/step_bagimpute.Rd
@@ -28,41 +28,34 @@ imp_vars(...)
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables.
-For \code{step_bagimpute}, this indicates the variables to be
-imputed. When used with \code{imp_vars}, the dots indicates
-which variables are used to predict the missing data in each
-variable. See \code{\link[=selections]{selections()}} for more details. For the
+\item{...}{One or more selector functions to choose variables. For
+\code{step_bagimpute}, this indicates the variables to be imputed. When used with
+\code{imp_vars}, the dots indicates which variables are used to predict the
+missing data in each variable. See \code{\link[=selections]{selections()}} for more details. For the
 \code{tidy} method, these are not currently used.}
 
-\item{role}{Not used by this step since no new variables are
-created.}
+\item{role}{Not used by this step since no new variables are created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{impute_with}{A call to \code{imp_vars} to specify which
-variables are used to impute the variables that can include
-specific variable names separated by commas or different
-selectors (see \code{\link[=selections]{selections()}}). If a column is
-included in both lists to be imputed and to be an imputation
-predictor, it will be removed from the latter and not used to
-impute itself.}
+\item{impute_with}{A call to \code{imp_vars} to specify which variables are used
+to impute the variables that can include specific variable names separated
+by commas or different selectors (see \code{\link[=selections]{selections()}}). If a column is
+included in both lists to be imputed and to be an imputation predictor, it
+will be removed from the latter and not used to impute itself.}
 
 \item{trees}{An integer for the number bagged trees to use in each model.}
 
-\item{models}{The \code{\link[ipred:ipredbagg]{ipred::ipredbagg()}} objects are
-stored here once this bagged trees have be trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{models}{The \code{\link[ipred:ipredbagg]{ipred::ipredbagg()}} objects are stored here once this
+bagged trees have be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{options}{A list of options to
-\code{\link[ipred:ipredbagg]{ipred::ipredbagg()}}. Defaults are set for the
-arguments \code{nbagg} and \code{keepX} but others can be passed
-in. \strong{Note} that the arguments \code{X} and \code{y} should
-not be passed here.}
+\item{options}{A list of options to \code{\link[ipred:ipredbagg]{ipred::ipredbagg()}}. Defaults are set
+for the arguments \code{nbagg} and \code{keepX} but others can be passed in. \strong{Note}
+that the arguments \code{X} and \code{y} should not be passed here.}
 
-\item{seed_val}{A integer used to create reproducible models.
-The same seed is used across all imputation models.}
+\item{seed_val}{A integer used to create reproducible models. The same seed
+is used across all imputation models.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
@@ -76,33 +69,29 @@ the computations for subsequent operations}
 \item{x}{A \code{step_bagimpute} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-selectors or variables selected) and \code{model} (the bagged
-tree object).
+An updated version of \code{recipe} with the new step added to the
+sequence of existing steps (if any). For the \code{tidy} method, a tibble with
+columns \code{terms} (the selectors or variables selected) and \code{model} (the
+bagged tree object).
 }
 \description{
-\code{step_bagimpute} creates a \emph{specification} of a
-recipe step that will create bagged tree models to impute
-missing data.
+\code{step_bagimpute} creates a \emph{specification} of a recipe step that will
+create bagged tree models to impute missing data.
 }
 \details{
-For each variables requiring imputation, a bagged tree
-is created where the outcome is the variable of interest and the
-predictors are any other variables listed in the
-\code{impute_with} formula. One advantage to the bagged tree is
-that is can accept predictors that have missing values
-themselves. This imputation method can be used when the variable
-of interest (and predictors) are numeric or categorical. Imputed
-categorical variables will remain categorical.
+For each variables requiring imputation, a bagged tree is created
+where the outcome is the variable of interest and the predictors are any
+other variables listed in the \code{impute_with} formula. One advantage to the
+bagged tree is that is can accept predictors that have missing values
+themselves. This imputation method can be used when the variable of interest
+(and predictors) are numeric or categorical. Imputed categorical variables
+will remain categorical. Also, integers will be imputed to integer too.
 
-Note that if a variable that is to be imputed is also in
-\code{impute_with}, this variable will be ignored.
+Note that if a variable that is to be imputed is also in \code{impute_with},
+this variable will be ignored.
 
-It is possible that missing values will still occur after
-imputation if a large majority (or all) of the imputing
-variables are also missing.
+It is possible that missing values will still occur after imputation if a
+large majority (or all) of the imputing variables are also missing.
 }
 \examples{
 data("credit_data")
@@ -152,8 +141,8 @@ tidy(imp_models, number = 1)
 
 }
 \references{
-Kuhn, M. and Johnson, K. (2013). \emph{Applied
-Predictive Modeling}. Springer Verlag.
+Kuhn, M. and Johnson, K. (2013). \emph{Applied Predictive Modeling}.
+Springer Verlag.
 }
 \concept{imputation}
 \concept{preprocessing}

--- a/man/step_knnimpute.Rd
+++ b/man/step_knnimpute.Rd
@@ -25,40 +25,34 @@ step_knnimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables.
-For \code{step_knnimpute}, this indicates the variables to be
-imputed. When used with \code{imp_vars}, the dots indicates
-which variables are used to predict the missing data in each
-variable. See \code{\link[=selections]{selections()}} for more details. For the
+\item{...}{One or more selector functions to choose variables. For
+\code{step_knnimpute}, this indicates the variables to be imputed. When used with
+\code{imp_vars}, the dots indicates which variables are used to predict the
+missing data in each variable. See \code{\link[=selections]{selections()}} for more details. For the
 \code{tidy} method, these are not currently used.}
 
-\item{role}{Not used by this step since no new variables are
-created.}
+\item{role}{Not used by this step since no new variables are created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
 \item{neighbors}{The number of neighbors.}
 
-\item{impute_with}{A call to \code{imp_vars} to specify which
-variables are used to impute the variables that can include
-specific variable names separated by commas or different
-selectors (see \code{\link[=selections]{selections()}}). If a column is
-included in both lists to be imputed and to be an imputation
-predictor, it will be removed from the latter and not used to
-impute itself.}
+\item{impute_with}{A call to \code{imp_vars} to specify which variables are used
+to impute the variables that can include specific variable names separated
+by commas or different selectors (see \code{\link[=selections]{selections()}}). If a column is
+included in both lists to be imputed and to be an imputation predictor, it
+will be removed from the latter and not used to impute itself.}
 
 \item{options}{A named list of options to pass to \code{\link[gower:gower_topn]{gower::gower_topn()}}.
 Available options are currently \code{nthread} and \code{eps}.}
 
-\item{ref_data}{A tibble of data that will reflect the data
-preprocessing done up to the point of this imputation step. This
-is \code{NULL} until the step is trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{ref_data}{A tibble of data that will reflect the data preprocessing
+done up to the point of this imputation step. This is \code{NULL} until the step
+is trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{columns}{The column names that will be imputed and used
-for imputation. This is \code{NULL} until the step is trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{columns}{The column names that will be imputed and used for
+imputation. This is \code{NULL} until the step is trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
@@ -72,33 +66,29 @@ the computations for subsequent operations}
 \item{x}{A \code{step_knnimpute} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-selectors or variables for imputation), \code{predictors}
+An updated version of \code{recipe} with the new step added to the
+sequence of existing steps (if any). For the \code{tidy} method, a tibble with
+columns \code{terms} (the selectors or variables for imputation), \code{predictors}
 (those variables used to impute), and \code{neighbors}.
 }
 \description{
-\code{step_knnimpute} creates a \emph{specification} of a
-recipe step that will impute missing data using nearest
-neighbors.
+\code{step_knnimpute} creates a \emph{specification} of a recipe step that will
+impute missing data using nearest neighbors.
 }
 \details{
-The step uses the training set to impute any other
-data sets. The only distance function available is Gower's
-distance which can be used for mixtures of nominal and numeric
-data.
+The step uses the training set to impute any other data sets. The
+only distance function available is Gower's distance which can be used for
+mixtures of nominal and numeric data.
 
-Once the nearest neighbors are determined, the mode is used to
-predictor nominal variables and the mean is used for numeric
-data.
+Once the nearest neighbors are determined, the mode is used to predictor
+nominal variables and the mean is used for numeric data. Note that, if the
+underlying data are integer, the mean will be converted to an integer too.
 
-Note that if a variable that is to be imputed is also in
-\code{impute_with}, this variable will be ignored.
+Note that if a variable that is to be imputed is also in \code{impute_with},
+this variable will be ignored.
 
-It is possible that missing values will still occur after
-imputation if a large majority (or all) of the imputing
-variables are also missing.
+It is possible that missing values will still occur after imputation if a
+large majority (or all) of the imputing variables are also missing.
 }
 \examples{
 library(recipes)
@@ -137,8 +127,8 @@ tidy(ratio_recipe, number = 1)
 tidy(ratio_recipe2, number = 1)
 }
 \references{
-Gower, C. (1971) "A general coefficient of
-similarity and some of its properties," Biometrics, 857-871.
+Gower, C. (1971) "A general coefficient of similarity and some
+of its properties," Biometrics, 857-871.
 }
 \concept{imputation}
 \concept{preprocessing}

--- a/man/step_meanimpute.Rd
+++ b/man/step_meanimpute.Rd
@@ -22,24 +22,22 @@ step_meanimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details. For the \code{tidy} method, these are not
-currently used.}
+\item{...}{One or more selector functions to choose which variables are
+affected by the step. See \code{\link[=selections]{selections()}} for more details. For the \code{tidy}
+method, these are not currently used.}
 
-\item{role}{Not used by this step since no new variables are
-created.}
+\item{role}{Not used by this step since no new variables are created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{means}{A named numeric vector of means. This is
-\code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{means}{A named numeric vector of means. This is \code{NULL} until computed
+by \code{\link[=prep.recipe]{prep.recipe()}}. Note that, if the original data are integers, the mean
+will be converted to an integer to maintain the same a data type.}
 
-\item{trim}{The fraction (0 to 0.5) of observations to be
-trimmed from each end of the variables before the mean is
-computed. Values of trim outside that range are taken as the
-nearest endpoint.}
+\item{trim}{The fraction (0 to 0.5) of observations to be trimmed from each
+end of the variables before the mean is computed. Values of trim outside
+that range are taken as the nearest endpoint.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
@@ -53,22 +51,20 @@ the computations for subsequent operations}
 \item{x}{A \code{step_meanimpute} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-selectors or variables selected) and \code{model} (the mean
+An updated version of \code{recipe} with the new step added to the
+sequence of existing steps (if any). For the \code{tidy} method, a tibble with
+columns \code{terms} (the selectors or variables selected) and \code{model} (the mean
 value).
 }
 \description{
-\code{step_meanimpute} creates a \emph{specification} of a
-recipe step that will substitute missing values of numeric
-variables by the training set mean of those variables.
+\code{step_meanimpute} creates a \emph{specification} of a recipe step that will
+substitute missing values of numeric variables by the training set mean of
+those variables.
 }
 \details{
-\code{step_meanimpute} estimates the variable means
-from the data used in the \code{training} argument of
-\code{prep.recipe}. \code{bake.recipe} then applies the new
-values to new data sets using these averages.
+\code{step_meanimpute} estimates the variable means from the data used
+in the \code{training} argument of \code{prep.recipe}. \code{bake.recipe} then applies the
+new values to new data sets using these averages.
 }
 \examples{
 data("credit_data")

--- a/man/step_medianimpute.Rd
+++ b/man/step_medianimpute.Rd
@@ -21,19 +21,18 @@ step_medianimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details. For the \code{tidy} method, these are not
-currently used.}
+\item{...}{One or more selector functions to choose which variables are
+affected by the step. See \code{\link[=selections]{selections()}} for more details. For the \code{tidy}
+method, these are not currently used.}
 
-\item{role}{Not used by this step since no new variables are
-created.}
+\item{role}{Not used by this step since no new variables are created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{medians}{A named numeric vector of medians. This is
-\code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{medians}{A named numeric vector of medians. This is \code{NULL} until
+computed by \code{\link[=prep.recipe]{prep.recipe()}}. Note that, if the original data are integers,
+the median will be converted to an integer to maintain the same a data type.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
@@ -47,22 +46,20 @@ the computations for subsequent operations}
 \item{x}{A \code{step_medianimpute} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-selectors or variables selected) and \code{model} (the median
-value).
+An updated version of \code{recipe} with the new step added to the
+sequence of existing steps (if any). For the \code{tidy} method, a tibble with
+columns \code{terms} (the selectors or variables selected) and \code{model} (the
+median value).
 }
 \description{
-\code{step_medianimpute} creates a \emph{specification} of a
-recipe step that will substitute missing values of numeric
-variables by the training set median of those variables.
+\code{step_medianimpute} creates a \emph{specification} of a recipe step that will
+substitute missing values of numeric variables by the training set median of
+those variables.
 }
 \details{
-\code{step_medianimpute} estimates the variable medians
-from the data used in the \code{training} argument of
-\code{prep.recipe}. \code{bake.recipe} then applies the new
-values to new data sets using these medians
+\code{step_medianimpute} estimates the variable medians from the data
+used in the \code{training} argument of \code{prep.recipe}. \code{bake.recipe} then applies
+the new values to new data sets using these medians
 }
 \examples{
 data("credit_data")

--- a/tests/testthat/test_bagimpute.R
+++ b/tests/testthat/test_bagimpute.R
@@ -55,7 +55,7 @@ test_that('imputation models', {
            model = imputed_trained$steps[[1]]$models,
            id = imputed_trained$steps[[1]]$id)
 
-  expect_equal(tidy(imputed, 1), imp_tibble_un)
+  expect_equivalent(as.data.frame(tidy(imputed, 1)), as.data.frame(imp_tibble_un))
   expect_equal(tidy(imputed_trained, 1)$terms, imp_tibble_tr$terms)
   expect_equal(tidy(imputed_trained, 1)$model, imp_tibble_tr$model)
 

--- a/tests/testthat/test_knnimpute.R
+++ b/tests/testthat/test_knnimpute.R
@@ -37,8 +37,7 @@ test_that('imputation values', {
     neighbors = rep(3, 2),
     id = ""
   )
-  expect_equal(imp_exp_un, tidy(impute_rec, number = 2))
-
+  expect_equivalent(as.data.frame(tidy(impute_rec, number = 2)), as.data.frame(imp_exp_un))
   discr_rec <- prep(discr_rec, training = biomass_tr, verbose = FALSE)
   tr_data <- bake(discr_rec, new_data = biomass_tr)
   te_data <- bake(discr_rec, new_data = biomass_te) %>%

--- a/tests/testthat/test_medianimpute.R
+++ b/tests/testthat/test_medianimpute.R
@@ -20,26 +20,32 @@ test_that('simple median', {
   te_imputed <- bake(imputed, new_data = credit_te)
 
   expect_equal(te_imputed$Age, credit_te$Age)
+
+  assets_pred <- median(credit_tr$Assets, na.rm = TRUE)
+  assets_pred <- recipes:::cast(assets_pred, credit_tr$Assets)
   expect_equal(te_imputed$Assets[is.na(credit_te$Assets)],
-               rep(median(credit_tr$Assets, na.rm = TRUE),
-                   sum(is.na(credit_te$Assets))))
+               rep(assets_pred, sum(is.na(credit_te$Assets))))
+
+  inc_pred <- median(credit_tr$Income, na.rm = TRUE)
+  inc_pred <- recipes:::cast(inc_pred, credit_tr$Assets)
   expect_equal(te_imputed$Income[is.na(credit_te$Income)],
-               rep(median(credit_tr$Income, na.rm = TRUE),
-                   sum(is.na(credit_te$Income))))
+               rep(inc_pred, sum(is.na(credit_te$Income))))
 
   medians <- vapply(credit_tr[, c("Age", "Assets", "Income")],
-                    median, numeric(1), na.rm = TRUE)
+                    median, double(1), na.rm = TRUE)
+  medians <- purrr::map2(medians, credit_tr[, c("Age", "Assets", "Income")], recipes:::cast)
+  medians <- unlist(medians)
   imp_tibble_un <-
     tibble(terms = c("Age", "Assets", "Income"),
            model = rep(NA_real_, 3),
            id = "")
   imp_tibble_tr <-
     tibble(terms = c("Age", "Assets", "Income"),
-           model = medians,
+           model = as.integer(unlist(medians)),
            id = "")
 
-  expect_equal(tidy(impute_rec, 1), imp_tibble_un)
-  expect_equal(tidy(imputed, 1), imp_tibble_tr)
+  expect_equivalent(as.data.frame(tidy(impute_rec, 1)), as.data.frame(imp_tibble_un))
+  expect_equivalent(as.data.frame(tidy(imputed, 1)), as.data.frame(imp_tibble_tr))
 
 })
 

--- a/tests/testthat/test_modeimpute.R
+++ b/tests/testthat/test_modeimpute.R
@@ -42,8 +42,9 @@ test_that('simple modes', {
            model = modes,
            id = "")
 
-  expect_equal(tidy(impute_rec, 1), imp_tibble_un)
-  expect_equal(tidy(imputed, 1), imp_tibble_tr)
+  expect_equivalent(as.data.frame(tidy(impute_rec, 1)), as.data.frame(imp_tibble_un))
+  expect_equivalent(as.data.frame(tidy(imputed, 1)), as.data.frame(imp_tibble_tr))
+
 })
 
 

--- a/tests/testthat/test_other.R
+++ b/tests/testthat/test_other.R
@@ -274,3 +274,20 @@ test_that('tunable', {
     c('name', 'call_info', 'source', 'component', 'component_id')
   )
 })
+
+
+test_that('issue #415 -  strings to factor conversion', {
+  trans_recipe <-
+    recipe(Species ~ ., data = iris)
+
+  prepped <- prep(trans_recipe, iris)
+
+  iris_no_outcome <- iris
+  iris_no_outcome["Species"] <- NULL
+
+  expect_error(
+    res <- bake(prepped, iris_no_outcome),
+    regex = NA
+  )
+  expect_equal(names(res), names(iris[, 1:4]))
+})


### PR DESCRIPTION
closes #415

closes #404

closes #342

Most issues were around assigning a matrix to columns in a tibble or for tidy methods adding empty names to `terms` columns. 