### PR TITLE
Improve printing of unprepped recipe steps

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -32,7 +32,7 @@ format_ch_vec <-
 format_selectors <- function(x, width = options()$width - 9) {
   ## convert to character without the leading ~
   x_items <- lapply(x, function(x) {
-    as.character(get_expr(x))
+    expr_deparse(quo_get_expr(x))
   })
 
   x_items <- unlist(x_items)

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -14,6 +14,6 @@ below to see their documentation.
 \describe{
   \item{generics}{\code{\link[generics]{tidy}}}
 
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 }}
 

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -37,11 +37,11 @@ excluded variable(s).
 }
 
 Also, select helpers from the \code{tidyselect} package can also be used:
-\code{\link[tidyselect:starts_with]{tidyselect::starts_with()}}, \code{\link[tidyselect:ends_with]{tidyselect::ends_with()}},
-\code{\link[tidyselect:contains]{tidyselect::contains()}}, \code{\link[tidyselect:matches]{tidyselect::matches()}},
-\code{\link[tidyselect:num_range]{tidyselect::num_range()}}, \code{\link[tidyselect:everything]{tidyselect::everything()}},
+\code{\link[tidyselect:starts_with]{tidyselect::starts_with()}}, \code{\link[tidyselect:starts_with]{tidyselect::ends_with()}},
+\code{\link[tidyselect:starts_with]{tidyselect::contains()}}, \code{\link[tidyselect:starts_with]{tidyselect::matches()}},
+\code{\link[tidyselect:starts_with]{tidyselect::num_range()}}, \code{\link[tidyselect:everything]{tidyselect::everything()}},
 \code{\link[tidyselect:one_of]{tidyselect::one_of()}}, \code{\link[tidyselect:all_of]{tidyselect::all_of()}}, and
-\code{\link[tidyselect:any_of]{tidyselect::any_of()}}
+\code{\link[tidyselect:all_of]{tidyselect::any_of()}}
 For example:
 
 \preformatted{
@@ -93,8 +93,8 @@ The complete list of allowable functions in steps:
 
 \itemize{
 \item \strong{By name}: \code{\link[tidyselect:starts_with]{tidyselect::starts_with()}},
-\code{\link[tidyselect:ends_with]{tidyselect::ends_with()}}, \code{\link[tidyselect:contains]{tidyselect::contains()}},
-\code{\link[tidyselect:matches]{tidyselect::matches()}}, \code{\link[tidyselect:num_range]{tidyselect::num_range()}},
+\code{\link[tidyselect:starts_with]{tidyselect::ends_with()}}, \code{\link[tidyselect:starts_with]{tidyselect::contains()}},
+\code{\link[tidyselect:starts_with]{tidyselect::matches()}}, \code{\link[tidyselect:starts_with]{tidyselect::num_range()}},
 \code{\link[tidyselect:everything]{tidyselect::everything()}}
 \item \strong{By role}: \code{\link[=has_role]{has_role()}},
 \code{\link[=all_predictors]{all_predictors()}}, and \code{\link[=all_outcomes]{all_outcomes()}}

--- a/man/step_bagimpute.Rd
+++ b/man/step_bagimpute.Rd
@@ -47,10 +47,10 @@ will be removed from the latter and not used to impute itself.}
 
 \item{trees}{An integer for the number bagged trees to use in each model.}
 
-\item{models}{The \code{\link[ipred:ipredbagg]{ipred::ipredbagg()}} objects are stored here once this
+\item{models}{The \code{\link[ipred:bagging]{ipred::ipredbagg()}} objects are stored here once this
 bagged trees have be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{options}{A list of options to \code{\link[ipred:ipredbagg]{ipred::ipredbagg()}}. Defaults are set
+\item{options}{A list of options to \code{\link[ipred:bagging]{ipred::ipredbagg()}}. Defaults are set
 for the arguments \code{nbagg} and \code{keepX} but others can be passed in. \strong{Note}
 that the arguments \code{X} and \code{y} should not be passed here.}
 

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -38,7 +38,7 @@ preprocessing have been estimated.}
 
 \item{holidays}{A character string that includes at least one
 holiday supported by the \code{timeDate} package. See
-\code{\link[timeDate:listHolidays]{timeDate::listHolidays()}} for a complete list.}
+\code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}} for a complete list.}
 
 \item{columns}{A character string of variables that will be
 used as inputs. This field is a placeholder and will be
@@ -85,7 +85,7 @@ holiday_values
 \seealso{
 \code{\link[=step_date]{step_date()}} \code{\link[=step_rm]{step_rm()}}
 \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}} \code{\link[timeDate:listHolidays]{timeDate::listHolidays()}}
+\code{\link[=bake.recipe]{bake.recipe()}} \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
 }
 \concept{dates}
 \concept{model_specification}

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -45,9 +45,9 @@ used.}
 
 \item{neighbors}{The number of neighbors.}
 
-\item{options}{A list of options to \code{\link[dimRed:Isomap]{dimRed::Isomap()}}.}
+\item{options}{A list of options to \code{\link[dimRed:Isomap-class]{dimRed::Isomap()}}.}
 
-\item{res}{The \code{\link[dimRed:Isomap]{dimRed::Isomap()}} object is stored
+\item{res}{The \code{\link[dimRed:Isomap-class]{dimRed::Isomap()}} object is stored
 here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -25,7 +25,7 @@ for more details. For the \code{tidy} method, these are not
 currently used.}
 
 \item{fn}{A function fun, a quosure style lambda `~ fun(.)`` or a list of
-either form. (see \code{\link[dplyr:mutate_at]{dplyr::mutate_at()}}). \strong{Note that this argument must be
+either form. (see \code{\link[dplyr:mutate_all]{dplyr::mutate_at()}}). \strong{Note that this argument must be
 named}.}
 
 \item{role}{For model terms created by this step, what analysis role should

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -31,7 +31,7 @@ method, these are not currently used.}
 
 \item{transform}{A function taking a single argument \code{x} that can be used
 to modify the numeric values prior to determining the levels (perhaps using
-\code{\link[base:as.integer]{base::as.integer()}}). The output of a function should be an integer that
+\code{\link[base:integer]{base::as.integer()}}). The output of a function should be an integer that
 corresponds to the value of \code{levels} that should be assigned. If not an
 integer, the value will be converted to an integer during \code{bake()}.}
 

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -54,7 +54,7 @@ given to \code{num_comp}.}
 \code{retx = FALSE}, \code{center = FALSE}, \code{scale. = FALSE}, and \code{tol = NULL}. \strong{Note} that the argument
 \code{x} should not be passed here (or at all).}
 
-\item{res}{The \code{\link[stats:prcomp.default]{stats::prcomp.default()}} object is
+\item{res}{The \code{\link[stats:prcomp]{stats::prcomp.default()}} object is
 stored here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -25,7 +25,7 @@ for more details. For the \code{tidy} method, these are not
 currently used.}
 
 \item{fn}{A function \code{fun}, a quosure style lambda `~ fun(.)`` or a list of
-either form (but containing only a single function, see \code{\link[dplyr:rename_at]{dplyr::rename_at()}}).
+either form (but containing only a single function, see \code{\link[dplyr:select_all]{dplyr::rename_at()}}).
 \strong{Note that this argument must be named}.}
 
 \item{role}{For model terms created by this step, what analysis role should

--- a/man/step_sample.Rd
+++ b/man/step_sample.Rd
@@ -33,7 +33,7 @@ created.}
 preprocessing have been estimated.}
 
 \item{size}{An integer or fraction. If the value is within (0, 1),
-\code{\link[dplyr:sample_frac]{dplyr::sample_frac()}} is applied to the data. If an integer
+\code{\link[dplyr:sample_n]{dplyr::sample_frac()}} is applied to the data. If an integer
 value of 1 or greater is used, \code{\link[dplyr:sample_n]{dplyr::sample_n()}} is applied.
 The default of \code{NULL} uses \code{\link[dplyr:sample_n]{dplyr::sample_n()}} with the size
 of the training set (or smaller for smaller \code{new_data}).}
@@ -61,7 +61,7 @@ and \code{id}.
 \description{
 \code{step_sample} creates a \emph{specification} of a recipe step
 that will sample rows using \code{\link[dplyr:sample_n]{dplyr::sample_n()}} or
-\code{\link[dplyr:sample_frac]{dplyr::sample_frac()}}.
+\code{\link[dplyr:sample_n]{dplyr::sample_frac()}}.
 }
 \examples{
 

--- a/man/terms_select.Rd
+++ b/man/terms_select.Rd
@@ -8,7 +8,7 @@ terms_select(terms, info, empty_fun = abort_selection)
 }
 \arguments{
 \item{terms}{A list of formulas whose right-hand side contains
-quoted expressions. See \code{\link[rlang:quos]{rlang::quos()}} for examples.}
+quoted expressions. See \code{\link[rlang:nse-defuse]{rlang::quos()}} for examples.}
 
 \item{info}{A tibble with columns \code{variable}, \code{type}, \code{role},
 and \code{source} that represent the current state of the data. The

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -23,12 +23,12 @@ test_that("format_ch_vec handles a vector with long items", {
 })
 
 test_that("format_selectors handles small numbers of selectors", {
-  test_exprs_small <- lapply(1:6, expr)
-  expect_equal(format_selectors(test_exprs_small), "1, 2, 3, 4, 5, 6")
+  test_exprs_small <- lapply(1:6, quo)
+  expect_equal(format_selectors(test_exprs_small), "1L, 2L, 3L, 4L, 5L, 6L")
 })
 
 test_that("format_ch_vec handles lots of small selectors", {
-  test_exprs_small_many <- lapply(1:100, expr)
+  test_exprs_small_many <- lapply(1:100, quo)
   # should fit the screen
   expect_true(length(format_selectors(test_exprs_small_many)) <=  max_width)
   #  should list as many items as possible, not just return "n items"


### PR DESCRIPTION
Closes #508.

This PR switches to using `expr_deparse()` for handling printing of R expressions in `format_selectors()`. It actually has some improvements compared to just using `as.character()`, which is nice 👏 in addition to being able to correctly handle all the tidyselect functions.

Here is what using those tidyselect functions looks like now:
``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step

example_df <- tibble(response = 1, x = 1, y = 1, z = 1)

remove1 <- c("x")
remove2 <- c("y")

recipe(response ~ ., data = example_df) %>% 
  step_rm(one_of(!!remove1)) %>%
  step_rm(one_of(remove2))
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          3
#> 
#> Operations:
#> 
#> Delete terms one_of("x")
#> Delete terms one_of(remove2)
```

<sup>Created on 2020-06-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

And here is what some other recipes steps look like (mostly the same, but also now not broken):
``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
library(modeldata)
data(biomass)

biomass_tr <- biomass[biomass$dataset == "Training",]

recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
       data = biomass_tr) %>%
  step_center(carbon, contains("gen"), -hydrogen)
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          5
#> 
#> Operations:
#> 
#> Centering for carbon, contains("gen"), -hydrogen

recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
       data = biomass_tr) %>%
  step_center(all_predictors(), -hydrogen)
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          5
#> 
#> Operations:
#> 
#> Centering for all_predictors(), -hydrogen

## will skip uranium when prepped because it's not there
recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
       data = biomass_tr) %>%
  step_center(any_of(c("carbon", "nitrogen", "uranium")))
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          5
#> 
#> Operations:
#> 
#> Centering for any_of(c("carbon", "nitrogen", "uranium"))
```

<sup>Created on 2020-06-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>