### PR TITLE
Fix NA handling in step_zv()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Avoided partial matching on `seq()` arguments in internal functions. 
 
+* `step_zv()` now handles `NA` values so that variables with zero variance _plus_ are removed.
+
 # recipes 0.1.12
 
 * Some S3 methods were not being registered previously. This caused issues in R 4.0. 

--- a/R/zv.R
+++ b/R/zv.R
@@ -85,7 +85,7 @@ step_zv_new <-
   }
 
 one_unique <- function(x)
-  length(unique(x)) == 1
+  length(unique(x[!is.na(x)])) == 1
 
 #' @export
 prep.step_zv <- function(x, training, info = NULL, ...) {

--- a/R/zv.R
+++ b/R/zv.R
@@ -84,8 +84,10 @@ step_zv_new <-
     )
   }
 
-one_unique <- function(x)
-  length(unique(x[!is.na(x)])) == 1
+one_unique <- function(x) {
+  x <- x[!is.na(x)]
+  length(unique(x)) < 2
+  }
 
 #' @export
 prep.step_zv <- function(x, training, info = NULL, ...) {

--- a/tests/testthat/test_zv.R
+++ b/tests/testthat/test_zv.R
@@ -39,3 +39,16 @@ test_that('printing', {
   expect_output(print(rec))
   expect_output(prep(rec, training = dat, verbose = TRUE))
 })
+
+
+test_that('mssing values in zero-variance screen', {
+
+  x <- rep(1, 5)
+  y <- c(NA, x)
+  z <- rep(NA, 5)
+
+  expect_true(recipes:::one_unique(x))
+  expect_true(recipes:::one_unique(y))
+  expect_true(recipes:::one_unique(z))
+
+})


### PR DESCRIPTION
Closes #486.

This PR removes NA values before unique values are counted up, to check for zero variance. Now a variable with zero variance _plus_ NA values will be removed:

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step

zdat <- tibble(
  y = c(1, 2, 3, 4), 
  x = c("a", "a", "a", NA_character_),
  z = 4:1
)

recipe(y ~ ., data = zdat) %>%
  step_zv(all_predictors()) %>% 
  step_dummy(all_nominal()) %>%
  prep()
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          2
#> 
#> Training data contained 4 data points and 1 incomplete row. 
#> 
#> Operations:
#> 
#> Zero variance filter removed x [trained]
#> Dummy variables were *not* created since no columns were selected. [trained]
```

<sup>Created on 2020-06-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>