### PR TITLE
fixes for tidymodels/dials#112

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * While `recipes` does not directly depend on `dials`, it has several S3 methods for generics in `dials`. Version 0.0.5 of `dials` added stricter validation for these methods, so changes were required for `recipes`.  
 
+* Some S3 methods were not being registered previously. This caused issues in R 4.0. 
+
 # recipes 0.1.10
 
 ## Breaking Changes

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,16 +11,36 @@
 maybe_register_tunable_methods <- function() {
 
   ns <- asNamespace("recipes")
-
   names <- names(ns)
-  names <- grep("tunable.step", names, fixed = TRUE, value = TRUE)
 
-  classes <- gsub("tunable.", "", names)
+  # ----------------------------------------------------------------------------
 
-  for (i in seq_along(names)) {
-    name <- names[[i]]
-    class <- classes[[i]]
+  tunable_names <- grep("tunable.step", names, fixed = TRUE, value = TRUE)
+  tunable_classes <- gsub("tunable.", "", tunable_names)
+
+  for (i in seq_along(tunable_names)) {
+    class <- tunable_classes[[i]]
     s3_register("tune::tunable", class)
+  }
+
+  # ----------------------------------------------------------------------------
+
+  tidy_names <- grep("tidy.step", names, fixed = TRUE, value = TRUE)
+  tidy_classes <- gsub("tidy.", "", tidy_names)
+
+  for (i in seq_along(tidy_names)) {
+    class <- tidy_classes[[i]]
+    s3_register("generics::tidy", class)
+  }
+
+  # ----------------------------------------------------------------------------
+
+  tidy_check_names <- grep("tidy.check", names, fixed = TRUE, value = TRUE)
+  tidy_check_classes <- gsub("tidy.", "", tidy_check_names)
+
+  for (i in seq_along(tidy_check_names)) {
+    class <- tidy_check_classes[[i]]
+    s3_register("generics::tidy", class)
   }
 
   invisible()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,9 +9,6 @@
 # is defined in the `tune` package. As of R 4.0, we need to register them.
 # Since `tune` is not on CRAN, we only register them if tune is installed
 maybe_register_tunable_methods <- function() {
-  if (!rlang::is_installed("tune")) {
-    return(invisible())
-  }
 
   ns <- asNamespace("recipes")
 
@@ -23,8 +20,7 @@ maybe_register_tunable_methods <- function() {
   for (i in seq_along(names)) {
     name <- names[[i]]
     class <- classes[[i]]
-
-    s3_register("tune::tunable", class, get(name, envir = ns))
+    s3_register("tune::tunable", class)
   }
 
   invisible()


### PR DESCRIPTION
It turns out that using `requireNamespace()` to determine if a package is installed does not give the right value when used inside of `.onload()` (but works otherwise). 

This was preventing the S3 `tunable` methods from being registered for step functions. 