### PR TITLE
More clear error message for one factor level in step_dummy()

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -270,6 +270,11 @@ bake.step_dummy <- function(object, new_data, ...) {
     if (!any(names(attributes(object$levels[[i]])) == "values"))
       rlang::abort("Factor level values not recorded")
 
+    if (length(attr(object$levels[[i]], "values")) == 1)
+      rlang::abort(
+        paste0("Only one factor level in ", orig_var)
+        )
+
     warn_new_levels(
       new_data[[orig_var]],
       attr(object$levels[[i]], "values")


### PR DESCRIPTION
Closes #451 

There is now a new error message for when a factor has only one factor level:

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
data <- data.frame(a = rep("A", 10))

recipe(~ a, data = data) %>%
  step_dummy(a) %>%
  prep()
#> Error: Only one factor level in a
#> Backtrace:
#>      █
#>   1. └─recipe(~a, data = data) %>% step_dummy(a) %>% prep()
#>   2.   ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
#>   3.   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   4.     └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   5.       └─`_fseq`(`_lhs`)
#>   6.         └─magrittr::freduce(value, `_function_list`)
#>   7.           ├─base::withVisible(function_list[[k]](value))
#>   8.           └─function_list[[k]](value)
#>   9.             ├─recipes::prep(.)
#>  10.             └─recipes:::prep.recipe(.) /recipes/R/recipe.R:286:10
#>  11.               ├─recipes::bake(x$steps[[i]], new_data = training) /recipes/R/recipe.R:384:8
#>  12.               └─recipes:::bake.step_dummy(x$steps[[i]], new_data = training) /recipes/R/recipe.R:506:8
```

<sup>Created on 2020-06-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>