### PR TITLE
cat() with a missing sep argument in print.step_mutate caused a double space when printing a recipe

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -135,7 +135,8 @@ bake.step_mutate <- function(object, new_data, ...) {
 print.step_mutate <-
   function(x, width = max(20, options()$width - 35), ...) {
     cat("Variable mutation for ",
-        paste0(names(x$inputs), collapse = ", "))
+        paste0(names(x$inputs), collapse = ", "),
+        sep = "")
     if (x$trained) {
       cat(" [trained]\n")
     } else {


### PR DESCRIPTION
There's a small typo in the print method for step_mutate, which shows up because the print method for a recipe includes the output of the print method for all of the operations. The print method for step_mutate is missing the sep argument in a cat() call, instead opting for ending the first piece of text with a space, but since sep for the cat() function by default is " ", this results in two spaces when printed.