### PR TITLE
Make step_pls() compatible with wide data.

### DIFF
--- a/R/pls.R
+++ b/R/pls.R
@@ -144,8 +144,17 @@ prep.step_pls <- function(x, training, info = NULL, ...) {
   }
 
   if (x$num_comp > 0) {
-    args <- list(formula = as.formula(paste(y_form, ".", sep = "~")),
-                 data = training[, c(y_names, x_names)])
+    if (length(x_names) < 1e4) {
+      args <- list(formula = as.formula(paste(y_form, ".", sep = "~")),
+                   data = training[, c(y_names, x_names)])
+    } else {
+      arg_data <- cbind(
+        training[y_names],
+        tibble::tibble(x = as.matrix(training[x_names]))
+      )
+      args <- list(formula = as.formula(paste(y_form, "x", sep = "~")),
+                   data = arg_data)
+    }
 
     x$options$ncomp <- min(x$num_comp, length(x_names))
     args <- c(args, x$options)


### PR DESCRIPTION
`step_pca()` works well with wide (>20k predictors) data but `step_pls()` does not. `pls::plsr()` has only a formula interface (which is the problem) but it actually provides for the wide data case, per https://github.com/bhmevik/pls/issues/28. This pull request is to make `step_pls()` make use of this `pls::plsr()` functionality. 

First let's look at the old behaviour.

You can see wide data is fine with `step_pca()` but there's a memory problem with `step_pls()`. 

``` r
suppressMessages(library(tidyverse))
suppressMessages(library(recipes))

df50k <- replicate(5e4 + 1, runif(200), simplify = FALSE) %>% 
  set_names(c("y", paste0("x", seq_len(5e4)))) %>% 
  as_tibble()

rec_pca <- recipe(df50k) %>% 
  update_role(everything(), new_role = "predictor") %>% 
  update_role(y, new_role = "outcome") %>% 
  step_pca(all_predictors())
rec_pca_prepped <- prep(rec_pca)
rec_pca_juiced <- juice(rec_pca_prepped)

rec_pls <- recipe(df50k) %>% 
  update_role(everything(), new_role = "predictor") %>% 
  update_role(y, new_role = "outcome") %>% 
  step_pls(all_predictors(), outcome = "y")
rec_pls_prepped <- prep(rec_pls)
#> Error: protect(): protection stack overflow
rec_pls_juiced <- juice(rec_pls_prepped)
#> Error in fully_trained(object): object 'rec_pls_prepped' not found
```

<sup>Created on 2020-06-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Now let's check out the new behaviour: 

``` r
suppressMessages(library(tidyverse))
suppressMessages(library(recipes))

df50k <- replicate(5e4 + 1, runif(200), simplify = FALSE) %>% 
  set_names(c("y", paste0("x", seq_len(5e4)))) %>% 
  as_tibble()

rec_pca <- recipe(df50k) %>% 
  update_role(everything(), new_role = "predictor") %>% 
  update_role(y, new_role = "outcome") %>% 
  step_pca(all_predictors())
rec_pca_prepped <- prep(rec_pca)
rec_pca_juiced <- juice(rec_pca_prepped)

rec_pls <- recipe(df50k) %>% 
  update_role(everything(), new_role = "predictor") %>% 
  update_role(y, new_role = "outcome") %>% 
  step_pls(all_predictors(), outcome = "y")
rec_pls_prepped <- prep(rec_pls)
rec_pls_juiced <- juice(rec_pls_prepped)
```

You'll see that I've written a new test. This is to show that in the case that the data is narrow enought that the current `step_pls()` works fine (I chose 11k predictors), the new `step_pls()` provides identical results. The test itself is pretty ugly because I have to write another prep method and assign it to the global environment to make it discoverable, per https://github.com/r-lib/testthat/issues/720. I think it's safe enough to delete this test if you don't like it. I just included it to give you something you can easily run for yourself to see that I am not changing the behaviour here.

You'll see that in my new implementation, I only change the behaviour for >10k predictors. This is because the new behaviour necessitates a copy of the data, whereas the old one does not, so I want to avoid the copy on narrow enough data, where the old method works just fine.

Happy to amend this PR as suggested.

All PLS tests pass. There were some other unrelated tests that were failing before and after these changes.