### PR TITLE
Use rlang warn, abort instead of warning, stop

### DIFF
--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -227,7 +227,7 @@ estimate_yj <- function(dat, limits = c(-5, 5), num_unique = 5,
     if (na_rm) {
       dat <- dat[-na_rows]
     } else {
-      stop("Missing values in data. See `na_rm` option", call. = FALSE)
+      rlang::abort("Missing values in data. See `na_rm` option")
     }
   }
 

--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -110,7 +110,7 @@ step_bagimpute <-
            skip = FALSE,
            id = rand_id("bagimpute")) {
     if (is.null(impute_with))
-      stop("Please list some variables in `impute_with`", call. = FALSE)
+      rlang::abort("Please list some variables in `impute_with`")
     add_step(
       recipe,
       step_bagimpute_new(

--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -223,7 +223,7 @@ bake.step_bagimpute <- function(object, new_data, ...) {
       pred_data <- old_data[missing_rows, preds, drop = FALSE]
       ## do a better job of checking this:
       if (all(is.na(pred_data))) {
-        warning("All predictors are missing; cannot impute", call. = FALSE)
+        rlang::warn("All predictors are missing; cannot impute")
       } else {
         pred_vals <- predict(object$models[[imp_var]], pred_data)
         pred_vals <- cast(pred_vals, new_data[[imp_var]])

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -61,7 +61,7 @@ step_bin2factor <-
            skip = FALSE,
            id = rand_id("bin2factor")) {
     if (length(levels) != 2 | !is.character(levels))
-      stop("`levels` should be a two element character string", call. = FALSE)
+      rlang::abort("`levels` should be a two element character string")
     add_step(
       recipe,
       step_bin2factor_new(
@@ -96,9 +96,9 @@ step_bin2factor_new <-
 prep.step_bin2factor <- function(x, training, info = NULL, ...) {
   col_names <- terms_select(x$terms, info = info)
   if (length(col_names) < 1)
-    stop("The selector should only select at least one variable")
+    rlang::abort("The selector should only select at least one variable")
   if (any(info$type[info$variable %in% col_names] != "numeric"))
-    stop("The variables should be numeric")
+    rlang::abort("The variables should be numeric")
   step_bin2factor_new(
     terms = x$terms,
     role = x$role,

--- a/R/class.R
+++ b/R/class.R
@@ -170,23 +170,29 @@ bake_check_class_core <- function(x,
   classes <- class(x)
   missing <- setdiff(class_nm, classes)
   if (length(missing) > 0) {
-    stop(var_nm,
-         " should have the class(es) ",
-         paste(class_nm, collapse = ", "),
-         " but has the class(es) ",
-         paste(classes, collapse = ", "),
-         ".")
+    rlang::abort(
+      paste0(
+        var_nm,
+        " should have the class(es) ",
+        paste(class_nm, collapse = ", "),
+        " but has the class(es) ",
+        paste(classes, collapse = ", "),
+        "."
+    )
+    )
   }
 
   extra <- setdiff(classes, class_nm)
   if (length(extra) > 0 && !aa) {
-    stop(
-      var_nm,
-      " has the class(es) ",
-      paste(classes, collapse = ", "),
-      ", but only the following is/are asked ",
-      paste(class_nm, collapse = ", "),
-      ", allow_additional is FALSE."
+    rlang::abort(
+      paste0(
+        var_nm,
+        " has the class(es) ",
+        paste(classes, collapse = ", "),
+        ", but only the following is/are asked ",
+        paste(class_nm, collapse = ", "),
+        ", allow_additional is FALSE."
+      )
     )
   }
 }

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -74,7 +74,7 @@ step_classdist <- function(recipe,
                            skip = FALSE,
                            id = rand_id("classdist")) {
   if (!is.character(class) || length(class) != 1)
-    stop("`class` should be a single character value.")
+    rlang::abort("`class` should be a single character value.")
   add_step(
     recipe,
     step_classdist_new(

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -73,8 +73,13 @@ bake.check_cols <- function(object, new_data, ...) {
   missing <- setdiff(original_cols, new_cols)
   if (length(missing) > 0) {
     mis_cols <- paste(paste0("`", missing, "`"), collapse = ", ")
-    stop("The following cols are missing from `new_data`: ",
-         mis_cols, ".", call. = FALSE)
+    rlang::abort(
+      paste0(
+        "The following cols are missing from `new_data`: ",
+         mis_cols,
+        "."
+        )
+    )
   }
   new_data
 }

--- a/R/corr.R
+++ b/R/corr.R
@@ -181,23 +181,29 @@ corr_filter <-
     if (any(!complete.cases(x))) {
       all_na <- apply(x, 2, function(x) all(is.na(x)))
       if (sum(all_na) >= nrow(x) - 1) {
-        warning("Too many correlations are `NA`; skipping correlation filter.",
-                call. = FALSE)
+        rlang::warn("Too many correlations are `NA`; skipping correlation filter.")
         return(numeric(0))
       } else {
         na_cols <- which(all_na)
         if (length(na_cols) >  0) {
           x[na_cols, ] <- 0
           x[, na_cols] <- 0
-          warning("The correlation matrix has missing values. ",
-                  length(na_cols), " columns were excluded from the filter.",
-                  call. = FALSE)
+          rlang::warn(
+            paste0(
+              "The correlation matrix has missing values. ",
+              length(na_cols),
+              " columns were excluded from the filter."
+            )
+          )
         }
       }
       if (any(is.na(x))) {
-        warning("The correlation matrix has sporadic missing values. ",
-                "Some columns were excluded from the filter.",
-                call. = FALSE)
+        rlang::warn(
+          paste0(
+            "The correlation matrix has sporadic missing values. ",
+            "Some columns were excluded from the filter."
+          )
+        )
         x[is.na(x)] <- 0
       }
       diag(x) <- 1

--- a/R/count.R
+++ b/R/count.R
@@ -66,18 +66,17 @@ step_count <- function(recipe,
                        skip = FALSE,
                        id = rand_id("count")) {
   if (!is.character(pattern))
-    stop("`pattern` should be a character string", call. = FALSE)
+    rlang::abort("`pattern` should be a character string")
   if (length(pattern) != 1)
-    stop("`pattern` should be a single pattern", call. = FALSE)
+    rlang::abort("`pattern` should be a single pattern")
   valid_args <- names(formals(grepl))[- (1:2)]
   if (any(!(names(options) %in% valid_args)))
-    stop("Valid options are: ",
-         paste0(valid_args, collapse = ", "),
-         call. = FALSE)
+    rlang::abort(paste0("Valid options are: ",
+                        paste0(valid_args, collapse = ", ")))
 
   terms <- ellipse_check(...)
   if (length(terms) > 1)
-    stop("For this step, only a single selector can be used.", call. = FALSE)
+    rlang::abort("For this step, only a single selector can be used.")
 
   add_step(
     recipe,
@@ -117,9 +116,9 @@ step_count_new <-
 prep.step_count <- function(x, training, info = NULL, ...) {
   col_name <- terms_select(x$terms, info = info)
   if (length(col_name) != 1)
-    stop("The selector should only select a single variable")
+    rlang::abort("The selector should only select a single variable")
   if (any(info$type[info$variable %in% col_name] != "nominal"))
-    stop("The regular expression input should be character or factor")
+    rlang::abort("The regular expression input should be character or factor")
 
   step_count_new(
     terms = x$terms,

--- a/R/date.R
+++ b/R/date.R
@@ -94,7 +94,7 @@ step_date <-
       "month")
   if (!is_tune(features) & !is_varying(features)) {
     if (!all(features %in% feat)) {
-      stop("Possible values of `features` should include: ",
+      rlang::abort("Possible values of `features` should include: ",
            paste0("'", feat, "'", collapse = ", "))
     }
   }
@@ -139,8 +139,11 @@ prep.step_date <- function(x, training, info = NULL, ...) {
 
   date_data <- info[info$variable %in% col_names, ]
   if (any(date_data$type != "date"))
-    stop("All variables for `step_date` should be either `Date` or",
-         "`POSIXct` classes.", call. = FALSE)
+    rlang::abort(
+      paste0("All variables for `step_date` should be either `Date` or",
+          "`POSIXct` classes."
+         )
+      )
 
   step_date_new(
     terms = x$terms,

--- a/R/depth.R
+++ b/R/depth.R
@@ -90,7 +90,7 @@ step_depth <-
            skip = FALSE,
            id = rand_id("depth")) {
     if (!is.character(class) || length(class) != 1)
-      stop("`class` should be a single character value.")
+      rlang::abort("`class` should be a single character value.")
 
     recipes_pkg_check("ddalpha")
 

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -11,7 +11,7 @@ discretize <- function(x, ...)
 
 #' @rdname discretize
 discretize.default <- function(x, ...)
-  stop("Only numeric `x` is accepted")
+  rlang::abort("Only numeric `x` is accepted")
 
 #' @rdname discretize
 #' @param cuts An integer defining how many cuts to make of the
@@ -95,7 +95,7 @@ discretize.numeric <-
     missing_lab <- "_missing"
 
     if (cuts < 2)
-      stop("There should be at least 2 cuts")
+      rlang::abort("There should be at least 2 cuts")
 
     if (unique_vals / (cuts + 1) >= min_unique) {
       breaks <- quantile(x, probs = seq(0, 1, length = cuts + 1), ...)

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -102,13 +102,14 @@ discretize.numeric <-
       num_breaks <- length(breaks)
       breaks <- unique(breaks)
       if (num_breaks > length(breaks))
-        warning(
+        rlang::warn(
+          paste0(
           "Not enough data for ",
           cuts,
           " breaks. Only ",
           length(breaks),
-          " breaks were used.",
-          sep = ""
+          " breaks were used."
+          )
         )
       if (infs) {
         breaks[1] <- -Inf
@@ -119,12 +120,12 @@ discretize.numeric <-
       if (is.null(labels)) {
         prefix <- prefix[1]
         if (make.names(prefix) != prefix) {
-          warning(
+          rlang::warn(paste0(
             "The prefix '",
             prefix,
             "' is not a valid R name. It has been changed to '",
             make.names(prefix),
-            "'."
+            "'.")
           )
           prefix <- make.names(prefix)
         }
@@ -142,8 +143,12 @@ discretize.numeric <-
       )
     } else {
       out <- list(bins = 0)
-      warning("Data not binned; too few unique values per bin. ",
-              "Adjust 'min_unique' as needed", call. = FALSE)
+      rlang::warn(
+        paste0(
+          "Data not binned; too few unique values per bin. ",
+          "Adjust 'min_unique' as needed"
+        )
+      )
     }
     class(out) <- "discretize"
     out
@@ -299,8 +304,12 @@ prep.step_discretize <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names])
 
   if (length(col_names) > 1 & any(names(x$options) %in% c("prefix", "labels"))) {
-    warning("Note that the options `prefix` and `labels`",
-            "will be applied to all variables")
+    rlang::warn(
+      paste0(
+        "Note that the options `prefix` and `labels`",
+        "will be applied to all variables"
+      )
+    )
   }
 
   x$options$cuts <- x$num_breaks

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -131,9 +131,9 @@ step_downsample_new <-
 prep.step_downsample <- function(x, training, info = NULL, ...) {
   col_name <- terms_select(x$terms, info = info)
   if (length(col_name) != 1)
-    stop("Please select a single factor variable.", call. = FALSE)
+    rlang::abort("Please select a single factor variable.")
   if (!is.factor(training[[col_name]]))
-    stop(col_name, " should be a factor variable.", call. = FALSE)
+    rlang::abort(col_name, " should be a factor variable.")
 
   obs_freq <- table(training[[col_name]])
   minority <- min(obs_freq)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -179,9 +179,12 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
       )
     col_names <- col_names[fac_check]
     if (length(col_names) == 0) {
-      stop("The `terms` argument in `step_dummy` did not select ",
-           "any factor columns.",
-           call. = FALSE)
+      rlang::abort(
+        paste0(
+        "The `terms` argument in `step_dummy` did not select ",
+        "any factor columns."
+        )
+      )
     }
 
 
@@ -265,7 +268,7 @@ bake.step_dummy <- function(object, new_data, ...) {
     fac_type <- attr(object$levels[[i]], "dataClasses")
 
     if (!any(names(attributes(object$levels[[i]])) == "values"))
-      stop("Factor level values not recorded", call. = FALSE)
+      rlang::abort("Factor level values not recorded")
 
     warn_new_levels(
       new_data[[orig_var]],

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -162,7 +162,7 @@ step_dummy_new <-
 passover <- function(cmd) {
   # cat("`step_dummy()` was not able to select any columns. ",
   #     "No dummy variables will be created.\n")
-} # figure out how to return a warning without exiting
+} # figure out how to return a warning() without exiting
 
 #' @export
 prep.step_dummy <- function(x, training, info = NULL, ...) {
@@ -171,15 +171,17 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   if (length(col_names) > 0) {
     fac_check <- vapply(training[, col_names], is.factor, logical(1))
     if (any(!fac_check))
-      warning(
+      rlang::warn(
+        paste0(
         "The following variables are not factor vectors and will be ignored: ",
-        paste0("`", names(fac_check)[!fac_check], "`", collapse = ", "),
-        call. = FALSE
+        paste0("`", names(fac_check)[!fac_check], "`", collapse = ", ")
+        )
       )
     col_names <- col_names[fac_check]
     if (length(col_names) == 0) {
       stop("The `terms` argument in `step_dummy` did not select ",
-           "any factor columns.", call. = FALSE)
+           "any factor columns.",
+           call. = FALSE)
     }
 
 
@@ -231,9 +233,11 @@ warn_new_levels <- function(dat, lvl) {
   ind <- which(!(dat %in% lvl))
   if (length(ind) > 0) {
     lvl2 <- unique(dat[ind])
-    warning("There are new levels in a factor: ",
-            paste0(lvl2, collapse = ", "),
-            call. = FALSE)
+    rlang::warn(
+      paste0("There are new levels in a factor: ",
+            paste0(lvl2, collapse = ", ")
+            )
+      )
   }
   invisible(NULL)
 }

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -95,10 +95,11 @@ prep.step_factor2string <- function(x, training, info = NULL, ...) {
   fac_check <-
     vapply(training[, col_names], is.factor, logical(1))
   if (any(!fac_check))
-    stop(
+    rlang::abort(
+      paste0(
       "The following variables are not factor vectors: ",
-      paste0("`", names(fac_check)[!fac_check], "`", collapse = ", "),
-      call. = FALSE
+      paste0("`", names(fac_check)[!fac_check], "`", collapse = ", ")
+      )
     )
 
   step_factor2string_new(

--- a/R/formula.R
+++ b/R/formula.R
@@ -18,9 +18,12 @@
 #' @export
 formula.recipe <- function(x, ...) {
   if (!fully_trained(x))
-    stop("All steps in the recipe must be prepped before the ",
-         "formula can be computed.",
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+      "All steps in the recipe must be prepped before the ",
+      "formula can be computed."
+      )
+    )
 
   x <- summary(x)
   x_vars <- x$variable[x$role == "predictor"]

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -57,13 +57,13 @@ step_geodist <- function(recipe,
                          skip = FALSE,
                          id = rand_id("geodist")) {
   if (length(ref_lon) != 1 || !is.numeric(ref_lon))
-    stop("`ref_lon` should be a single numeric value.", call. = FALSE)
+    rlang::abort("`ref_lon` should be a single numeric value.")
   if (length(ref_lat) != 1 || !is.numeric(ref_lat))
-    stop("`ref_lat` should be a single numeric value.", call. = FALSE)
+    rlang::abort("`ref_lat` should be a single numeric value.")
   if (length(log) != 1 || !is.logical(log))
-    stop("`log` should be a single logical value.", call. = FALSE)
+    rlang::abort("`log` should be a single logical value.")
   if (length(name) != 1 || !is.character(name))
-    stop("`name` should be a single character value.", call. = FALSE)
+    rlang::abort("`name` should be a single character value.")
 
   add_step(
     recipe,
@@ -107,15 +107,15 @@ step_geodist_new <-
 prep.step_geodist <- function(x, training, info = NULL, ...) {
   lon_name <- terms_select(x$lon, info = info)
   if (length(lon_name) > 1)
-    stop("`lon` should resolve to a single column name.", call. = FALSE)
+    rlang::abort("`lon` should resolve to a single column name.")
   check_type(training[, lon_name])
   lat_name <- terms_select(x$lat, info = info)
   if (length(lat_name) > 1)
-    stop("`lat` should resolve to a single column name.", call. = FALSE)
+    rlang::abort("`lat` should resolve to a single column name.")
   check_type(training[, lat_name])
 
   if (any(names(training) == x$name))
-    stop("'", x$name, "' is already used in the data.", call. = FALSE)
+    rlang::abort("'", x$name, "' is already used in the data.")
 
   step_geodist_new(
     lon = x$lon,

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -63,8 +63,7 @@ step_holiday <-
     if (!is_tune(holidays) & !is_varying(holidays)) {
       all_days <- listHolidays()
       if (!all(holidays %in% all_days))
-        stop("Invalid `holidays` value. See timeDate::listHolidays",
-             call. = FALSE)
+        rlang::abort("Invalid `holidays` value. See timeDate::listHolidays")
     }
 
   add_step(
@@ -101,8 +100,12 @@ prep.step_holiday <- function(x, training, info = NULL, ...) {
 
   holiday_data <- info[info$variable %in% col_names, ]
   if (any(holiday_data$type != "date"))
-    stop("All variables for `step_holiday` should be either `Date` ",
-         "or `POSIXct` classes.", call. = FALSE)
+    rlang::abort(
+      paste0(
+        "All variables for `step_holiday` should be either `Date` ",
+        "or `POSIXct` classes."
+         )
+    )
 
   step_holiday_new(
     terms = x$terms,

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -58,8 +58,7 @@ step_hyperbolic <-
            id = rand_id("hyperbolic")) {
     funcs <- c("sin", "cos", "tan")
     if (!(func %in% funcs))
-      stop("`func` should be either `sin``, `cos`, or `tan`",
-           call. = FALSE)
+      rlang::abort("`func` should be either `sin``, `cos`, or `tan`")
     add_step(
       recipe,
       step_hyperbolic_new(

--- a/R/ica.R
+++ b/R/ica.R
@@ -160,7 +160,7 @@ prep.step_ica <- function(x, training, info = NULL, ...) {
         silent = TRUE
       )
     if (inherits(indc, "try-error")) {
-      stop("`step_ica` failed with error:\n", as.character(indc), call. = FALSE)
+      rlang::abort(paste0("`step_ica` failed with error:\n", as.character(indc)))
     }
   } else {
     indc <- list(x_vars = col_names)

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -336,8 +336,7 @@ find_selectors <- function (f) {
   }
   else {
     # User supplied incorrect input
-    stop("Don't know how to handle type ", typeof(f),
-         call. = FALSE)
+    rlang::abort(paste0("Don't know how to handle type ", typeof(f), "."))
   }
 }
 
@@ -354,8 +353,7 @@ replace_selectors <- function(x, elem, value) {
     map_pairlist(x, replace_selectors, elem, value)
   } else {
     # User supplied incorrect input
-    stop("Don't know how to handle type ", typeof(x),
-         call. = FALSE)
+    rlang::abort(paste0("Don't know how to handle type ", typeof(x), "."))
   }
 }
 

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -163,11 +163,13 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
       unique(unlist(lapply(make_new_formula(int_terms), all.vars)))
     var_check <- info[info$variable %in% vars, ]
     if (any(var_check$type == "nominal"))
-      warning(
+      rlang::warn(
+        paste0(
         "Categorical variables used in `step_interact` should probably be ",
         "avoided;  This can lead to differences in dummy variable values that ",
         "are produced by `step_dummy`. Please convert all involved variables ",
-        "to dummy variables first.", call. = FALSE
+        "to dummy variables first."
+        )
       )
 
     ## For each interaction, create a new formula that has main effects
@@ -264,12 +266,13 @@ get_term_names <- function(form, vnames) {
     silent = TRUE
   )
   if (inherits(nms, "try-error")) {
-    warning(
-      "Interaction specification failed for: ",
-      deparse(form),
-      ". No interactions will be created.",
-      call. = FALSE
+    rlang::warn(
+      paste0(
+        "Interaction specification failed for: ",
+        deparse(form),
+        ". No interactions will be created."
       )
+    )
     return(rlang::na_chr)
   }
   nms <- nms[nms != "(Intercept)"]

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -51,9 +51,9 @@ step_intercept <- function(recipe, ..., role = "predictor",
   if (length(list(...)) > 0)
     rlang::warn("Selectors are not used for this step.")
   if (!is.numeric(value))
-    stop("Intercept value must be numeric.", call. = FALSE)
+    rlang::abort("Intercept value must be numeric.")
   if (!is.character(name) | length(name) != 1)
-    stop("Intercept/constant column name must be a character value.")
+    rlang::abort("Intercept/constant column name must be a character value.")
   add_step(
     recipe,
     step_intercept_new(

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -49,12 +49,11 @@ step_intercept <- function(recipe, ..., role = "predictor",
                            value = 1,
                            skip = FALSE, id = rand_id("intercept")) {
   if (length(list(...)) > 0)
-    warning("Selectors are not used for this step.", call. = FALSE)
+    rlang::warn("Selectors are not used for this step.")
   if (!is.numeric(value))
     stop("Intercept value must be numeric.", call. = FALSE)
   if (!is.character(name) | length(name) != 1)
-    stop("Intercept/constant column name must be a character value.",
-         call. = FALSE)
+    stop("Intercept/constant column name must be a character value.")
   add_step(
     recipe,
     step_intercept_new(

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -169,7 +169,7 @@ prep.step_isomap <- function(x, training, info = NULL, ...) {
         ),
         silent = TRUE)
     if (inherits(iso_map, "try-error")) {
-      stop("`step_isomap` failed with error:\n", as.character(iso_map), call. = FALSE)
+      rlang::abort(paste0("`step_isomap` failed with error:\n", as.character(iso_map)))
     }
 
   } else {

--- a/R/knn_imp.R
+++ b/R/knn_imp.R
@@ -215,7 +215,7 @@ bake.step_knnimpute <- function(object, new_data, ...) {
       imp_data <- old_data[missing_rows, preds, drop = FALSE]
       ## do a better job of checking this:
       if (all(is.na(imp_data))) {
-        warning("All predictors are missing; cannot impute", call. = FALSE)
+        rlang::warn("All predictors are missing; cannot impute")
       } else {
         imp_var_complete <- !is.na(object$ref_data[[imp_var]])
         nn_ind <- nn_index(object$ref_data[imp_var_complete,],

--- a/R/knn_imp.R
+++ b/R/knn_imp.R
@@ -98,15 +98,15 @@ step_knnimpute <-
            skip = FALSE,
            id = rand_id("knnimpute")) {
     if (is.null(impute_with)) {
-      stop("Please list some variables in `impute_with`", call. = FALSE)
+      rlang::abort("Please list some variables in `impute_with`")
     }
 
     if (!is.list(options))
-      stop("`options` should be a named list.", call. = FALSE)
+      rlang::abort("`options` should be a named list.")
     opt_nms <- names(options)
     if (length(options) > 0) {
       if (any(!(opt_nms %in% c("eps", "nthread")))) {
-        stop("Availible options are 'eps', and 'nthread'.", call. = FALSE)
+        rlang::abort("Availible options are 'eps', and 'nthread'.")
       }
       if (all(opt_nms != "nthread")) {
         options$nthread <- 1

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -180,7 +180,7 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
         silent = TRUE
       )
     if (inherits(kprc, "try-error")) {
-      stop("`step_kpca` failed with error:\n", as.character(kprc), call. = FALSE)
+      rlang::abort(paste0("`step_kpca` failed with error:\n", as.character(kprc)))
     }
   } else {
     kprc <- list(x_vars = col_names)

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -177,7 +177,8 @@ prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
         silent = TRUE
       )
     if (inherits(kprc, "try-error")) {
-      stop("`step_kpca_poly` failed with error:\n", as.character(kprc), call. = FALSE)
+      rlang::abort(paste0("`step_kpca_poly` failed with error:\n",
+                          as.character(kprc)))
     }
   } else {
     kprc <- list(x_vars = col_names)

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -170,7 +170,8 @@ prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
       )
 
     if (inherits(kprc, "try-error")) {
-      stop("`step_kpca_rbf` failed with error:\n", as.character(kprc), call. = FALSE)
+      rlang::abort(paste0("`step_kpca_rbf` failed with error:\n",
+                          as.character(kprc)))
     }
   } else {
     kprc <- list(x_vars = col_names)

--- a/R/lag.R
+++ b/R/lag.R
@@ -112,8 +112,7 @@ prep.step_lag <- function(x, training, info = NULL, ...) {
 bake.step_lag <- function(object, new_data, ...) {
 
   if (!all(object$lag == as.integer(object$lag)))
-    stop("step_lag requires 'lag' argument to be integer valued.",
-         call. = FALSE)
+    rlang::abort("step_lag requires 'lag' argument to be integer valued.")
 
   make_call <- function(col, lag_val) {
     call2(

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -144,7 +144,7 @@ recommend_rm <- function(x, eps  = 1e-6, ...) {
   if (!is.matrix(x))
     x <- as.matrix(x)
   if (is.null(colnames(x)))
-    stop("`x` should have column names", call. = FALSE)
+    rlang::abort("`x` should have column names")
 
   qr_decomp <- qr(x)
   qr_decomp_R <- qr.R(qr_decomp)           # extract R matrix
@@ -178,7 +178,7 @@ iter_lc_rm <- function(x,
                        max_steps = 10,
                        verbose = FALSE) {
   if (is.null(colnames(x)))
-    stop("`x` should have column names", call. = FALSE)
+    rlang::abort("`x` should have column names")
 
   orig_names <- colnames(x)
   if (!is.matrix(x))

--- a/R/log.R
+++ b/R/log.R
@@ -139,7 +139,7 @@ bake.step_log <- function(object, new_data, ...) {
         log(new_data[[ col_names[i] ]] + object$offset, base = object$base)
   } else {
     if (object$offset != 0)
-      warning("When signed is TRUE, offset will be ignored")
+      rlang::warn("When signed is TRUE, offset will be ignored")
      for (i in seq_along(col_names))
        new_data[, col_names[i]] <-
          ifelse(abs(new_data[[ col_names[i] ]]) < 1,

--- a/R/lowerimpute.R
+++ b/R/lowerimpute.R
@@ -105,10 +105,11 @@ prep.step_lowerimpute <- function(x, training, info = NULL, ...) {
            numeric(1),
            na.rm = TRUE)
   if (any(threshold < 0))
-    stop(
-      "Some columns have negative values. Lower bound ",
-      "imputation is intended for data bounded at zero.",
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "Some columns have negative values. Lower bound ",
+        "imputation is intended for data bounded at zero."
+      )
     )
   step_lowerimpute_new(
     terms = x$terms,

--- a/R/misc.R
+++ b/R/misc.R
@@ -542,17 +542,18 @@ check_nominal_type <- function(x, lvl) {
     was_factor <- fac_ref_cols[!(fac_ref_cols %in% fac_act_cols)]
 
     if (length(was_factor) > 0) {
-      warning(
-        " There ",
-        ifelse(length(was_factor) > 1, "were ", "was "),
-        length(was_factor),
-        ifelse(length(was_factor) > 1, " columns ", " column "),
-        "that ",
-        ifelse(length(was_factor) > 1, "were factors ", "was a factor "),
-        "when the recipe was prepped:\n ",
-        paste0("'", was_factor, "'", collapse = ", "),
-        ".\n This may cause errors when processing new data.",
-        call. = FALSE
+      rlang::warn(
+        paste0(
+          " There ",
+          ifelse(length(was_factor) > 1, "were ", "was "),
+          length(was_factor),
+          ifelse(length(was_factor) > 1, " columns ", " column "),
+          "that ",
+          ifelse(length(was_factor) > 1, "were factors ", "was a factor "),
+          "when the recipe was prepped:\n ",
+          paste0("'", was_factor, "'", collapse = ", "),
+          ".\n This may cause errors when processing new data."
+        )
       )
     }
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -146,7 +146,7 @@ mod_call_args <- function(cl, args, removals = NULL) {
 
 names0 <- function(num, prefix = "x") {
   if (num < 1)
-    stop("`num` should be > 0", call. = FALSE)
+    rlang::abort("`num` should be > 0")
   ind <- format(1:num)
   ind <- gsub(" ", "0", ind)
   paste0(prefix, ind)
@@ -285,9 +285,12 @@ merge_term_info <- function(.new, .old) {
 ellipse_check <- function(...) {
   terms <- quos(...)
   if (is_empty(terms))
-    stop("Please supply at least one variable specification.",
-         "See ?selections.",
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+      "Please supply at least one variable specification.",
+      "See ?selections."
+      )
+    )
   terms
 }
 
@@ -329,8 +332,8 @@ printer <- function(tr_obj = NULL,
 #' @keywords internal
 #' @rdname recipes-internal
 prepare   <- function(x, ...)
-  stop("As of version 0.0.1.9006, used `prep` ",
-       "instead of `prepare`", call. = FALSE)
+  rlang::abort(paste0("As of version 0.0.1.9006, used `prep` ",
+       "instead of `prepare`"))
 
 
 #' Check to see if a recipe is trained/prepared
@@ -370,8 +373,7 @@ fully_trained <- function(x) {
 detect_step <- function(recipe, name) {
   exports <- getNamespaceExports("recipes")
   if (!any(grepl(paste0(".*", name, ".*"), exports)))
-    stop("Please provide the name of valid step or check (ex: `center`).",
-         call. = FALSE)
+    rlang::abort("Please provide the name of valid step or check (ex: `center`).")
   name %in% tidy(recipe)$type
 }
 
@@ -413,8 +415,12 @@ check_type <- function(dat, quant = TRUE) {
     label <- "factor or character"
   }
   if (!all(all_good))
-    stop("All columns selected for the step",
-         " should be ", label, call. = FALSE)
+    rlang::abort(
+      paste0(
+        "All columns selected for the step",
+         " should be ",
+         label)
+      )
   invisible(all_good)
 }
 
@@ -487,10 +493,15 @@ check_name <- function(res, new_data, object, newname = NULL, names = FALSE) {
   new_data_names <- colnames(new_data)
   intersection <- new_data_names %in% newname
   if(any(intersection)) {
-    stop("Name collision occured in `", class(object)[1],
-         "`. The following variable names already exists: ",
-         paste0(new_data_names[intersection], collapse = ", "), ".",
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+        "Name collision occured in `",
+        class(object)[1],
+        "`. The following variable names already exists: ",
+        paste0(new_data_names[intersection], collapse = ", "),
+        "."
+      )
+    )
   }
   if(names) {
     names(res) <- newname

--- a/R/missing.r
+++ b/R/missing.r
@@ -112,8 +112,8 @@ bake.check_missing <- function(object, new_data, ...) {
   if (any(nr_na > 0)) {
     with_na     <- names(nr_na[nr_na > 0])
     with_na_str <- paste(paste0("`", with_na, "`"), collapse = ", ")
-    stop("The following columns contain missing values: ",
-         with_na_str, ".", call. = FALSE)
+    rlang::abort(paste0("The following columns contain missing values: ",
+                        with_na_str, "."))
   }
   new_data
 }

--- a/R/modeimpute.R
+++ b/R/modeimpute.R
@@ -122,8 +122,7 @@ print.step_modeimpute <-
 
 mode_est <- function(x) {
   if (!is.character(x) & !is.factor(x))
-    stop("The data should be character or factor to compute the mode.",
-         call. = FALSE)
+    rlang::abort("The data should be character or factor to compute the mode.")
   tab <- table(x)
   modes <- names(tab)[tab == max(tab)]
   sample(modes, size = 1)

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -114,10 +114,11 @@ new_values_func <- function(x,
   if (length(new_vals) == 0) return()
   if (all(is.na(new_vals)) && ignore_NA) return()
   if (ignore_NA) new_vals <- new_vals[!is.na(new_vals)]
-  stop(colname,
-       " contains the new value(s): ",
-       paste(new_vals, collapse = ","),
-       call. = FALSE)
+  rlang::abort(paste0(
+    colname,
+    " contains the new value(s): ",
+    paste(new_vals, collapse = ",")
+  ))
 }
 
 prep.check_new_values <- function(x, training, info = NULL, ...) {

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -151,6 +151,7 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
     nnm <- try(do.call(dimRed::embed, opts), silent = TRUE)
     if (inherits(nnm, "try-error")) {
       rlang::abort(paste0("`step_nnmf` failed with error:\n", as.character(nnm)))
+    }
   } else {
     nnm <- list(x_vars = col_names)
   }

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -150,8 +150,7 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
 
     nnm <- try(do.call(dimRed::embed, opts), silent = TRUE)
     if (inherits(nnm, "try-error")) {
-      stop("`step_nnmf` failed with error:\n", as.character(nnm), call. = FALSE)
-    }
+      rlang::abort(paste0("`step_nnmf` failed with error:\n", as.character(nnm)))
   } else {
     nnm <- list(x_vars = col_names)
   }

--- a/R/novel.R
+++ b/R/novel.R
@@ -109,7 +109,7 @@ get_existing_values <- function(x) {
       attr(out, "is_ordered") <- is.ordered(x)
     }
     else
-      stop("Data should be either character or factor", call. = FALSE)
+      rlang::abort("Data should be either character or factor")
   }
   out
 }
@@ -119,11 +119,10 @@ prep.step_novel <- function(x, training, info = NULL, ...) {
   col_names <- terms_select(x$terms, info = info)
   col_check <- dplyr::filter(info, variable %in% col_names)
   if (any(col_check$type != "nominal"))
-    stop(
-      "Columns must be character or factor: ",
-      paste0(col_check$variable[col_check$type != "nominal"],
-             collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0("Columns must be character or factor: ",
+             paste0(col_check$variable[col_check$type != "nominal"],
+                    collapse = ", "))
     )
 
   # Get existing levels and their factor type (i.e. ordered)
@@ -132,10 +131,11 @@ prep.step_novel <- function(x, training, info = NULL, ...) {
   level_check <-
     map_lgl(objects, function(x, y) y %in% x, y = x$new_level)
   if (any(level_check))
-    stop(
-      "Columns already contain the new level: ",
-      paste0(names(level_check)[level_check], collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "Columns already contain the new level: ",
+        paste0(names(level_check)[level_check], collapse = ", ")
+      )
     )
 
   step_novel_new(

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -93,7 +93,7 @@ step_num2factor <-
            id = rand_id("num2factor")) {
     if (!is_tune(ordered) & !is_varying(ordered)) {
       if (!is.logical(ordered) || length(ordered) != 1)
-        stop("`ordered` should be a single logical variable")
+        rlang::abort("`ordered` should be a single logical variable")
     }
 
     if (rlang::is_missing(levels) || !is.character(levels)) {

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -111,9 +111,12 @@ prep.step_ordinalscore <-
     ord_check <-
       vapply(training[, col_names], is.ordered, c(logic = TRUE))
     if (!all(ord_check))
-      stop("Ordinal factor variables should be selected as ",
-           "inputs into this step.",
-           call. = TRUE)
+      rlang::abort(
+        paste0(
+          "Ordinal factor variables should be selected as ",
+           "inputs into this step."
+          )
+        )
     step_ordinalscore_new(
       terms = x$terms,
       role = x$role,

--- a/R/other.R
+++ b/R/other.R
@@ -106,10 +106,10 @@ step_other <-
            id = rand_id("other")) {
     if (!is_tune(threshold) & !is_varying(threshold)) {
       if (threshold <= 0) {
-        stop("`threshold` should be greater than zero", call. = FALSE)
+        rlang::abort("`threshold` should be greater than zero")
       }
       if (threshold >= 1 && !is_integerish(threshold)) {
-        stop("If `threshold` is greater than one it should be an integer.", call. = FALSE)
+        rlang::abort("If `threshold` is greater than one it should be an integer.")
       }
     }
     add_step(
@@ -238,11 +238,13 @@ keep_levels <- function(x, threshold = .1, other = "other") {
     keepers <- names(xtab)[which.max(xtab)]
 
   if (other %in% keepers)
-    stop(
-      "The level ",
-      other,
-      " is already a factor level that will be retained. ",
-      "Please choose a different value.", call. = FALSE
+    rlang::abort(
+        paste0(
+        "The level ",
+        other,
+        " is already a factor level that will be retained. ",
+        "Please choose a different value."
+      )
     )
 
   list(keep = orig[orig %in% keepers],

--- a/R/pca.R
+++ b/R/pca.R
@@ -114,7 +114,7 @@ step_pca <- function(recipe,
 
   if (!is_tune(threshold) & !is_varying(threshold)) {
     if (!is.na(threshold) && (threshold > 1 | threshold <= 0)) {
-      stop("`threshold` should be on (0, 1].", call. = FALSE)
+      rlang::abort("`threshold` should be on (0, 1].")
     }
   }
 

--- a/R/pls.R
+++ b/R/pls.R
@@ -91,7 +91,7 @@ step_pls <-
            skip = FALSE,
            id = rand_id("pls")) {
     if (is.null(outcome))
-      stop("`outcome` should select at least one column.", call. = FALSE)
+      rlang::abort("`outcome` should select at least one column.")
 
     recipes_pkg_check("pls")
 

--- a/R/profile.R
+++ b/R/profile.R
@@ -116,17 +116,15 @@ step_profile <- function(recipe,
                          id = rand_id("profile")) {
 
   if (pct < 0 | pct > 1)
-    stop("`pct should be on [0, 1]`", call. = FALSE)
+    rlang::abort("`pct should be on [0, 1]`")
   if (length(grid) != 2)
-    stop("`grid` should have two named elements. See ?step_profile",
-         call. = FALSE)
+    rlang::abort("`grid` should have two named elements. See ?step_profile")
   if (all(sort(names(grid)) == c("len", "ptcl")))
-    stop("`grid` should have two named elements. See ?step_profile",
-         call. = FALSE)
+    rlang::abort("`grid` should have two named elements. See ?step_profile")
   if (grid$len < 2)
-    stop("`grid$len should be at least 2.`", call. = FALSE)
+    rlang::abort("`grid$len should be at least 2.`")
   if (!is.logical(grid$pctl))
-    stop("`grid$pctl should be logical.`", call. = FALSE)
+    rlang::abort("`grid$pctl should be logical.`")
 
   add_step(recipe,
            step_profile_new(
@@ -167,12 +165,16 @@ prep.step_profile <- function(x, training, info = NULL, ...) {
   profile_name <- terms_select(x$profile, info = info)
 
   if(length(fixed_names) == 0)
-    stop("At least one variable should be fixed", call. = FALSE)
+    rlang::abort("At least one variable should be fixed")
   if(length(profile_name) != 1)
-    stop("Only one variable should be profiled", call. = FALSE)
+    rlang::abort("Only one variable should be profiled")
   if(any(profile_name == fixed_names))
-    stop("The profiled variable cannot be in the list of ",
-         "variables to be fixed.", call. = FALSE)
+    rlang::abort(
+      paste0(
+        "The profiled variable cannot be in the list of ",
+        "variables to be fixed."
+        )
+      )
   fixed_vals <- lapply(
     training[, fixed_names],
     fixed,
@@ -255,7 +257,7 @@ fixed <- function (x, pct, index, ...) UseMethod("fixed")
 #' @export
 #' @rdname fixed
 fixed.default <- function(x, pct, index, ...) {
-  stop("No method for determining a value to fix for ",
+  rlang::abort("No method for determining a value to fix for ",
        "objects of class(s) ",
        paste0("'", class(x), "'", collapse = ","),
        call. = FALSE)

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -160,7 +160,7 @@ range_check_func <- function(x,
     lower_allowed <- lower - ((upper - lower) * slack_prop[1])
     upper_allowed <- upper + ((upper - lower) * slack_prop[2])
   } else {
-    stop("slack_prop should be of length 1 or of length 2")
+    rlang::abort("slack_prop should be of length 1 or of length 2")
   }
 
   if (min_x < lower_allowed & max_x > upper_allowed) {
@@ -177,7 +177,7 @@ range_check_func <- function(x,
   if (warn & !is.null(msg)) {
     rlang::warn(msg)
   } else if (!is.null(msg)) {
-    stop(msg, call. = FALSE)
+    rlang::abort(msg)
   }
 }
 

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -175,7 +175,7 @@ range_check_func <- function(x,
                   upper_allowed)
   }
   if (warn & !is.null(msg)) {
-    warning(msg, call. = FALSE)
+    rlang::warn(msg)
   } else if (!is.null(msg)) {
     stop(msg, call. = FALSE)
   }

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -70,8 +70,12 @@ step_ratio <-
            skip = FALSE,
            id = rand_id("ratio")) {
     if (is_empty(denom))
-      stop("Please supply at least one denominator variable specification. ",
-           "See ?selections.", call. = FALSE)
+      rlang::abort(
+        paste0(
+          "Please supply at least one denominator variable specification. ",
+          "See ?selections."
+          )
+        )
     add_step(
       recipe,
       step_ratio_new(
@@ -113,11 +117,11 @@ prep.step_ratio <- function(x, training, info = NULL, ...) {
   col_names <- col_names[!(col_names$top == col_names$bottom), ]
 
   if (nrow(col_names) == 0)
-    stop("No variables were selected for making ratios", call. = FALSE)
+    rlang::abort("No variables were selected for making ratios")
   if (any(info$type[info$variable %in% col_names$top] != "numeric"))
-    stop("The ratio variables should be numeric")
+    rlang::abort("The ratio variables should be numeric")
   if (any(info$type[info$variable %in% col_names$bottom] != "numeric"))
-    stop("The ratio variables should be numeric")
+    rlang::abort("The ratio variables should be numeric")
 
   step_ratio_new(
     terms = x$terms,

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -15,7 +15,7 @@ recipe <- function(x, ...)
 #' @rdname recipe
 #' @export
 recipe.default <- function(x, ...)
-  stop("`x` should be a data frame, matrix, or tibble", call. = FALSE)
+  rlang::abort("`x` should be a data frame, matrix, or tibble")
 
 #' @rdname recipe
 #' @param vars A character string of column names corresponding to variables
@@ -154,11 +154,17 @@ recipe.data.frame <-
 
     if (!is.null(formula)) {
       if (!is.null(vars))
-        stop("This `vars` specification will be ignored when a formula is ",
-             "used", call. = FALSE)
+        rlang::abort(
+          paste0("This `vars` specification will be ignored ",
+             "when a formula is used"
+             )
+          )
       if (!is.null(roles))
-        stop("This `roles` specification will be ignored when a formula is ",
-             "used", call. = FALSE)
+        rlang::abort(
+          paste0("This `roles` specification will be ignored ",
+             "when a formula is used"
+             )
+          )
 
       obj <- recipe.formula(formula, x, ...)
       return(obj)
@@ -171,9 +177,9 @@ recipe.data.frame <-
       x <- as_tibble(x)
 
     if (any(table(vars) > 1))
-      stop("`vars` should have unique members", call. = FALSE)
+      rlang::abort("`vars` should have unique members")
     if (any(!(vars %in% colnames(x))))
-      stop("1+ elements of `vars` are not in `x`", call. = FALSE)
+      rlang::abort("1+ elements of `vars` are not in `x`")
 
     x <- x[, vars]
 
@@ -182,8 +188,10 @@ recipe.data.frame <-
     ## Check and add roles when available
     if (!is.null(roles)) {
       if (length(roles) != length(vars))
-        stop("The number of roles should be the same as the number of ",
-             "variables", call. = FALSE)
+        rlang::abort(
+          paste0("The number of roles should be the same as the number of ",
+             "variables")
+        )
       var_info$role <- roles
     } else
       var_info$role <- NA
@@ -337,13 +345,19 @@ prep.recipe <-
 
     if (is.null(training)) {
       if (fresh)
-        stop("A training set must be supplied to the `training` argument ",
-             "when `fresh = TRUE`", call. = FALSE)
+        rlang::abort(
+          paste0("A training set must be supplied to the `training` argument ",
+             "when `fresh = TRUE`"
+             )
+          )
       training <- x$template
     } else {
       if (!all(vars %in% colnames(training))) {
-        stop("Not all variables in the recipe are present in the supplied ",
-             "training set", call. = FALSE)
+        rlang::abort(
+          paste0("Not all variables in the recipe are present in the supplied ",
+             "training set"
+          )
+        )
       }
       training <- if (!is_tibble(training))
         as_tibble(training[, vars, drop = FALSE])
@@ -354,11 +368,12 @@ prep.recipe <-
     steps_trained <- vapply(x$steps, is_trained, logical(1))
     if (any(steps_trained) & !fresh) {
       if(!x$retained)
-        stop(
+        rlang::abort(
+          paste0(
           "To prep new steps after prepping the original ",
           "recipe, `retain = TRUE` must be set each time that ",
-          "the recipe is trained.",
-          call. = FALSE
+          "the recipe is trained."
+          )
         )
       if (!is.null(x$training))
         rlang::warn(
@@ -519,15 +534,16 @@ bake <- function(object, ...)
 #' @export
 bake.recipe <- function(object, new_data = NULL, ..., composition = "tibble") {
   if (!fully_trained(object)) {
-    stop("At least one step has not been trained. Please ",
-         "run `prep`.",
-         call. = FALSE)
+    rlang::abort("At least one step has not been trained. Please run `prep`.")
   }
 
   if (!any(composition == formats)) {
-    stop("`composition` should be one of: ",
-         paste0("'", formats, "'", collapse = ","),
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+      "`composition` should be one of: ",
+      paste0("'", formats, "'", collapse = ",")
+      )
+    )
   }
 
   terms <- quos(...)
@@ -538,10 +554,9 @@ bake.recipe <- function(object, new_data = NULL, ..., composition = "tibble") {
   # In case someone used the deprecated `newdata`:
   if (is.null(new_data) || is.null(ncol(new_data))) {
     if (any(names(terms) == "newdata")) {
-      stop("Please use `new_data` instead of `newdata` with `bake`.",
-           call. = FALSE)
+      rlang::abort("Please use `new_data` instead of `newdata` with `bake`.")
     } else {
-      stop("Please pass a data set to `new_data`.", call. = FALSE)
+      rlang::abort("Please pass a data set to `new_data`.")
     }
   }
 
@@ -735,20 +750,23 @@ summary.recipe <- function(object, original = FALSE, ...) {
 #' @seealso [recipe()] [prep.recipe()] [bake.recipe()]
 juice <- function(object, ..., composition = "tibble") {
   if (!fully_trained(object)) {
-    stop("At least one step has not been trained. Please ",
-         "run `prep`.",
-         call. = FALSE)
+    rlang::abort("At least one step has not been trained. Please run `prep`.")
   }
 
   if (!isTRUE(object$retained)) {
-    stop("Use `retain = TRUE` in `prep` to be able to extract the training set",
-         call. = FALSE)
+    rlang::abort(
+      paste0("Use `retain = TRUE` in `prep` to be able",
+             "to extract the training set"
+             )
+    )
   }
 
   if (!any(composition == formats)) {
-    stop("`composition` should be one of: ",
-         paste0("'", formats, "'", collapse = ","),
-         call. = FALSE)
+    rlang::abort(
+      paste0("`composition` should be one of: ",
+         paste0("'", formats, "'", collapse = ",")
+         )
+      )
   }
 
   terms <- quos(...)

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -361,11 +361,12 @@ prep.recipe <-
           call. = FALSE
         )
       if (!is.null(x$training))
-        warning(
-          "The previous data will be used by `prep`; ",
-          "the data passed using `training` will be ",
-          "ignored.",
-          call. = FALSE
+        rlang::warn(
+          paste0(
+            "The previous data will be used by `prep`; ",
+            "the data passed using `training` will be ",
+            "ignored."
+          )
         )
       training <- x$template
     }
@@ -386,9 +387,13 @@ prep.recipe <-
     # use `retain = TRUE` so issue a warning if this is not the case
     skippers <- map_lgl(x$steps, is_skipable)
     if (any(skippers) & !retain)
-      warning("Since some operations have `skip = FALSE`, using ",
-              "`retain = TRUE` will allow those steps results to ",
-              "be accessible.")
+      rlang::warn(
+        paste0(
+          "Since some operations have `skip = FALSE`, using ",
+          "`retain = TRUE` will allow those steps results to ",
+          "be accessible."
+        )
+      )
 
 
     running_info <- x$term_info %>% mutate(number = 0, skip = FALSE)

--- a/R/regex.R
+++ b/R/regex.R
@@ -62,23 +62,21 @@ step_regex <- function(recipe,
                        id = rand_id("regex")) {
   if (!is_tune(pattern) & !is_varying(pattern)) {
     if (!is.character(pattern)) {
-      stop("`pattern` should be a character string", call. = FALSE)
+      rlang::abort("`pattern` should be a character string")
     }
     if (length(pattern) != 1) {
-      stop("`pattern` should be a single pattern", call. = FALSE)
+      rlang::abort("`pattern` should be a single pattern")
     }
   }
   valid_args <- names(formals(grepl))[-(1:2)]
   if (any(!(names(options) %in% valid_args))) {
-    stop("Valid options are: ",
-         paste0(valid_args, collapse = ", "),
-         call. = FALSE)
+    rlang::abort(paste0("Valid options are: ",
+                        paste0(valid_args, collapse = ", ")))
   }
 
   terms <- ellipse_check(...)
   if (length(terms) > 1)
-    stop("For this step, only a single selector can be used.",
-         call. = FALSE)
+    rlang::abort("For this step, only a single selector can be used.")
 
   add_step(
     recipe,
@@ -116,9 +114,9 @@ step_regex_new <-
 prep.step_regex <- function(x, training, info = NULL, ...) {
   col_name <- terms_select(x$terms, info = info)
   if (length(col_name) != 1)
-    stop("The selector should only select a single variable")
+    rlang::abort("The selector should only select a single variable")
   if (any(info$type[info$variable %in% col_name] != "nominal"))
-    stop("The regular expression input should be character or factor")
+    rlang::abort("The regular expression input should be character or factor")
 
   step_regex_new(
     terms = x$terms,

--- a/R/relu.R
+++ b/R/relu.R
@@ -79,17 +79,17 @@ step_relu <-
            id = rand_id("relu")) {
     if (!is_tune(shift) & !is_varying(shift)) {
       if (!is.numeric(shift)) {
-        stop("Shift argument must be a numeric value.", call. = FALSE)
+        rlang::abort("Shift argument must be a numeric value.")
       }
     }
     if (!is_tune(reverse) & !is_varying(reverse)) {
       if (!is.logical(reverse)) {
-        stop("Reverse argument must be a logical value.", call. = FALSE)
+        rlang::abort("Reverse argument must be a logical value.")
       }
     }
     if (!is_tune(smooth) & !is_varying(smooth)) {
       if (!is.logical(smooth)) {
-        stop("Smooth argument must be logical value.", call. = FALSE)
+        rlang::abort("Smooth argument must be logical value.")
       }
     }
     if (reverse & prefix == "right_relu_") {
@@ -174,7 +174,7 @@ print.step_relu <-
 
 relu <- function(x, shift = 0, reverse = FALSE, smooth = FALSE) {
   if (!is.numeric(x))
-    stop("step_relu can only be applied to numeric data.", call. = FALSE)
+    rlang::abort("step_relu can only be applied to numeric data.")
 
   if (reverse) {
     shifted <- shift - x

--- a/R/roles.R
+++ b/R/roles.R
@@ -120,11 +120,11 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
   single_chr(new_role, "new_", null_ok = FALSE)
 
   if (length(new_type) != 1L & length(new_type) != 0L) {
-    stop("`new_type` must have length 1.")
+    rlang::abort("`new_type` must have length 1.")
   }
 
   if (!is.character(new_type) & !is.null(new_type)) {
-    stop("`new_type` must be a character vector, or `NULL`.")
+    rlang::abort("`new_type` must be a character vector, or `NULL`.")
   }
 
   terms <- quos(...)
@@ -141,10 +141,10 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
 
   if (all(is.na(recipe$var_info$role[existing_var_idx]))) {
     vars <- glue::glue_collapse(glue::single_quote(vars), sep = ", ")
-    stop(glue::glue(
+    rlang::abort(glue::glue(
       "No role currently exists for column(s): {vars}. Please use ",
       "`update_role()` instead."
-    ), call. = FALSE)
+    ))
   }
 
   role_already_exists <- recipe$var_info$role[existing_var_idx] %in% new_role
@@ -229,8 +229,12 @@ update_role <- function(recipe, ..., new_role = "predictor", old_role = NULL) {
       dplyr::group_by(variable) %>%
       dplyr::count()
     if (any(var_counts$n > 1)) {
-      stop("`old_role` can only be `NULL` when the variable(s) have ",
-           "a single existing role.", call. = FALSE)
+      rlang::abort(
+        paste0(
+          "`old_role` can only be `NULL` when the variable(s) have ",
+          "a single existing role."
+        )
+      )
     }
   }
 
@@ -314,15 +318,15 @@ single_chr <- function(x, prefix = "", null_ok = FALSE) {
   }
 
   if (length(x) != 1L) {
-    stop(arg, " must have length 1.", call. = FALSE)
+    rlang::abort(arg, " must have length 1.")
   }
 
   if (!is.character(x)) {
-    stop(arg, " must be a character vector.", call. = FALSE)
+    rlang::abort(arg, " must be a character vector.")
   }
 
   if (is.na(x)) {
-    stop(arg, " must not be `NA`.", call. = FALSE)
+    rlang::abort(arg, " must not be `NA`.")
   }
 
   invisible(NULL)

--- a/R/roles.R
+++ b/R/roles.R
@@ -130,7 +130,7 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
   terms <- quos(...)
 
   if (is_empty(terms)) {
-    warning("No selectors were found", call. = FALSE)
+    rlang::warn("No selectors were found")
   }
 
   vars <- terms_select(terms = terms, info = summary(recipe))
@@ -164,12 +164,11 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
       sep = ", "
     )
 
-    warning(
+    rlang::warn(
       glue::glue(
         "Role, '{new_role}', already exists for column(s): {bad_vars}. ",
         "Skipping."
-      ),
-      call. = FALSE
+      )
     )
 
     vars <- vars[!(vars %in% vars_that_role_exists_for)]
@@ -216,7 +215,7 @@ update_role <- function(recipe, ..., new_role = "predictor", old_role = NULL) {
   terms <- quos(...)
 
   if (is_empty(terms)) {
-    warning("No selectors were found", call. = FALSE)
+    rlang::warn("No selectors were found")
   }
 
   rec_vars <- summary(recipe)
@@ -256,11 +255,11 @@ remove_role <- function(recipe, ..., old_role) {
 
   terms <- quos(...)
   if (is_empty(terms)) {
-    warning("No selectors were found", call. = FALSE)
+    rlang::warn("No selectors were found")
   }
   vars <- terms_select(terms = terms, info = summary(recipe))
   if (length(vars) == 0) {
-    warning("No columns were selected for role removal.", call. = FALSE)
+    rlang::warn("No columns were selected for role removal.")
   }
 
   term_info <- summary(recipe)
@@ -291,10 +290,8 @@ role_rm_machine <- function(x, role, var) {
     var <- glue::single_quote(x$variable[1])
     role <- glue::single_quote(role)
 
-    warning(
-      glue::glue("Column, {var}, does not have role, {role}."),
-      call. = FALSE
-    )
+    rlang::warn(
+      glue::glue("Column, {var}, does not have role, {role}."))
 
     return(x)
   }

--- a/R/roles.R
+++ b/R/roles.R
@@ -318,15 +318,15 @@ single_chr <- function(x, prefix = "", null_ok = FALSE) {
   }
 
   if (length(x) != 1L) {
-    rlang::abort(arg, " must have length 1.")
+    rlang::abort(paste0(arg, " must have length 1."))
   }
 
   if (!is.character(x)) {
-    rlang::abort(arg, " must be a character vector.")
+    rlang::abort(paste0(arg, " must be a character vector."))
   }
 
   if (is.na(x)) {
-    rlang::abort(arg, " must not be `NA`.")
+    rlang::abort(paste0(arg, " must not be `NA`."))
   }
 
   invisible(NULL)

--- a/R/rollimpute.R
+++ b/R/rollimpute.R
@@ -78,7 +78,7 @@ step_rollimpute <-
 
     if (!is_tune(window) & !is_varying(window)) {
       if (window < 3 | window %% 2 != 1) {
-        stop("`window` should be an odd integer >= 3", call. = FALSE)
+        rlang::abort("`window` should be an odd integer >= 3")
       }
       window <- as.integer(floor(window))
     }
@@ -119,8 +119,7 @@ prep.step_rollimpute <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names])
   dbl_check <- vapply(training[, col_names], is.double, logical(1))
   if (any(!dbl_check))
-    stop("All columns must be double precision for rolling imputation",
-         call. = FALSE)
+    rlang::abort("All columns must be double precision for rolling imputation")
 
   step_rollimpute_new(
     terms = x$terms,

--- a/R/sample.R
+++ b/R/sample.R
@@ -60,7 +60,7 @@ step_sample <- function(
 ) {
 
   if (length(list(...)) > 0) {
-    warning("Selectors are not used for this step.", call. = FALSE)
+    rlang::warn("Selectors are not used for this step.")
   }
 
   if (!is_tune(size) & !is_varying(size)) {

--- a/R/sample.R
+++ b/R/sample.R
@@ -65,12 +65,12 @@ step_sample <- function(
 
   if (!is_tune(size) & !is_varying(size)) {
     if (!is.null(size) & (!is.numeric(size) || size < 0)) {
-      stop("`size` should be a positive number or NULL.", call. = FALSE)
+      rlang::abort("`size` should be a positive number or NULL.")
     }
   }
   if (!is_tune(replace) & !is_varying(replace)) {
     if (!is.logical(replace)) {
-      stop("`replace` should be a single logical.", call. = FALSE)
+      rlang::abort("`replace` should be a single logical.")
     }
   }
 

--- a/R/scale.R
+++ b/R/scale.R
@@ -106,7 +106,7 @@ prep.step_scale <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names])
 
   if (x$factor != 1 & x$factor != 2) {
-    warning("Scaling `factor` should take either a value of 1 or 2", call. = FALSE)
+    rlang::warn("Scaling `factor` should take either a value of 1 or 2")
   }
 
   sds <-

--- a/R/selections.R
+++ b/R/selections.R
@@ -134,18 +134,21 @@ element_check <- function(x, allowed = selectors) {
     # when called from a step
     not_good <- funs[!(funs %in% allowed)]
     if (length(not_good) > 0)
-      stop(
-        "Not all functions are allowed in step function selectors (e.g. ",
-        paste0("`", not_good, "`", collapse = ", "),
-        "). See ?selections.",
-        call. = FALSE
+      rlang::abort(
+          paste0(
+          "Not all functions are allowed in step function selectors (e.g. ",
+          paste0("`", not_good, "`", collapse = ", "),
+          "). See ?selections."
+        )
       )
   } else {
     # when called from formula.recipe
     if (length(funs) > 0)
-      stop(
-        "No in-line functions should be used here; use steps to define ",
-        "baking actions", call. = FALSE
+      rlang::abort(
+        paste0(
+          "No in-line functions should be used here; use steps to define ",
+          "baking actions"
+        )
       )
   }
   invisible(NULL)
@@ -183,7 +186,7 @@ terms_select <- function(terms, info, empty_fun = abort_selection) {
   vars <- unique(info$variable)
 
   if (is_empty(terms)) {
-    stop("At least one selector should be used", call. = FALSE)
+    rlang::abort("At least one selector should be used")
   }
 
   ## check arguments against whitelist
@@ -340,5 +343,5 @@ set_current_info <- function(x) {
 #' @export
 #' @rdname has_role
 current_info <- function() {
-  cur_info_env %||% stop("Variable context not set", call. = FALSE)
+  cur_info_env %||% rlang::abort("Variable context not set")
 }

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -85,8 +85,7 @@ prep.step_shuffle <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_shuffle <- function(object, new_data, ...) {
   if (nrow(new_data) == 1) {
-    warning("`new_data` contains a single row; unable to shuffle",
-            call. = FALSE)
+    rlang::warn("`new_data` contains a single row; unable to shuffle")
     return(new_data)
   }
 

--- a/R/sparsity.R
+++ b/R/sparsity.R
@@ -5,16 +5,21 @@ convert_matrix <- function(x, sparse = TRUE) {
   if (!all(is_num)) {
     num_viol <- sum(!is_num)
     if (num_viol < 5)
-      stop(
+      rlang::abort(
+        paste0(
         "Columns (",
         paste0("`", names(is_num)[!is_num], "`", collapse = ", "),
-        ") are not numeric; cannot convert to matrix.",
-        call. = FALSE
+        ") are not numeric; cannot convert to matrix."
+        )
       )
     else
-      stop(num_viol, " columns are not numeric; cannot ",
-           "convert to matrix.",
-           call. = FALSE)
+      rlang::abort(
+        paste0(
+          num_viol,
+          " columns are not numeric; cannot ",
+           "convert to matrix."
+          )
+        )
   }
 
   # Issue-206: Don't use model.matrix(~ . + 0) here as it drops NA rows unless

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -64,11 +64,11 @@ step_string2factor <-
            id = rand_id("string2factor")) {
     if (!is_tune(ordered) & !is_varying(ordered)) {
       if (!is.logical(ordered) || length(ordered) != 1) {
-        stop("`ordered` should be a single logical variable")
+        rlang::abort("`ordered` should be a single logical variable")
       }
     }
     if ((!is.null(levels) & !is.character(levels)) | is.list(levels)) {
-      stop("`levels` should be NULL or a single character vector")
+      rlang::abort("`levels` should be NULL or a single character vector")
     }
 
     add_step(
@@ -112,10 +112,11 @@ prep.step_string2factor <- function(x, training, info = NULL, ...) {
       logical(1)
     )
   if (any(!str_check))
-    stop(
-      "The following variables are not character vectors: ",
-      paste0("`", names(str_check)[!str_check], "`", collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "The following variables are not character vectors: ",
+        paste0("`", names(str_check)[!str_check], "`", collapse = ", ")
+      )
     )
 
   if (is.null(x$levels)) {

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -18,7 +18,7 @@
 #'  `operation` (either "step" or "check"),
 #'  `type` (the method, e.g. "nzv", "center"), a logical
 #'  column called `trained` for whether the operation has been
-#'  estimated using `prep`, a logical for `skip`, and a character column `id`. 
+#'  estimated using `prep`, a logical for `skip`, and a character column `id`.
 #'
 #' @examples
 #' library(modeldata)
@@ -47,7 +47,7 @@ NULL
 tidy.recipe <- function(x, number = NA, ...) {
   num_oper <- length(x$steps)
   if (num_oper == 0)
-    stop("No steps in recipe.", call. = FALSE)
+    rlang::abort("No steps in recipe.")
   pattern <- "(^step_)|(^check_)"
   if (is.na(number)) {
     skipped <- vapply(x$steps, function(x) x$skip, logical(1))
@@ -71,8 +71,13 @@ tidy.recipe <- function(x, number = NA, ...) {
                   id = ids)
   } else {
     if (number > num_oper || length(number) > 1)
-      stop("`number` should be a single value between 1 and ",
-           num_oper, ".", call. = FALSE)
+      rlang::abort(
+        paste0(
+          "`number` should be a single value between 1 and ",
+           num_oper,
+          "."
+          )
+      )
 
     res <- tidy(x$steps[[number]], ...)
   }
@@ -82,15 +87,21 @@ tidy.recipe <- function(x, number = NA, ...) {
 #' @rdname tidy.recipe
 #' @export
 tidy.step <- function(x, ...) {
-  stop("No `tidy` method for a step with classes: ",
-       paste0(class(x), collapse = ", "),
-       call. = FALSE)
+  rlang::abort(
+    paste0(
+      "No `tidy` method for a step with classes: ",
+      paste0(class(x), collapse = ", ")
+    )
+  )
 }
 
 #' @rdname tidy.recipe
 #' @export
 tidy.check <- function(x, ...) {
-  stop("No `tidy` method for a check with classes: ",
-       paste0(class(x), collapse = ", "),
-       call. = FALSE)
+  rlang::abort(
+    paste0(
+       "No `tidy` method for a check with classes: ",
+       paste0(class(x), collapse = ", ")
+    )
+  )
 }

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -95,11 +95,12 @@ prep.step_unknown <- function(x, training, info = NULL, ...) {
   col_names <- terms_select(x$terms, info = info)
   col_check <- dplyr::filter(info, variable %in% col_names)
   if (any(col_check$type != "nominal"))
-    stop(
-      "Columns must be character or factor: ",
-      paste0(col_check$variable[col_check$type != "nominal"],
-             collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "Columns must be character or factor: ",
+        paste0(col_check$variable[col_check$type != "nominal"],
+               collapse = ", ")
+      )
     )
 
   # Get existing levels and their factor type (i.e. ordered)
@@ -108,10 +109,11 @@ prep.step_unknown <- function(x, training, info = NULL, ...) {
   level_check <-
     map_lgl(objects, function(x, y) y %in% x, y = x$new_level)
   if (any(level_check))
-    stop(
-      "Columns already contain a level '", x$new_level, "': ",
-      paste0(names(level_check)[level_check], collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "Columns already contain a level '", x$new_level, "': ",
+        paste0(names(level_check)[level_check], collapse = ", ")
+      )
     )
 
   step_unknown_new(

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -82,7 +82,7 @@ prep.step_unorder <- function(x, training, info = NULL, ...) {
                         is.ordered,
                         logical(1L))
   if(all(!order_check)) {
-    stop("`step_unorder` required ordered factors.", call. = FALSE)
+    rlang::abort("`step_unorder` required ordered factors.")
   } else {
     if(any(!order_check)) {
       bad_cols <- names(order_check)[!order_check]

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -87,9 +87,13 @@ prep.step_unorder <- function(x, training, info = NULL, ...) {
     if(any(!order_check)) {
       bad_cols <- names(order_check)[!order_check]
       bad_cols <- paste0(bad_cols, collapse = ", ")
-      warning("`step_unorder` requires ordered factors. Variables ",
-              bad_cols,
-              " will be ignored.", call. = FALSE)
+      rlang::warn(
+        paste0(
+          "`step_unorder` requires ordered factors. Variables ",
+          bad_cols,
+          " will be ignored."
+        )
+      )
       col_names <- names(order_check)[order_check]
     }
   }

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -139,9 +139,9 @@ step_upsample_new <-
 prep.step_upsample <- function(x, training, info = NULL, ...) {
   col_name <- terms_select(x$terms, info = info)
   if (length(col_name) != 1)
-    stop("Please select a single factor variable.", call. = FALSE)
+    rlang::abort("Please select a single factor variable.")
   if (!is.factor(training[[col_name]]))
-    stop(col_name, " should be a factor variable.", call. = FALSE)
+    rlang::abort(col_name, " should be a factor variable.")
 
 
   obs_freq <- table(training[[col_name]])

--- a/R/window.R
+++ b/R/window.R
@@ -129,9 +129,16 @@ step_window <-
         tmp <- size
         size <- as.integer(size)
         if (!isTRUE(all.equal(tmp, size)))
-          warning("`size` was not an integer (", tmp, ") and was ",
-                  "converted to ", size, ".", sep = "",
-                  call. = FALSE)
+          rlang::warn(
+            paste0(
+            "`size` was not an integer (",
+            tmp,
+            ") and was ",
+            "converted to ",
+            size,
+            "."
+            )
+          )
       }
       if (size %% 2 == 0) {
         stop("`size` should be odd.", call. = FALSE)

--- a/R/window.R
+++ b/R/window.R
@@ -115,14 +115,17 @@ step_window <-
            skip = FALSE,
            id = rand_id("window")) {
     if (!(statistic %in% roll_funs) | length(statistic) != 1)
-      stop("`statistic` should be one of: ",
-           paste0("'", roll_funs, "'", collapse = ", "),
-           call. = FALSE)
+      rlang::abort(
+        paste0(
+        "`statistic` should be one of: ",
+        paste0("'", roll_funs, "'", collapse = ", ")
+          )
+        )
 
     ## ensure size is odd, integer, and not too small
     if (!is_tune(size) & !is_varying(size)) {
       if (is.na(size) | is.null(size)) {
-        stop("`size` needs a value.", call. = FALSE)
+        rlang::abort("`size` needs a value.")
       }
 
       if (!is.integer(size)) {
@@ -141,10 +144,10 @@ step_window <-
           )
       }
       if (size %% 2 == 0) {
-        stop("`size` should be odd.", call. = FALSE)
+        rlang::abort("`size` should be odd.")
       }
       if (size < 3) {
-        stop("`size` should be at least 3.", call. = FALSE)
+        rlang::abort("`size` should be at least 3.")
       }
     }
     add_step(
@@ -188,13 +191,16 @@ prep.step_window <- function(x, training, info = NULL, ...) {
   col_names <- terms_select(x$terms, info = info)
 
   if (any(info$type[info$variable %in% col_names] != "numeric"))
-    stop("The selected variables should be numeric")
+    rlang::abort("The selected variables should be numeric")
 
   if (!is.null(x$names)) {
     if (length(x$names) != length(col_names))
-      stop("There were ", length(col_names), " term(s) selected but ",
+      rlang::abort(
+        paste0("There were ", length(col_names), " term(s) selected but ",
            length(x$names), " values for the new features ",
-           "were passed to `names`.", call. = FALSE)
+           "were passed to `names`."
+        )
+      )
   }
 
   step_window_new(
@@ -218,7 +224,7 @@ roller <- function(x, stat = "mean", window = 3L, na_rm = TRUE) {
 
   gap <- floor(window / 2)
   if (m - window <= 2)
-    stop("The window is too large.", call. = FALSE)
+    rlang::abort("The window is too large.")
 
   ## stats for centered window
   opts <- list(

--- a/inst/boilerplate.R
+++ b/inst/boilerplate.R
@@ -11,11 +11,11 @@ make_new <- function(name,
   in_recipes_root <-
     tail(stringr::str_split(getwd(), "/")[[1]], 1) == "recipes"
   if (!in_recipes_root) {
-    stop("Change working directory to package root")
+    rlang::abort("Change working directory to package root")
   }
 
   if (glue::glue("{name}.R") %in% list.files("./R")) {
-    stop("step or check already present with this name in /R")
+    rlang::abort("step or check already present with this name in /R")
   }
 
   boilerplate <-

--- a/vignettes/Custom_Steps.Rmd
+++ b/vignettes/Custom_Steps.Rmd
@@ -170,7 +170,7 @@ prep.step_percentile <- function(x, training, info = NULL, ...) {
   
   ## We'll use the names later so
   if (x$options$names == FALSE)
-    stop("`names` should be set to TRUE", call. = FALSE)
+    rlang::abort("`names` should be set to TRUE")
   
   if (!x$approx) {
     ref_dist <- training[, col_names]
@@ -284,6 +284,6 @@ The process here is exactly the same as steps; the internal functions have a sim
 It is strongly recommended that:
  
  1. The operations start with `check_` (i.e. `check_range` and `check_range_new`)
- 1. The check uses `stop(..., call. = FALSE)` when the conditions are not met
+ 1. The check uses `rlang::abort(paste0(...))` when the conditions are not met
  1. The original data are returned (unaltered) by the check when the conditions are satisfied. 
 


### PR DESCRIPTION
The PR replaces `warning()` with `rlang;:warn()`, and `stop()` with `rlang::abort()`. Messages for warn/abort are pasted together using paste0. 

Closes #442

