### PR TITLE
Fix typo in prep.recipe().

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -404,7 +404,7 @@ prep.recipe <-
     if (any(skippers) & !retain)
       rlang::warn(
         paste0(
-          "Since some operations have `skip = FALSE`, using ",
+          "Since some operations have `skip = TRUE`, using ",
           "`retain = TRUE` will allow those steps results to ",
           "be accessible."
         )


### PR DESCRIPTION
I think this is a typo. The code appears to be checking if there are any `skip = TRUE` but then warning that there are some `skip = FALSE`.
Am I missing something?