### PR TITLE
fixing typo so that "lincomp" is now "lincomb" in step_lincomb

### DIFF
--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -65,7 +65,7 @@ step_lincomb <-
            max_steps = 5,
            removals = NULL,
            skip = FALSE,
-           id = rand_id("lincomp")) {
+           id = rand_id("lincomb")) {
     add_step(
       recipe,
       step_lincomb_new(

--- a/man/step_lincomb.Rd
+++ b/man/step_lincomb.Rd
@@ -13,7 +13,7 @@ step_lincomb(
   max_steps = 5,
   removals = NULL,
   skip = FALSE,
-  id = rand_id("lincomp")
+  id = rand_id("lincomb")
 )
 
 \method{tidy}{step_lincomb}(x, ...)


### PR DESCRIPTION
fixes #577 