### PR TITLE
Add ID interface to `tidy.recipe()`, with corresponding tests.

### DIFF
--- a/R/tidy.R
+++ b/R/tidy.R
@@ -60,14 +60,12 @@ tidy.recipe <- function(x, number = NA, id = NA, ...) {
   pattern <- "(^step_)|(^check_)"
   if (!is.na(id)) {
     if (!is.na(number))
-      rlang::abort(paste0("You must specify one of `number` or `id`, ",
-                          "or neither."))
-    if (is.null(id)) {
+      rlang::abort("You may specify `number` or `id`, but not both.")
+    if (length(id) != 1L && !is.character(id))
       rlang::abort("If `id` is provided, it must be a length 1 character vector.")
-    }
     step_ids <- vapply(x$steps, function(x) x$id, character(1))
     if(!(id %in% step_ids)) {
-      rlang::abort("`id` provided not found in the recipe.")
+      rlang::abort("Supplied `id` not found in the recipe.")
     }
     number <- which(id == step_ids)
   }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -7,13 +7,19 @@
 #' @name tidy.recipe
 #'
 #' @param x A `recipe` object (trained or otherwise).
-#' @param number An integer or `NA`. If missing, the return
-#'  value is a list of the operation in the recipe. If a number is
-#'  given, a `tidy` method is executed for that operation in the
-#'  recipe (if it exists).
+#' @param number An integer or `NA`. If missing and `id` is not provided,
+#'  the return value is a list of the operations in the recipe.
+#'  If a number is  given, a `tidy` method is executed for that operation
+#'  in the recipe (if it exists). `number` must not be provided if
+#'  `id` is.
+#' @param id A character string or `NA`. If missing and `number` is not provided,
+#'  the return value is a list of the operations in the recipe.
+#'  If a character string is given, a `tidy` method is executed for that
+#'  operation in the recipe (if it exists). `id` must not be provided
+#'  if `number` is.
 #' @param ... Not currently used.
 #' @return A tibble with columns that would vary depending on what
-#'  `tidy` method is executed. When `x` is `NA`, a
+#'  `tidy` method is executed. When `number` and `id` are `NA`, a
 #'  tibble with columns `number` (the operation iteration),
 #'  `operation` (either "step" or "check"),
 #'  `type` (the method, e.g. "nzv", "center"), a logical

--- a/man/tidy.recipe.Rd
+++ b/man/tidy.recipe.Rd
@@ -6,7 +6,7 @@
 \alias{tidy.check}
 \title{Tidy the Result of a Recipe}
 \usage{
-\method{tidy}{recipe}(x, number = NA, ...)
+\method{tidy}{recipe}(x, number = NA, id = NA, ...)
 
 \method{tidy}{step}(x, ...)
 
@@ -15,16 +15,23 @@
 \arguments{
 \item{x}{A \code{recipe} object (trained or otherwise).}
 
-\item{number}{An integer or \code{NA}. If missing, the return
-value is a list of the operation in the recipe. If a number is
-given, a \code{tidy} method is executed for that operation in the
-recipe (if it exists).}
+\item{number}{An integer or \code{NA}. If missing and \code{id} is not provided,
+the return value is a list of the operations in the recipe.
+If a number is  given, a \code{tidy} method is executed for that operation
+in the recipe (if it exists). \code{number} must not be provided if
+\code{id} is.}
+
+\item{id}{A character string or \code{NA}. If missing and \code{number} is not provided,
+the return value is a list of the operations in the recipe.
+If a character string is given, a \code{tidy} method is executed for that
+operation in the recipe (if it exists). \code{id} must not be provided
+if \code{number} is.}
 
 \item{...}{Not currently used.}
 }
 \value{
 A tibble with columns that would vary depending on what
-\code{tidy} method is executed. When \code{x} is \code{NA}, a
+\code{tidy} method is executed. When \code{number} and \code{id} are \code{NA}, a
 tibble with columns \code{number} (the operation iteration),
 \code{operation} (either "step" or "check"),
 \code{type} (the method, e.g. "nzv", "center"), a logical

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -10,7 +10,7 @@ data(okc)
 set.seed(131)
 okc_rec <- recipe(~ ., data = okc) %>%
   step_other(all_nominal(), threshold = 0.05, other = "another") %>%
-  step_date(date, features = "dow") %>%
+  step_date(date, features = "dow", id = "date_dow") %>%
   step_center(all_numeric()) %>%
   step_dummy(all_nominal()) %>%
   check_cols(starts_with("date"))
@@ -43,10 +43,23 @@ test_that('trained', {
   expect_equal(tidy(trained), exp_res_2)
 })
 
+test_that('select step', {
+  exp_res_3 <- tibble(
+   terms = factor("date"),
+   value = factor("dow"),
+   ordinal = FALSE,
+   id = okc_rec$steps[[2]][["id"]]
+  )
+  expect_equal(tidy(okc_rec, number = 2), exp_res_3)
+  expect_equal(tidy(okc_rec, id = "date_dow"), exp_res_3)
+})
+
 
 test_that('bad args', {
   expect_error(tidy(trained, number = NULL))
   expect_error(tidy(trained, number = 100))
+  expect_error(tidy(trained, number = 1, id = "id"))
+  expect_error(tidy(trained, id = "id"))
   expect_error(tidy(recipe(x = iris)))
 })
 


### PR DESCRIPTION
Add an `id` argument to `tidy.recipe()` for selecting a step. Only allows once step, which matches how the `number` argument works. Only `number` or `id` may be provided, not both. 

Fixes #273 