### PR TITLE
Register the S3 method to the class, not the full function name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+ * Delayed S3 method registration for `tune::tunable()` methods that live in recipes will now work correctly on R >=4.0.0 (#439, tidymodels/tune#146).
+
 #  `recipes` 0.1.8
 
 ## Breaking Changes

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,8 +18,13 @@ maybe_register_tunable_methods <- function() {
   names <- names(ns)
   names <- grep("tunable.step", names, fixed = TRUE, value = TRUE)
 
-  for (name in names) {
-    s3_register("tune::tunable", name, get(name, envir = ns))
+  classes <- gsub("tunable.", "", names)
+
+  for (i in seq_along(names)) {
+    name <- names[[i]]
+    class <- classes[[i]]
+
+    s3_register("tune::tunable", class, get(name, envir = ns))
   }
 
   invisible()


### PR DESCRIPTION
Closes tidymodels/tune#146

I made a typo 😭. We will need a minor recipes release for tune.

When you register a method with `s3_register()`, you supply it in the form:

`s3_register("tune::tunable", "step_knnimpute", tunable.step_knnimpute)`

I was accidentally doing:

`s3_register("tune::tunable", "tunable.step_knnimpute", tunable.step_knnimpute)`

It only fails in R devel because we currently explicitly export the tunable methods anyways, so they are "found" in the package environment during S3 lookup. This is what was changed in R devel, as noted by the NEWS entry: "S3 method lookup now by default skips the elements of the search path between the global and base environments." (i.e. any package env).

I think this change in S3 method lookup is good motivation to not explicitly export the tunable methods anyways, so we might consider also not exporting them.