### PR TITLE
fixes #428 - faulty printing for step_rename_at() and step_mutate_at()

### DIFF
--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -95,7 +95,7 @@ bake.step_mutate_at <- function(object, new_data, ...) {
 print.step_mutate_at <-
   function(x, width = max(20, options()$width - 35), ...) {
     cat("Variable mutation for ", sep = "")
-    printer(names(x$means), x$terms, x$trained, width = width)
+    printer(x$inputs, x$terms, x$trained, width = width)
     invisible(x)
   }
 

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -87,7 +87,7 @@ bake.step_rename_at <- function(object, new_data, ...) {
 print.step_rename_at <-
   function(x, width = max(20, options()$width - 35), ...) {
     cat("Variable renaming for ", sep = "")
-    printer(names(x$means), x$terms, x$trained, width = width)
+    printer(x$inputs, x$terms, x$trained, width = width)
     invisible(x)
   }
 


### PR DESCRIPTION
It appears that the printing function wasn't properly changed from the [boilerplate](https://github.com/tidymodels/recipes/blob/master/inst/boilerplate.R).

``` r
library(recipes)
recipe(~ ., data = iris) %>%
  step_mutate_at(contains("Length"), fn = ~ 1/.) %>%  
  prep()
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>  predictor          5
#> 
#> Training data contained 150 data points and no missing data.
#> 
#> Operations:
#> 
#> Variable mutation for Sepal.Length, Petal.Length [trained]
```

<sup>Created on 2019-12-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>