### PR TITLE
Typo: Nature Spline --> Natural Spline

### DIFF
--- a/R/ns.R
+++ b/R/ns.R
@@ -1,4 +1,4 @@
-#' Nature Spline Basis Functions
+#' Natural Spline Basis Functions
 #'
 #' `step_ns` creates a *specification* of a recipe step
 #'  that will create new columns that are basis expansions of


### PR DESCRIPTION
I guess there is a typing mistake in the title of `step_ns()` documentation.