### PR TITLE
Support modern tidyselect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     stats,
     tibble,
     tidyr (>= 1.0.0),
-    tidyselect (>= 0.2.5),
+    tidyselect (>= 1.1.0),
     timeDate,
     utils,
     withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* If steps that drop/add variables are skipped when baking the test set, the resulting column ordering of the baked test set will now be relative to the original recipe specification rather than relative to the baked training set. This is often more intuitive.
+
 # recipes 0.1.14
 
 * `prep()` gained an option to print a summary of which columns were added and/or removed during execution. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* The full tidyselect DSL is now allowed inside recipes `step_*()` functions. This includes the operators `&`, `|`, `-` and `!` and the new `where()` function. Additionally, the restriction preventing user defined selectors from being used has been lifted (#572).
+
 * If steps that drop/add variables are skipped when baking the test set, the resulting column ordering of the baked test set will now be relative to the original recipe specification rather than relative to the baked training set. This is often more intuitive.
 
 # recipes 0.1.14

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -106,7 +106,8 @@ step_BoxCox_new <-
 
 #' @export
 prep.step_BoxCox <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   values <- vapply(

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -106,7 +106,7 @@ step_BoxCox_new <-
 
 #' @export
 prep.step_BoxCox <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -109,7 +109,7 @@ step_YeoJohnson_new <-
 
 #' @export
 prep.step_YeoJohnson <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   values <- vapply(

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -109,7 +109,7 @@ step_YeoJohnson_new <-
 
 #' @export
 prep.step_YeoJohnson <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   values <- vapply(

--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -163,9 +163,10 @@ bag_wrap <- function(vars, dat, opt, seed_val) {
 
 ## This figures out which data should be used to predict each variable
 ## scheduled for imputation
-impute_var_lists <- function(to_impute, impute_using, info) {
-  to_impute <- terms_select(terms = to_impute, info = info)
-  impute_using <- terms_select(terms = impute_using, info = info)
+impute_var_lists <- function(to_impute, impute_using, training, info) {
+  to_impute <- eval_step_select(to_impute, training, info)
+  impute_using <- eval_step_select(impute_using, training, info)
+
   var_lists <- vector(mode = "list", length = length(to_impute))
   for (i in seq_along(var_lists)) {
     var_lists[[i]] <- list(y = to_impute[i],
@@ -180,6 +181,7 @@ prep.step_bagimpute <- function(x, training, info = NULL, ...) {
     impute_var_lists(
       to_impute = x$terms,
       impute_using = x$impute_with,
+      training = training,
       info = info
     )
   opt <- x$options

--- a/R/bag_imp.R
+++ b/R/bag_imp.R
@@ -164,8 +164,8 @@ bag_wrap <- function(vars, dat, opt, seed_val) {
 ## This figures out which data should be used to predict each variable
 ## scheduled for imputation
 impute_var_lists <- function(to_impute, impute_using, training, info) {
-  to_impute <- eval_step_select(to_impute, training, info)
-  impute_using <- eval_step_select(impute_using, training, info)
+  to_impute <- eval_select_recipes(to_impute, training, info)
+  impute_using <- eval_select_recipes(impute_using, training, info)
 
   var_lists <- vector(mode = "list", length = length(to_impute))
   for (i in seq_along(var_lists)) {

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -94,7 +94,7 @@ step_bin2factor_new <-
 
 #' @export
 prep.step_bin2factor <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   if (length(col_names) < 1)
     rlang::abort("The selector should only select at least one variable")
   if (any(info$type[info$variable %in% col_names] != "numeric"))

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -94,7 +94,7 @@ step_bin2factor_new <-
 
 #' @export
 prep.step_bin2factor <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   if (length(col_names) < 1)
     rlang::abort("The selector should only select at least one variable")
   if (any(info$type[info$variable %in% col_names] != "numeric"))

--- a/R/bs.R
+++ b/R/bs.R
@@ -114,7 +114,7 @@ bs_wrapper <- function(x, args) {
 
 #' @export
 prep.step_bs <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   opt <- x$options

--- a/R/bs.R
+++ b/R/bs.R
@@ -114,7 +114,7 @@ bs_wrapper <- function(x, args) {
 
 #' @export
 prep.step_bs <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   opt <- x$options

--- a/R/center.R
+++ b/R/center.R
@@ -103,7 +103,7 @@ step_center_new <-
 
 #' @export
 prep.step_center <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   means <-

--- a/R/center.R
+++ b/R/center.R
@@ -103,7 +103,7 @@ step_center_new <-
 
 #' @export
 prep.step_center <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   means <-

--- a/R/class.R
+++ b/R/class.R
@@ -133,9 +133,9 @@ check_class_new <-
 
 prep.check_class <- function(x,
                              training,
-                             info = NULL, # info is an argument to terms_select
+                             info = NULL,
                              ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   # vapply requires a very specific return here
   # class can give back multiple values, return shape

--- a/R/class.R
+++ b/R/class.R
@@ -135,7 +135,7 @@ prep.check_class <- function(x,
                              training,
                              info = NULL,
                              ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   # vapply requires a very specific return here
   # class can give back multiple values, return shape

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -135,7 +135,7 @@ get_both <- function(x, mfun = mean, cfun = cov) {
 #' @export
 prep.step_classdist <- function(x, training, info = NULL, ...) {
   class_var <- x$class[1]
-  x_names <- terms_select(x$terms, info = info)
+  x_names <- eval_step_select(x$terms, training, info)
   check_type(training[, x_names])
 
   x_dat <-

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -135,7 +135,7 @@ get_both <- function(x, mfun = mean, cfun = cov) {
 #' @export
 prep.step_classdist <- function(x, training, info = NULL, ...) {
   class_var <- x$class[1]
-  x_names <- eval_step_select(x$terms, training, info)
+  x_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, x_names])
 
   x_dat <-

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -56,7 +56,8 @@ check_cols_new <-
   }
 
 prep.check_cols <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_cols_new(
     terms = x$terms,
     role  = x$role,

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -56,7 +56,7 @@ check_cols_new <-
   }
 
 prep.check_cols <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_cols_new(
     terms = x$terms,

--- a/R/corr.R
+++ b/R/corr.R
@@ -117,7 +117,7 @@ step_corr_new <-
 
 #' @export
 prep.step_corr <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (length(col_names) > 1) {

--- a/R/corr.R
+++ b/R/corr.R
@@ -117,7 +117,7 @@ step_corr_new <-
 
 #' @export
 prep.step_corr <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (length(col_names) > 1) {

--- a/R/count.R
+++ b/R/count.R
@@ -114,7 +114,7 @@ step_count_new <-
 
 #' @export
 prep.step_count <- function(x, training, info = NULL, ...) {
-  col_name <- terms_select(x$terms, info = info)
+  col_name <- eval_step_select(x$terms, training, info)
   if (length(col_name) != 1)
     rlang::abort("The selector should only select a single variable")
   if (any(info$type[info$variable %in% col_name] != "nominal"))

--- a/R/count.R
+++ b/R/count.R
@@ -114,7 +114,7 @@ step_count_new <-
 
 #' @export
 prep.step_count <- function(x, training, info = NULL, ...) {
-  col_name <- eval_step_select(x$terms, training, info)
+  col_name <- eval_select_recipes(x$terms, training, info)
   if (length(col_name) != 1)
     rlang::abort("The selector should only select a single variable")
   if (any(info$type[info$variable %in% col_name] != "nominal"))

--- a/R/cut.R
+++ b/R/cut.R
@@ -103,7 +103,8 @@ step_cut_new <-
   }
 
 prep.step_cut <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   all_breaks <- vector("list", length(col_names))

--- a/R/cut.R
+++ b/R/cut.R
@@ -103,7 +103,7 @@ step_cut_new <-
   }
 
 prep.step_cut <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/date.R
+++ b/R/date.R
@@ -135,7 +135,7 @@ step_date_new <-
 
 #' @export
 prep.step_date <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   date_data <- info[info$variable %in% col_names, ]
   if (any(date_data$type != "date"))

--- a/R/date.R
+++ b/R/date.R
@@ -135,7 +135,7 @@ step_date_new <-
 
 #' @export
 prep.step_date <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   date_data <- info[info$variable %in% col_names, ]
   if (any(date_data$type != "date"))

--- a/R/depth.R
+++ b/R/depth.R
@@ -142,7 +142,7 @@ step_depth_new <-
 #' @export
 prep.step_depth <- function(x, training, info = NULL, ...) {
   class_var <- x$class[1]
-  x_names <- terms_select(x$terms, info = info)
+  x_names <- eval_step_select(x$terms, training, info)
   check_type(training[, x_names])
 
   x_dat <-

--- a/R/depth.R
+++ b/R/depth.R
@@ -142,7 +142,7 @@ step_depth_new <-
 #' @export
 prep.step_depth <- function(x, training, info = NULL, ...) {
   class_var <- x$class[1]
-  x_names <- eval_step_select(x$terms, training, info)
+  x_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, x_names])
 
   x_dat <-

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -300,7 +300,7 @@ bin_wrapper <- function(x, args) {
 
 #' @export
 prep.step_discretize <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (length(col_names) > 1 & any(names(x$options) %in% c("prefix", "labels"))) {

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -300,7 +300,7 @@ bin_wrapper <- function(x, args) {
 
 #' @export
 prep.step_discretize <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (length(col_names) > 1 & any(names(x$options) %in% c("prefix", "labels"))) {

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -136,7 +136,7 @@ step_downsample_new <-
 
 #' @export
 prep.step_downsample <- function(x, training, info = NULL, ...) {
-  col_name <- eval_step_select(x$terms, training, info)
+  col_name <- eval_select_recipes(x$terms, training, info)
 
   if (length(col_name) != 1)
     rlang::abort("Please select a single factor variable.")

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -136,7 +136,8 @@ step_downsample_new <-
 
 #' @export
 prep.step_downsample <- function(x, training, info = NULL, ...) {
-  col_name <- terms_select(x$terms, info = info)
+  col_name <- eval_step_select(x$terms, training, info)
+
   if (length(col_name) != 1)
     rlang::abort("Please select a single factor variable.")
   if (!is.factor(training[[col_name]]))

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -165,7 +165,7 @@ passover <- function(cmd) {
 
 #' @export
 prep.step_dummy <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info, empty_fun = passover)
+  col_names <- eval_step_select(x$terms, training, info)
 
   if (length(col_names) > 0) {
     fac_check <- vapply(training[, col_names], is.factor, logical(1))

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -165,7 +165,7 @@ passover <- function(cmd) {
 
 #' @export
 prep.step_dummy <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   if (length(col_names) > 0) {
     fac_check <- vapply(training[, col_names], is.factor, logical(1))

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -91,7 +91,7 @@ step_factor2string_new <-
 
 #' @export
 prep.step_factor2string <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   fac_check <-
     vapply(training[, col_names], is.factor, logical(1))
   if (any(!fac_check))

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -91,7 +91,7 @@ step_factor2string_new <-
 
 #' @export
 prep.step_factor2string <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   fac_check <-
     vapply(training[, col_names], is.factor, logical(1))
   if (any(!fac_check))

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -105,11 +105,13 @@ step_geodist_new <-
 
 #' @export
 prep.step_geodist <- function(x, training, info = NULL, ...) {
-  lon_name <- terms_select(x$lon, info = info)
+  lon_name <- eval_step_select(x$lon, training, info)
+  lat_name <- eval_step_select(x$lat, training, info)
+
   if (length(lon_name) > 1)
     rlang::abort("`lon` should resolve to a single column name.")
   check_type(training[, lon_name])
-  lat_name <- terms_select(x$lat, info = info)
+
   if (length(lat_name) > 1)
     rlang::abort("`lat` should resolve to a single column name.")
   check_type(training[, lat_name])

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -105,8 +105,8 @@ step_geodist_new <-
 
 #' @export
 prep.step_geodist <- function(x, training, info = NULL, ...) {
-  lon_name <- eval_step_select(x$lon, training, info)
-  lat_name <- eval_step_select(x$lat, training, info)
+  lon_name <- eval_select_recipes(x$lon, training, info)
+  lat_name <- eval_select_recipes(x$lat, training, info)
 
   if (length(lon_name) > 1)
     rlang::abort("`lon` should resolve to a single column name.")

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -96,7 +96,7 @@ step_holiday_new <-
 
 #' @export
 prep.step_holiday <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   holiday_data <- info[info$variable %in% col_names, ]
   if (any(holiday_data$type != "date"))

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -96,7 +96,7 @@ step_holiday_new <-
 
 #' @export
 prep.step_holiday <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   holiday_data <- info[info$variable %in% col_names, ]
   if (any(holiday_data$type != "date"))

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -91,7 +91,7 @@ step_hyperbolic_new <-
 
 #' @export
 prep.step_hyperbolic <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   step_hyperbolic_new(

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -91,7 +91,7 @@ step_hyperbolic_new <-
 
 #' @export
 prep.step_hyperbolic <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   step_hyperbolic_new(

--- a/R/ica.R
+++ b/R/ica.R
@@ -144,7 +144,7 @@ step_ica_new <-
 
 #' @export
 prep.step_ica <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/ica.R
+++ b/R/ica.R
@@ -144,7 +144,7 @@ step_ica_new <-
 
 #' @export
 prep.step_ica <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/impute_lm.R
+++ b/R/impute_lm.R
@@ -152,6 +152,7 @@ prep.step_impute_linear <- function(x, training, info = NULL, ...) {
     impute_var_lists(
       to_impute = x$terms,
       impute_using = x$impute_with,
+      training = training,
       info = info
     )
 

--- a/R/integer.R
+++ b/R/integer.R
@@ -126,7 +126,7 @@ get_unique_values <- function(x, zero = FALSE) {
 
 #' @export
 prep.step_integer <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   step_integer_new(
     terms = x$terms,

--- a/R/integer.R
+++ b/R/integer.R
@@ -126,7 +126,7 @@ get_unique_values <- function(x, zero = FALSE) {
 
 #' @export
 prep.step_integer <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   step_integer_new(
     terms = x$terms,

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -136,11 +136,16 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
 
   form_sel <- find_selectors(x$terms)
 
+  eval_select_recipes_expr <- function(expr) {
+    # Wrap `expr` into a list-of-quos as `eval_select_recipes()` expects
+    quos <- enquos(expr)
+    eval_select_recipes(quos, data = training, info = info)
+  }
+
   ## Resolve the selectors to a expression containing an additive
   ## function of the variables
-
   if(length(form_sel) > 0) {
-    form_res <- map(form_sel, terms_select, info = info)
+    form_res <- map(form_sel, eval_select_recipes_expr)
     form_res <- map(form_res, vec_2_expr)
     ## Subsitute the column names into the original interaction
     ## formula.
@@ -328,7 +333,7 @@ find_selectors <- function (f) {
   }
   else if (is.call(f)) {
     fname <- as.character(f[[1]])
-    res <- if (fname %in% selectors) f else list()
+    res <- if (fname %in% intersect_selectors) f else list()
     c(res, unlist(lapply(f[-1], find_selectors), use.names = FALSE))
   }
   else if (is.name(f) || is.atomic(f)) {
@@ -356,6 +361,27 @@ replace_selectors <- function(x, elem, value) {
     rlang::abort(paste0("Don't know how to handle type ", typeof(x), "."))
   }
 }
+
+intersect_selectors <- c(
+  "starts_with",
+  "ends_with",
+  "contains",
+  "matches",
+  "num_range",
+  "everything",
+  "one_of",
+  "all_of",
+  "any_of",
+  "c",
+
+  "has_role",
+  "all_predictors",
+  "all_outcomes",
+
+  "has_type",
+  "all_numeric",
+  "all_nominal"
+)
 
 plus_call <- function(x, y) call("+", x, y)
 

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -136,9 +136,13 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
 
   form_sel <- find_selectors(x$terms)
 
+  # Use formula environment as quosure env
+  env <- rlang::f_env(x$terms)
+
   eval_select_recipes_expr <- function(expr) {
     # Wrap `expr` into a list-of-quos as `eval_select_recipes()` expects
-    quos <- enquos(expr)
+    quo <- new_quosure(expr, env)
+    quos <- list(quo)
     eval_select_recipes(quos, data = training, info = info)
   }
 
@@ -373,6 +377,7 @@ intersect_selectors <- c(
   "all_of",
   "any_of",
   "c",
+  "where",
 
   "has_role",
   "all_predictors",

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -80,7 +80,7 @@ step_inverse_new <-
 
 #' @export
 prep.step_inverse <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -80,7 +80,8 @@ step_inverse_new <-
 
 #' @export
 prep.step_inverse <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   step_inverse_new(

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -77,7 +77,7 @@ step_invlogit_new <-
 
 #' @export
 prep.step_invlogit <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   step_invlogit_new(

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -77,7 +77,7 @@ step_invlogit_new <-
 
 #' @export
 prep.step_invlogit <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   step_invlogit_new(

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -151,7 +151,7 @@ step_isomap_new <-
 
 #' @export
 prep.step_isomap <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -151,7 +151,8 @@ step_isomap_new <-
 
 #' @export
 prep.step_isomap <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   if (x$num_terms > 0) {

--- a/R/knn_imp.R
+++ b/R/knn_imp.R
@@ -159,6 +159,7 @@ prep.step_knnimpute <- function(x, training, info = NULL, ...) {
     impute_var_lists(
       to_impute = x$terms,
       impute_using = x$impute_with,
+      training = training,
       info = info
     )
   all_x_vars <- lapply(var_lists, function(x) c(x$x, x$y))

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -166,7 +166,7 @@ step_kpca_new <-
 
 #' @export
 prep.step_kpca <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -166,7 +166,7 @@ step_kpca_new <-
 
 #' @export
 prep.step_kpca <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -154,7 +154,7 @@ step_kpca_poly_new <-
 
 #' @export
 prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -154,7 +154,8 @@ step_kpca_poly_new <-
 
 #' @export
 prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -148,7 +148,7 @@ step_kpca_rbf_new <-
 
 #' @export
 prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -148,7 +148,7 @@ step_kpca_rbf_new <-
 
 #' @export
 prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/lag.R
+++ b/R/lag.R
@@ -102,7 +102,7 @@ prep.step_lag <- function(x, training, info = NULL, ...) {
     lag = x$lag,
     default = x$default,
     prefix = x$prefix,
-    columns = terms_select(x$terms, info = info),
+    columns = eval_step_select(x$terms, training, info),
     skip = x$skip,
     id = x$id
   )

--- a/R/lag.R
+++ b/R/lag.R
@@ -102,7 +102,7 @@ prep.step_lag <- function(x, training, info = NULL, ...) {
     lag = x$lag,
     default = x$default,
     prefix = x$prefix,
-    columns = eval_step_select(x$terms, training, info),
+    columns = eval_select_recipes(x$terms, training, info),
     skip = x$skip,
     id = x$id
   )

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -96,7 +96,8 @@ step_lincomb_new <-
 
 #' @export
 prep.step_lincomb <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   filter <- iter_lc_rm(x = training[, col_names],

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -96,7 +96,7 @@ step_lincomb_new <-
 
 #' @export
 prep.step_lincomb <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/log.R
+++ b/R/log.R
@@ -110,7 +110,7 @@ step_log_new <-
 
 #' @export
 prep.step_log <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/log.R
+++ b/R/log.R
@@ -110,7 +110,8 @@ step_log_new <-
 
 #' @export
 prep.step_log <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   step_log_new(

--- a/R/logit.R
+++ b/R/logit.R
@@ -78,7 +78,7 @@ step_logit_new <-
 
 #' @export
 prep.step_logit <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/logit.R
+++ b/R/logit.R
@@ -78,7 +78,8 @@ step_logit_new <-
 
 #' @export
 prep.step_logit <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   step_logit_new(

--- a/R/lowerimpute.R
+++ b/R/lowerimpute.R
@@ -96,7 +96,7 @@ step_lowerimpute_new <-
 
 #' @export
 prep.step_lowerimpute <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   threshold <-

--- a/R/lowerimpute.R
+++ b/R/lowerimpute.R
@@ -96,7 +96,7 @@ step_lowerimpute_new <-
 
 #' @export
 prep.step_lowerimpute <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   threshold <-

--- a/R/meanimpute.R
+++ b/R/meanimpute.R
@@ -94,7 +94,7 @@ step_meanimpute_new <-
 
 #' @export
 prep.step_meanimpute <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/meanimpute.R
+++ b/R/meanimpute.R
@@ -94,7 +94,8 @@ step_meanimpute_new <-
 
 #' @export
 prep.step_meanimpute <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   means <- lapply(training[, col_names], mean, trim = x$trim, na.rm = TRUE)

--- a/R/medianimpute.R
+++ b/R/medianimpute.R
@@ -88,7 +88,7 @@ step_medianimpute_new <-
 
 #' @export
 prep.step_medianimpute <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/medianimpute.R
+++ b/R/medianimpute.R
@@ -88,7 +88,8 @@ step_medianimpute_new <-
 
 #' @export
 prep.step_medianimpute <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   medians <- lapply(training[, col_names], median, na.rm = TRUE)

--- a/R/misc.R
+++ b/R/misc.R
@@ -61,7 +61,7 @@ get_rhs_vars <- function(formula, data, no_lhs = FALSE) {
   ## or embedded functions like `Sepal.Length + poly(Sepal.Width)`.
   ## or should it? what about Y ~ log(x)?
   ## Answer: when called from `form2args`, the function
-  ## `element_check` stops when in-line functions are used.
+  ## `inline_check` stops when in-line functions are used.
   data_info <- attr(model.frame(formula, data), "terms")
   response_info <- attr(data_info, "response")
   predictor_names <- names(attr(data_info, "dataClasses"))

--- a/R/missing.r
+++ b/R/missing.r
@@ -96,7 +96,7 @@ check_missing_new <-
   }
 
 prep.check_missing <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_missing_new(terms = x$terms,
                     role  = x$role,

--- a/R/missing.r
+++ b/R/missing.r
@@ -96,7 +96,8 @@ check_missing_new <-
   }
 
 prep.check_missing <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_missing_new(terms = x$terms,
                     role  = x$role,
                     trained = TRUE,

--- a/R/modeimpute.R
+++ b/R/modeimpute.R
@@ -90,7 +90,7 @@ step_modeimpute_new <-
 
 #' @export
 prep.step_modeimpute <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   modes <- vapply(training[, col_names], mode_est, c(mode = ""))
   step_modeimpute_new(
     terms = x$terms,

--- a/R/modeimpute.R
+++ b/R/modeimpute.R
@@ -90,7 +90,7 @@ step_modeimpute_new <-
 
 #' @export
 prep.step_modeimpute <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   modes <- vapply(training[, col_names], mode_est, c(mode = ""))
   step_modeimpute_new(
     terms = x$terms,

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -74,7 +74,7 @@ step_mutate_at_new <-
 
 #' @export
 prep.step_mutate_at <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   step_mutate_at_new(
     terms = x$terms,

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -74,7 +74,8 @@ step_mutate_at_new <-
 
 #' @export
 prep.step_mutate_at <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   step_mutate_at_new(
     terms = x$terms,
     fn = x$fn,

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -69,7 +69,7 @@ prep.step_naomit <- function(x, training, info = NULL, ...) {
     terms = x$terms,
     role = x$role,
     trained = TRUE,
-    columns = terms_select(x$terms, info = info),
+    columns = eval_step_select(x$terms, training, info),
     skip = x$skip,
     id = x$id
   )

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -69,7 +69,7 @@ prep.step_naomit <- function(x, training, info = NULL, ...) {
     terms = x$terms,
     role = x$role,
     trained = TRUE,
-    columns = eval_step_select(x$terms, training, info),
+    columns = eval_select_recipes(x$terms, training, info),
     skip = x$skip,
     id = x$id
   )

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -122,7 +122,7 @@ new_values_func <- function(x,
 }
 
 prep.check_new_values <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   values <- lapply(training[ ,col_names], unique)
 

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -122,8 +122,10 @@ new_values_func <- function(x,
 }
 
 prep.check_new_values <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   values <- lapply(training[ ,col_names], unique)
+
   check_new_values_new(
     terms   = x$terms,
     role    = x$role,

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -126,7 +126,7 @@ step_nnmf_new <-
 
 #' @export
 prep.step_nnmf <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -126,7 +126,8 @@ step_nnmf_new <-
 
 #' @export
 prep.step_nnmf <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -96,7 +96,7 @@ step_normalize_new <-
 
 #' @export
 prep.step_normalize <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -96,7 +96,8 @@ step_normalize_new <-
 
 #' @export
 prep.step_normalize <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   means <- vapply(training[, col_names], mean, c(mean = 0), na.rm = x$na_rm)

--- a/R/novel.R
+++ b/R/novel.R
@@ -116,7 +116,7 @@ get_existing_values <- function(x) {
 
 #' @export
 prep.step_novel <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   col_check <- dplyr::filter(info, variable %in% col_names)
 

--- a/R/novel.R
+++ b/R/novel.R
@@ -116,8 +116,10 @@ get_existing_values <- function(x) {
 
 #' @export
 prep.step_novel <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   col_check <- dplyr::filter(info, variable %in% col_names)
+
   if (any(col_check$type != "nominal"))
     rlang::abort(
       paste0("Columns must be character or factor: ",

--- a/R/ns.R
+++ b/R/ns.R
@@ -109,7 +109,8 @@ ns_wrapper <- function(x, args) {
 
 #' @export
 prep.step_ns <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   opt <- x$options

--- a/R/ns.R
+++ b/R/ns.R
@@ -109,7 +109,7 @@ ns_wrapper <- function(x, args) {
 
 #' @export
 prep.step_ns <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -135,7 +135,7 @@ get_ord_lvls_num <- function(x, foo)
 
 #' @export
 prep.step_num2factor <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -135,7 +135,8 @@ get_ord_lvls_num <- function(x, foo)
 
 #' @export
 prep.step_num2factor <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   res <- lapply(training[, col_names], get_ord_lvls_num, foo = x$transform)

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -137,7 +137,8 @@ step_nzv_new <-
 
 #' @export
 prep.step_nzv <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   filter <- nzv(
     x = training[, col_names],
     freq_cut = x$freq_cut,

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -137,7 +137,7 @@ step_nzv_new <-
 
 #' @export
 prep.step_nzv <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   filter <- nzv(
     x = training[, col_names],

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -107,7 +107,7 @@ step_ordinalscore_new <-
 #' @export
 prep.step_ordinalscore <-
   function(x, training, info = NULL, ...) {
-    col_names <- eval_step_select(x$terms, training, info)
+    col_names <- eval_select_recipes(x$terms, training, info)
     ord_check <-
       vapply(training[, col_names], is.ordered, c(logic = TRUE))
     if (!all(ord_check))

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -107,7 +107,7 @@ step_ordinalscore_new <-
 #' @export
 prep.step_ordinalscore <-
   function(x, training, info = NULL, ...) {
-    col_names <- terms_select(x$terms, info = info)
+    col_names <- eval_step_select(x$terms, training, info)
     ord_check <-
       vapply(training[, col_names], is.ordered, c(logic = TRUE))
     if (!all(ord_check))

--- a/R/other.R
+++ b/R/other.R
@@ -144,7 +144,7 @@ step_other_new <-
 
 #' @export
 prep.step_other <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   if (length(col_names) > 0) {
     objects <- lapply(training[, col_names],

--- a/R/other.R
+++ b/R/other.R
@@ -144,7 +144,7 @@ step_other_new <-
 
 #' @export
 prep.step_other <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info, empty_fun = passover)
+  col_names <- eval_step_select(x$terms, training, info)
 
   if (length(col_names) > 0) {
     objects <- lapply(training[, col_names],

--- a/R/pca.R
+++ b/R/pca.R
@@ -158,7 +158,8 @@ step_pca_new <-
 
 #' @export
 prep.step_pca <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   if (x$num_comp > 0) {

--- a/R/pca.R
+++ b/R/pca.R
@@ -158,7 +158,7 @@ step_pca_new <-
 
 #' @export
 prep.step_pca <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/pls.R
+++ b/R/pls.R
@@ -295,8 +295,9 @@ prop2int <- function(x, p) {
 
 #' @export
 prep.step_pls <- function(x, training, info = NULL, ...) {
-  x_names <- terms_select(x$terms,   info = info)
-  y_names <- terms_select(x$outcome, info = info)
+  x_names <- eval_step_select(x$terms, training, info)
+  y_names <- eval_step_select(x$outcome, training, info)
+
   check_type(training[, x_names])
   if (length(y_names) > 1 ) {
     rlang::abort("`step_pls()` only supports univariate models.")

--- a/R/pls.R
+++ b/R/pls.R
@@ -353,10 +353,19 @@ bake.step_pls <- function(object, new_data, ...) {
     comps <- check_name(comps, new_data, object)
 
     new_data <- bind_cols(new_data, as_tibble(comps))
-    if (!use_old_pls(object$res) && !object$preserve) {
+
+    # Old pls never preserved original columns,
+    # but didn't have the `preserve` option
+    if (use_old_pls(object$res)) {
+      pls_vars <- rownames(object$res$projection)
+      keep_vars <- !(colnames(new_data) %in% pls_vars)
+      new_data <- new_data[, keep_vars, drop = FALSE]
+    } else if (!object$preserve) {
       pls_vars <- names(object$res$mu)
-      new_data <- new_data[, !(colnames(new_data) %in% pls_vars), drop = FALSE]
+      keep_vars <- !(colnames(new_data) %in% pls_vars)
+      new_data <- new_data[, keep_vars, drop = FALSE]
     }
+
     if (!is_tibble(new_data)) {
       new_data <- as_tibble(new_data)
     }

--- a/R/pls.R
+++ b/R/pls.R
@@ -295,8 +295,8 @@ prop2int <- function(x, p) {
 
 #' @export
 prep.step_pls <- function(x, training, info = NULL, ...) {
-  x_names <- eval_step_select(x$terms, training, info)
-  y_names <- eval_step_select(x$outcome, training, info)
+  x_names <- eval_select_recipes(x$terms, training, info)
+  y_names <- eval_select_recipes(x$outcome, training, info)
 
   check_type(training[, x_names])
   if (length(y_names) > 1 ) {

--- a/R/poly.R
+++ b/R/poly.R
@@ -130,7 +130,7 @@ poly_wrapper <- function(x, args) {
 
 #' @export
 prep.step_poly <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/poly.R
+++ b/R/poly.R
@@ -130,7 +130,8 @@ poly_wrapper <- function(x, args) {
 
 #' @export
 prep.step_poly <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   opts <- x$options

--- a/R/profile.R
+++ b/R/profile.R
@@ -161,8 +161,8 @@ step_profile_new <-
 
 #' @export
 prep.step_profile <- function(x, training, info = NULL, ...) {
-  fixed_names <- eval_step_select(x$terms, training, info)
-  profile_name <- eval_step_select(x$profile, training, info)
+  fixed_names <- eval_select_recipes(x$terms, training, info)
+  profile_name <- eval_select_recipes(x$profile, training, info)
 
   if(length(fixed_names) == 0)
     rlang::abort("At least one variable should be fixed")

--- a/R/profile.R
+++ b/R/profile.R
@@ -161,8 +161,8 @@ step_profile_new <-
 
 #' @export
 prep.step_profile <- function(x, training, info = NULL, ...) {
-  fixed_names <- terms_select(x$terms, info = info)
-  profile_name <- terms_select(x$profile, info = info)
+  fixed_names <- eval_step_select(x$terms, training, info)
+  profile_name <- eval_step_select(x$profile, training, info)
 
   if(length(fixed_names) == 0)
     rlang::abort("At least one variable should be fixed")

--- a/R/range.R
+++ b/R/range.R
@@ -95,7 +95,7 @@ step_range_new <-
 
 #' @export
 prep.step_range <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   mins <-

--- a/R/range.R
+++ b/R/range.R
@@ -95,7 +95,7 @@ step_range_new <-
 
 #' @export
 prep.step_range <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   mins <-

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -119,9 +119,9 @@ check_range_new <-
 
 prep.check_range <- function(x,
                              training,
-                             info = NULL, # info is an argument to terms_select
+                             info = NULL,
                              ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   ## TODO add informative error for nonnumerics
 

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -121,7 +121,7 @@ prep.check_range <- function(x,
                              training,
                              info = NULL,
                              ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   ## TODO add informative error for nonnumerics
 

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -110,8 +110,8 @@ step_ratio_new <-
 #' @export
 prep.step_ratio <- function(x, training, info = NULL, ...) {
   col_names <- expand.grid(
-    top = eval_step_select(x$terms, training, info),
-    bottom = eval_step_select(x$denom, training, info),
+    top = eval_select_recipes(x$terms, training, info),
+    bottom = eval_select_recipes(x$denom, training, info),
     stringsAsFactors = FALSE
   )
   col_names <- col_names[!(col_names$top == col_names$bottom), ]

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -110,8 +110,8 @@ step_ratio_new <-
 #' @export
 prep.step_ratio <- function(x, training, info = NULL, ...) {
   col_names <- expand.grid(
-    top = terms_select(x$terms, info = info),
-    bottom = terms_select(x$denom, info = info),
+    top = eval_step_select(x$terms, training, info),
+    bottom = eval_step_select(x$denom, training, info),
     stringsAsFactors = FALSE
   )
   col_names <- col_names[!(col_names$top == col_names$bottom), ]

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -244,8 +244,9 @@ recipe.matrix <- function(x, ...) {
 form2args <- function(formula, data, ...) {
   if (!is_formula(formula))
     formula <- as.formula(formula)
+
   ## check for in-line formulas
-  element_check(formula, allowed = NULL)
+  inline_check(formula)
 
   if (!is_tibble(data))
     data <- as_tibble(data)
@@ -271,6 +272,20 @@ form2args <- function(formula, data, ...) {
   ## pass to recipe.default with vars and roles
 
   list(x = data, vars = vars, roles = roles)
+}
+
+inline_check <- function(x) {
+  funs <- fun_calls(x)
+  funs <- funs[!(funs %in% c("~", "+", "-"))]
+
+  if (length(funs) > 0) {
+    rlang::abort(paste0(
+      "No in-line functions should be used here; ",
+      "use steps to define baking actions."
+    ))
+  }
+
+  invisible(x)
 }
 
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -483,61 +483,6 @@ prep.recipe <-
     x
   }
 
-# For columns that should be retained (based on the selectors used in `bake()`
-# or `bake(new_data = NULL)`), match those to the existing columns in the data.
-#
-# Some details:
-#  1. When running `bake(new_data = NULL)`, the resulting columns should be
-#  consistent with the variables in `term_info$variables`. If selectors are
-#  used, the final columns that are returned should be a subset of those.
-#  2. `term_info$variables` is consistent with a recipe when _no_ steps are
-#  skipped.
-#  3. If a step is skipped, its effect is only seen in `bake()` when a data
-#  frame is given to `new_data`. Also, if a
-#  step is skipped, the columns names that should be returned are possibly
-#  inconsistent with what is in `term_info$variables`. The results might be that
-#  there are more/less/different columns between `bake()` and `bake(new_data = NULL)`.
-#
-# `final_vars()` follows this logic:
-#
-#  - During `bake(new_data = NULL)` it determines which of the selected columns
-#    are consistent with `term_info$variables` and returns them.
-#  - During `bake()`, the selected columns are subsetted with the names of the
-#    processed data.
-#
-# The column ordering is non-trivial. The approach here is to order the data
-# consistent with `term_info$variables` and to add other variables at the
-# end of the tibble. This seems reasonable but might lead to unexpected (but
-# consistent) results.
-#
-# Consider a recipe for the `mtcars` data with a single step:
-#     `step_rm(cyl, skip = TRUE)`
-# is used. For `bake(new_data = NULL)`, only ten columns are returned. However,
-# when `bake()` is run on the recipe with new data, it should return all eleven.
-# When `bake()` is run, `cyl` is not included in `term_info$variables` so this
-# column would come at the end (instead of as the second column as it is in
-# `mtcars`).
-
-final_vars <- function(nms, vars, trms, baking) {
-  # In case there are multiple roles for a column:
-  trms <- trms[!duplicated(trms$variable), ]
-
-  if (baking) {
-    possible <- nms[nms %in% vars]
-  } else {
-    possible <- trms$variable[trms$variable %in% vars]
-  }
-  possible <- possible[!is.na(possible)]
-  possible <- possible[!duplicated(possible)]
-  possible <-
-    tibble::tibble(variable = possible, .order_2 = seq_along(possible))
-  trms$.order_1 <- 1:nrow(trms)
-  both <-
-    dplyr::left_join(possible, trms, by = "variable") %>%
-    dplyr::arrange(.order_1, .order_2)
-  both$variable
-}
-
 #' @rdname bake
 #' @aliases bake bake.recipe
 #' @author Max Kuhn
@@ -643,49 +588,50 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
 
   check_nominal_type(new_data, object$orig_lvls)
 
-  # Determine return variables. The context (ie. `info`) can
-  # change depending on whether a skip step was used. If so, we
-  # use an alternate info tibble that has all possible terms
-  # in it.
-  has_skip <- vapply(object$steps, function(x) x$skip, logical(1))
+  # Drop completely new columns from `new_data` and reorder columns that do
+  # still exist to match the ordering used when training
+  original_names <- names(new_data)
+  original_training_names <- unique(object$var_info$variable)
+  bakeable_names <- intersect(original_training_names, original_names)
+  new_data <- new_data[, bakeable_names]
 
-  if (any(has_skip)) {
-    keepers <-
-      terms_select(terms = terms,
-                   info = object$last_term_info,
-                   empty_fun = passover)
-  } else {
-    keepers <-
-      terms_select(terms = terms,
-                   info = object$term_info,
-                   empty_fun = passover)
+  n_steps <- length(object$steps)
+
+  for (i in seq_len(n_steps)) {
+    step <- object$steps[[i]]
+
+    if (is_skipable(step)) {
+      next
+    }
+
+    new_data <- bake(step, new_data = new_data)
+
+    if (!is_tibble(new_data)) {
+      new_data <- as_tibble(new_data)
+    }
   }
 
-  if (length(keepers) > 0) {
-    for (i in seq(along.with = object$steps)) {
-      if (!is_skipable(object$steps[[i]])) {
-        new_data <- bake(object$steps[[i]], new_data = new_data)
-        if (!is_tibble(new_data))
-          new_data <- as_tibble(new_data)
-      }
-    }
-    vars <- final_vars(names(new_data), keepers, object$term_info, baking = TRUE)
-    new_data <- new_data[, vars]
+  # Use `last_term_info`, which maintains info on all columns that got added
+  # and removed from the training data. This is important for skipped steps
+  # which might have resulted in columns not being added/removed in the test
+  # set.
+  info <- object$last_term_info
 
-    ## The levels are not null when no nominal data are present or
-    ## if strings_as_factors = FALSE in `prep`
-    if (!is.null(object$levels)) {
-      var_levels <- object$levels
-      var_levels <- var_levels[keepers]
-      check_values <-
-        vapply(var_levels, function(x)
-          (!all(is.na(x))), c(all = TRUE))
-      var_levels <- var_levels[check_values]
-      if (length(var_levels) > 0)
-        new_data <- strings2factors(new_data, var_levels)
-    }
-  } else {
-    new_data <- tibble(.rows = nrow(new_data))
+  # Now reduce to only user selected columns
+  out_names <- eval_select_recipes(terms, new_data, info)
+  new_data <- new_data[, out_names]
+
+  ## The levels are not null when no nominal data are present or
+  ## if strings_as_factors = FALSE in `prep`
+  if (!is.null(object$levels)) {
+    var_levels <- object$levels
+    var_levels <- var_levels[out_names]
+    check_values <-
+      vapply(var_levels, function(x)
+        (!all(is.na(x))), c(all = TRUE))
+    var_levels <- var_levels[check_values]
+    if (length(var_levels) > 0)
+      new_data <- strings2factors(new_data, var_levels)
   }
 
   if (composition == "dgCMatrix") {
@@ -770,7 +716,7 @@ print.recipe <- function(x, form_width = 30, ...) {
 #' @examples
 #' rec <- recipe( ~ ., data = USArrests)
 #' summary(rec)
-#' rec <- step_pca(rec, all_numeric(), num = 3)
+#' rec <- step_pca(rec, all_numeric(), num_comp = 3)
 #' summary(rec) # still the same since not yet trained
 #' rec <- prep(rec, training = USArrests)
 #' summary(rec)
@@ -811,49 +757,39 @@ juice <- function(object, ..., composition = "tibble") {
   }
 
   if (!isTRUE(object$retained)) {
-    rlang::abort(
-      paste0("Use `retain = TRUE` in `prep()` to be able ",
-             "to extract the training set"
-             )
-    )
+    rlang::abort(paste0(
+      "Use `retain = TRUE` in `prep()` to be able ",
+      "to extract the training set"
+    ))
   }
 
   if (!any(composition == formats)) {
-    rlang::abort(
-      paste0("`composition` should be one of: ",
-         paste0("'", formats, "'", collapse = ",")
-         )
-      )
+    rlang::abort(paste0(
+      "`composition` should be one of: ",
+      paste0("'", formats, "'", collapse = ",")
+    ))
   }
 
   terms <- quos(...)
   if (is_empty(terms)) {
     terms <- quos(everything())
   }
-  keepers <-
-    terms_select(terms = terms,
-                 info = object$term_info,
-                 empty_fun = passover)
 
-  if (length(keepers) > 0) {
-    vars <- final_vars(names(object$template), keepers, object$term_info, baking = FALSE)
-    new_data <- object$template[, vars]
+  # Get user requested columns
+  new_data <- object$template
+  out_names <- eval_select_recipes(terms, new_data, object$term_info)
+  new_data <- new_data[, out_names]
 
-    ## Since most models require factors, do the conversion from character
-    if (!is.null(object$levels)) {
-      var_levels <- object$levels
-      var_levels <- var_levels[keepers]
-      check_values <-
-        vapply(var_levels, function(x)
-          (!all(is.na(x))), c(all = TRUE))
-      var_levels <- var_levels[check_values]
-      if (length(var_levels) > 0)
-        new_data <- strings2factors(new_data, var_levels)
-    }
-
-
-  } else {
-    new_data <- tibble(.rows = nrow(object$template))
+  ## Since most models require factors, do the conversion from character
+  if (!is.null(object$levels)) {
+    var_levels <- object$levels
+    var_levels <- var_levels[out_names]
+    check_values <-
+      vapply(var_levels, function(x)
+        (!all(is.na(x))), c(all = TRUE))
+    var_levels <- var_levels[check_values]
+    if (length(var_levels) > 0)
+      new_data <- strings2factors(new_data, var_levels)
   }
 
   if (composition == "dgCMatrix") {

--- a/R/regex.R
+++ b/R/regex.R
@@ -112,7 +112,7 @@ step_regex_new <-
 
 #' @export
 prep.step_regex <- function(x, training, info = NULL, ...) {
-  col_name <- eval_step_select(x$terms, training, info)
+  col_name <- eval_select_recipes(x$terms, training, info)
 
   if (length(col_name) != 1)
     rlang::abort("The selector should only select a single variable")

--- a/R/regex.R
+++ b/R/regex.R
@@ -112,7 +112,8 @@ step_regex_new <-
 
 #' @export
 prep.step_regex <- function(x, training, info = NULL, ...) {
-  col_name <- terms_select(x$terms, info = info)
+  col_name <- eval_step_select(x$terms, training, info)
+
   if (length(col_name) != 1)
     rlang::abort("The selector should only select a single variable")
   if (any(info$type[info$variable %in% col_name] != "nominal"))

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -84,7 +84,7 @@ step_relevel_new <-
 
 #' @export
 prep.step_relevel <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   col_check <- dplyr::filter(info, .data$variable %in% col_names)
 

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -84,8 +84,10 @@ step_relevel_new <-
 
 #' @export
 prep.step_relevel <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   col_check <- dplyr::filter(info, .data$variable %in% col_names)
+
   if (any(col_check$type != "nominal")) {
     rlang::abort(
       "Columns must be character or factor: ",

--- a/R/relu.R
+++ b/R/relu.R
@@ -131,7 +131,7 @@ step_relu_new <-
 
 #' @export
 prep.step_relu <- function(x, training, info = NULL, ...) {
-  columns <- eval_step_select(x$terms, training, info)
+  columns <- eval_select_recipes(x$terms, training, info)
   check_type(training[, columns])
 
   step_relu_new(

--- a/R/relu.R
+++ b/R/relu.R
@@ -131,7 +131,7 @@ step_relu_new <-
 
 #' @export
 prep.step_relu <- function(x, training, info = NULL, ...) {
-  columns <- terms_select(x$terms, info = info)
+  columns <- eval_step_select(x$terms, training, info)
   check_type(training[, columns])
 
   step_relu_new(

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -67,7 +67,8 @@ step_rename_at_new <-
 
 #' @export
 prep.step_rename_at <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   step_rename_at_new(
     terms = x$terms,
     fn = x$fn,

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -67,7 +67,7 @@ step_rename_at_new <-
 
 #' @export
 prep.step_rename_at <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   step_rename_at_new(
     terms = x$terms,

--- a/R/rm.R
+++ b/R/rm.R
@@ -73,7 +73,7 @@ step_rm_new <- function(terms, role, trained, removals, skip, id) {
 
 #' @export
 prep.step_rm <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   step_rm_new(
     terms = x$terms,
     role = x$role,

--- a/R/rm.R
+++ b/R/rm.R
@@ -73,7 +73,7 @@ step_rm_new <- function(terms, role, trained, removals, skip, id) {
 
 #' @export
 prep.step_rm <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   step_rm_new(
     terms = x$terms,
     role = x$role,

--- a/R/rollimpute.R
+++ b/R/rollimpute.R
@@ -116,7 +116,7 @@ step_rollimpute_new <-
 
 #' @export
 prep.step_rollimpute <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
   dbl_check <- vapply(training[, col_names], is.double, logical(1))
   if (any(!dbl_check))

--- a/R/rollimpute.R
+++ b/R/rollimpute.R
@@ -116,7 +116,7 @@ step_rollimpute_new <-
 
 #' @export
 prep.step_rollimpute <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
   dbl_check <- vapply(training[, col_names], is.double, logical(1))
   if (any(!dbl_check))

--- a/R/scale.R
+++ b/R/scale.R
@@ -102,7 +102,7 @@ step_scale_new <-
 
 #' @export
 prep.step_scale <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$factor != 1 & x$factor != 2) {

--- a/R/scale.R
+++ b/R/scale.R
@@ -102,7 +102,7 @@ step_scale_new <-
 
 #' @export
 prep.step_scale <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   if (x$factor != 1 & x$factor != 2) {

--- a/R/selections.R
+++ b/R/selections.R
@@ -127,11 +127,21 @@ type_selectors <- c("has_type", "all_numeric", "all_nominal")
 selectors <-
   unique(c(name_selectors, role_selectors, type_selectors))
 
+# - Can't include these in `selectors`. If we did, `step_interact()` would break
+#   since it differentiates between named selector functions and formula ops
+#   like `-`.
+# - `:` is not included here. We select using `info$variable` of the term info,
+#   and I am not sure that the ordering given there always matches the order
+#   of columns in the training data.
+ops_tidyselect <- c("&", "|", "!", "-")
+ops_formula <- c("~", "+", "-")
+
 ## This flags formulas that are not allowed. When called from `recipe.formula`
 ## `allowed` is NULL.
 element_check <- function(x, allowed = selectors) {
   funs <- fun_calls(x)
-  funs <- funs[!(funs %in% c("~", "+", "-"))]
+  funs <- funs[!(funs %in% ops_formula)]
+  funs <- funs[!(funs %in% ops_tidyselect)]
   # i.e. tidyselect::matches()
   funs <- funs[!(funs %in% c("::", "tidyselect", "dplyr", "recipes"))]
   if (!is.null(allowed)) {

--- a/R/selections.R
+++ b/R/selections.R
@@ -238,7 +238,7 @@ eval_select_recipes <- function(quos, data, info) {
   # Maintain ordering between `data` column names and `info$variable` so
   # `eval_select()` and recipes selectors return compatible positions
   data_info <- tibble(variable = names(data))
-  data_info <- left_join(data_info, info, by = "variable")
+  data_info <- dplyr::left_join(data_info, info, by = "variable")
 
   nested_info <- nest_current_info(data_info)
 

--- a/R/selections.R
+++ b/R/selections.R
@@ -106,123 +106,6 @@
 #'   }
 NULL
 
-## These are the allowable functions for formulas in the the `terms` arguments
-## to the steps or to `recipes.formula`.
-name_selectors <- c("starts_with",
-                    "ends_with",
-                    "contains",
-                    "matches",
-                    "num_range",
-                    "everything",
-                    "one_of",
-                    "all_of",
-                    "any_of",
-                    "c")
-
-role_selectors <-
-  c("has_role", "all_predictors", "all_outcomes")
-
-type_selectors <- c("has_type", "all_numeric", "all_nominal")
-
-selectors <-
-  unique(c(name_selectors, role_selectors, type_selectors))
-
-## This flags formulas that are not allowed. When called from `recipe.formula`
-## `allowed` is NULL.
-element_check <- function(x, allowed = selectors) {
-  funs <- fun_calls(x)
-  funs <- funs[!(funs %in% c("~", "+", "-"))]
-  # i.e. tidyselect::matches()
-  funs <- funs[!(funs %in% c("::", "tidyselect", "dplyr", "recipes"))]
-  if (!is.null(allowed)) {
-    # when called from a step
-    not_good <- funs[!(funs %in% allowed)]
-    if (length(not_good) > 0)
-      rlang::abort(
-          paste0(
-          "Not all functions are allowed in step function selectors (e.g. ",
-          paste0("`", not_good, "`", collapse = ", "),
-          "). See ?selections."
-        )
-      )
-  } else {
-    # when called from formula.recipe
-    if (length(funs) > 0)
-      rlang::abort(
-        paste0(
-          "No in-line functions should be used here; use steps to define ",
-          "baking actions"
-        )
-      )
-  }
-  invisible(NULL)
-}
-
-#' Select Terms in a Step Function.
-#'
-#' This function bakes the step function selectors and might be
-#'  useful when creating custom steps.
-#'
-#' @param info A tibble with columns `variable`, `type`, `role`,
-#'  and `source` that represent the current state of the data. The
-#'  function [summary.recipe()] can be used to get this information
-#'  from a recipe.
-#' @param terms A list of formulas whose right-hand side contains
-#'  quoted expressions. See [rlang::quos()] for examples.
-#' @param empty_fun A function to execute when no terms are selected by the
-#'  step. The default function throws an error with a message.
-#' @keywords datagen
-#' @concept preprocessing
-#' @return A character string of column names or an error of there
-#'  are no selectors or if no variables are selected.
-#' @seealso [recipe()] [summary.recipe()]
-#'   [prep.recipe()]
-#' @export
-#' @examples
-#' library(rlang)
-#' library(modeldata)
-#' data(okc)
-#' rec <- recipe(~ ., data = okc)
-#' info <- summary(rec)
-#' terms_select(info = info, quos(all_predictors()))
-terms_select <- function(terms, info, empty_fun = abort_selection) {
-  # unique in case a variable has multiple roles
-  vars <- unique(info$variable)
-
-  if (is_empty(terms)) {
-    rlang::abort("At least one selector should be used")
-  }
-
-  ## check arguments against whitelist
-  lapply(terms, element_check)
-
-  # Set current_info so available to helpers
-
-  nested_info <- nest_current_info(info)
-
-  local_current_info(nested_info)
-
-  # `terms` might be a single call (like in step_interact()),
-  # or it could be a list of quosures.
-  # They have to be unquoted differently
-  if (is.call(terms)) {
-    sel <- with_handlers(
-      tidyselect::vars_select(vars, !! terms),
-      tidyselect_empty = empty_fun
-    )
-  } else {
-    sel <- with_handlers(
-      tidyselect::vars_select(vars, !!! terms),
-      tidyselect_empty = empty_fun
-    )
-  }
-
-  unname(sel)
-}
-
-abort_selection <- exiting(function(cnd) {
-  abort("No variables or terms were selected.")
-})
 
 eval_select_recipes <- function(quos, data, info) {
   # Maintain ordering between `data` column names and `info$variable` so
@@ -392,3 +275,123 @@ local_current_info <- function(nested_info, frame = parent.frame()) {
 current_info <- function() {
   cur_info_env %||% rlang::abort("Variable context not set")
 }
+
+# ------------------------------------------------------------------------------
+# Old method for selection. This has been completely superseded by
+# `eval_select_recipes()`, and should no longer be used in recipes, but we
+# have exported it so we continue to support it here.
+
+# This flags formulas that are not allowed
+element_check <- function(x) {
+  funs <- fun_calls(x)
+  funs <- funs[!(funs %in% c("~", "+", "-"))]
+
+  # i.e. tidyselect::matches()
+  funs <- funs[!(funs %in% c("::", "tidyselect", "dplyr", "recipes"))]
+
+  name_selectors <- c(
+    "starts_with",
+    "ends_with",
+    "contains",
+    "matches",
+    "num_range",
+    "everything",
+    "one_of",
+    "all_of",
+    "any_of",
+    "c"
+  )
+  role_selectors <- c(
+    "has_role",
+    "all_predictors",
+    "all_outcomes"
+  )
+  type_selectors <- c(
+    "has_type",
+    "all_numeric",
+    "all_nominal"
+  )
+  selectors <- c(
+    name_selectors,
+    role_selectors,
+    type_selectors
+  )
+
+  not_good <- funs[!(funs %in% selectors)]
+
+  if (length(not_good) > 0) {
+    rlang::abort(paste0(
+      "Not all functions are allowed in step function selectors (e.g. ",
+      paste0("`", not_good, "`", collapse = ", "),
+      "). See ?selections."
+    ))
+  }
+
+  invisible(NULL)
+}
+
+#' Select Terms in a Step Function.
+#'
+#' This function bakes the step function selectors and might be
+#'  useful when creating custom steps.
+#'
+#' @param info A tibble with columns `variable`, `type`, `role`,
+#'  and `source` that represent the current state of the data. The
+#'  function [summary.recipe()] can be used to get this information
+#'  from a recipe.
+#' @param terms A list of formulas whose right-hand side contains
+#'  quoted expressions. See [rlang::quos()] for examples.
+#' @param empty_fun A function to execute when no terms are selected by the
+#'  step. The default function throws an error with a message.
+#' @keywords datagen
+#' @concept preprocessing
+#' @return A character string of column names or an error of there
+#'  are no selectors or if no variables are selected.
+#' @seealso [recipe()] [summary.recipe()]
+#'   [prep.recipe()]
+#' @export
+#' @examples
+#' library(rlang)
+#' library(modeldata)
+#' data(okc)
+#' rec <- recipe(~ ., data = okc)
+#' info <- summary(rec)
+#' terms_select(info = info, quos(all_predictors()))
+terms_select <- function(terms, info, empty_fun = abort_selection) {
+  # unique in case a variable has multiple roles
+  vars <- unique(info$variable)
+
+  if (is_empty(terms)) {
+    rlang::abort("At least one selector should be used")
+  }
+
+  ## check arguments against whitelist
+  lapply(terms, element_check)
+
+  # Set current_info so available to helpers
+
+  nested_info <- nest_current_info(info)
+
+  local_current_info(nested_info)
+
+  # `terms` might be a single call (like in step_interact()),
+  # or it could be a list of quosures.
+  # They have to be unquoted differently
+  if (is.call(terms)) {
+    sel <- with_handlers(
+      tidyselect::vars_select(vars, !! terms),
+      tidyselect_empty = empty_fun
+    )
+  } else {
+    sel <- with_handlers(
+      tidyselect::vars_select(vars, !!! terms),
+      tidyselect_empty = empty_fun
+    )
+  }
+
+  unname(sel)
+}
+
+abort_selection <- exiting(function(cnd) {
+  abort("No variables or terms were selected.")
+})

--- a/R/selections.R
+++ b/R/selections.R
@@ -3,7 +3,9 @@
 #' @name selections
 #' @aliases selections
 #' @aliases selection
-#' @title Methods for Select Variables in Step Functions
+#'
+#' @title Methods for Selecting Variables in Step Functions
+#'
 #' @description When selecting variables or model terms in `step`
 #'  functions, `dplyr`-like tools are used. The *selector* functions
 #'  can choose variables based on their name, current role, data
@@ -13,29 +15,24 @@
 #'
 #' \preformatted{
 #'   recipe( ~ ., data = USArrests) \%>\%
-#'     step_pca(Murder, Assault, UrbanPop, Rape, num = 3)
+#'     step_pca(Murder, Assault, UrbanPop, Rape, num_comp = 3)
 #' }
 #'
-#'   The first four arguments indicate which variables should be
+#'  The first four arguments indicate which variables should be
 #'  used in the PCA while the last argument is a specific argument
 #'  to [step_pca()].
 #'
 #' Note that:
 #'
 #'   \enumerate{
-#'   \item The selector arguments should not contain functions
-#'    beyond those supported (see below).
 #'   \item These arguments are not evaluated until the `prep`
 #'    function for the step is executed.
-
 #'   \item The `dplyr`-like syntax allows for negative signs to
 #'    exclude variables (e.g. `-Murder`) and the set of selectors will
 #'    processed in order.
-
 #'   \item A leading exclusion in these arguments (e.g. `-Murder`)
 #'   has the effect of adding all variables to the list except the
 #'   excluded variable(s).
-
 #'   }
 #'
 #' Also, select helpers from the `tidyselect` package can also be used:
@@ -44,7 +41,8 @@
 #'   [tidyselect::num_range()], [tidyselect::everything()],
 #'   [tidyselect::one_of()], [tidyselect::all_of()], and
 #'   [tidyselect::any_of()]
-#'   For example:
+#'
+#' For example:
 #'
 #' \preformatted{
 #'   recipe(Species ~ ., data = iris) \%>\%
@@ -53,25 +51,20 @@
 #'
 #' would only select `Sepal.Length`
 #'
-#' **Inline** functions that specify computations, such as
-#'  `log(x)`, should not be used in selectors and will produce an
-#'  error. A list of allowed selector functions is below.
-#'
 #' Columns of the design matrix that may not exist when the step
-#'  is coded can also be selected. For example, when using
-#'  `step_pca`, the number of columns created by feature extraction
-#'  may not be known when subsequent steps are defined. In this
-#'  case, using `matches("^PC")` will select all of the columns
-#'  whose names start with "PC" *once those columns are created*.
+#' is coded can also be selected. For example, when using
+#' `step_pca()`, the number of columns created by feature extraction
+#' may not be known when subsequent steps are defined. In this
+#' case, using `matches("^PC")` will select all of the columns
+#' whose names start with "PC" *once those columns are created*.
 #'
-#' There are sets of functions that can be used to select
-#'  variables based on their role or type: [has_role()] and
-#'  [has_type()]. For convenience, there are also functions that are
-#'  more specific: [all_numeric()], [all_nominal()],
-#'  [all_predictors()], and [all_outcomes()]. These can be used in
-#'  conjunction with the previous functions described for selecting
-#'  variables using their names:
-
+#' There are sets of recipes specific functions that can be used to select
+#' variables based on their role or type: [has_role()] and
+#' [has_type()]. For convenience, there are also functions that are
+#' more specific: [all_numeric()], [all_nominal()],
+#' [all_predictors()], and [all_outcomes()]. These can be used in
+#' conjunction with the previous functions described for selecting
+#' variables using their names:
 #'
 #' \preformatted{
 #'   data(biomass)
@@ -79,31 +72,24 @@
 #'     step_center(all_numeric(), -all_outcomes())
 #' }
 #'
-#'   This results in all the numeric predictors: carbon, hydrogen,
-#'  oxygen, nitrogen, and sulfur.
+#' This results in all the numeric predictors: carbon, hydrogen,
+#' oxygen, nitrogen, and sulfur.
 #'
-#'   If a role for a variable has not been defined, it will never be
-#'  selected using role-specific selectors.
+#' If a role for a variable has not been defined, it will never be
+#' selected using role-specific selectors.
 #'
 #' Selectors can be used in [step_interact()] in similar ways but
-#'  must be embedded in a model formula (as opposed to a sequence
-#'  of selectors). For example, the interaction specification
-#'  could be `~ starts_with("Species"):Sepal.Width`. This can be
-#'  useful if `Species` was converted to dummy variables
-#'  previously using [step_dummy()].
-#'
-#' The complete list of allowable functions in steps:
-#'
-#'   \itemize{
-#'     \item **By name**: [tidyselect::starts_with()],
-#'       [tidyselect::ends_with()], [tidyselect::contains()],
-#'       [tidyselect::matches()], [tidyselect::num_range()],
-#'       [tidyselect::everything()]
-#'     \item **By role**: [has_role()],
-#'       [all_predictors()], and [all_outcomes()]
-#'     \item **By type**: [has_type()], [all_numeric()],
-#'       and [all_nominal()]
-#'   }
+#' must be embedded in a model formula (as opposed to a sequence
+#' of selectors). For example, the interaction specification
+#' could be `~ starts_with("Species"):Sepal.Width`. This can be
+#' useful if `Species` was converted to dummy variables
+#' previously using [step_dummy()]. The implementation of
+#' `step_interact()` is special, and is more restricted than
+#' the other step functions. Only the selector functions from
+#' recipes and tidyselect are allowed. User defined selector functions
+#' will not be recognized. Additionally, the tidyselect domain specific
+#' language is not recognized here, meaning that `&`, `|`, `!`, and `-`
+#' will not work.
 NULL
 
 

--- a/R/selections.R
+++ b/R/selections.R
@@ -127,21 +127,11 @@ type_selectors <- c("has_type", "all_numeric", "all_nominal")
 selectors <-
   unique(c(name_selectors, role_selectors, type_selectors))
 
-# - Can't include these in `selectors`. If we did, `step_interact()` would break
-#   since it differentiates between named selector functions and formula ops
-#   like `-`.
-# - `:` is not included here. We select using `info$variable` of the term info,
-#   and I am not sure that the ordering given there always matches the order
-#   of columns in the training data.
-ops_tidyselect <- c("&", "|", "!", "-")
-ops_formula <- c("~", "+", "-")
-
 ## This flags formulas that are not allowed. When called from `recipe.formula`
 ## `allowed` is NULL.
 element_check <- function(x, allowed = selectors) {
   funs <- fun_calls(x)
-  funs <- funs[!(funs %in% ops_formula)]
-  funs <- funs[!(funs %in% ops_tidyselect)]
+  funs <- funs[!(funs %in% c("~", "+", "-"))]
   # i.e. tidyselect::matches()
   funs <- funs[!(funs %in% c("::", "tidyselect", "dplyr", "recipes"))]
   if (!is.null(allowed)) {

--- a/R/selections.R
+++ b/R/selections.R
@@ -235,7 +235,12 @@ abort_selection <- exiting(function(cnd) {
 })
 
 eval_select_recipes <- function(quos, data, info) {
-  nested_info <- nest_current_info(info)
+  # Maintain ordering between `data` column names and `info$variable` so
+  # `eval_select()` and recipes selectors return compatible positions
+  data_info <- tibble(variable = names(data))
+  data_info <- left_join(data_info, info, by = "variable")
+
+  nested_info <- nest_current_info(data_info)
 
   local_current_info(nested_info)
 

--- a/R/selections.R
+++ b/R/selections.R
@@ -234,7 +234,7 @@ abort_selection <- exiting(function(cnd) {
   abort("No variables or terms were selected.")
 })
 
-eval_step_select <- function(quos, data, info) {
+eval_select_recipes <- function(quos, data, info) {
   nested_info <- nest_current_info(info)
 
   local_current_info(nested_info)

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -71,7 +71,7 @@ step_shuffle_new <- function(terms, role, trained, columns, skip, id) {
 
 #' @export
 prep.step_shuffle <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   step_shuffle_new(
     terms = x$terms,
     role = x$role,

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -71,7 +71,7 @@ step_shuffle_new <- function(terms, role, trained, columns, skip, id) {
 
 #' @export
 prep.step_shuffle <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   step_shuffle_new(
     terms = x$terms,
     role = x$role,

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -100,7 +100,7 @@ step_spatialsign_new <-
 
 #' @export
 prep.step_spatialsign <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   check_type(training[, col_names])
 

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -100,7 +100,8 @@ step_spatialsign_new <-
 
 #' @export
 prep.step_spatialsign <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
+
   check_type(training[, col_names])
 
   step_spatialsign_new(

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -76,7 +76,7 @@ step_sqrt_new <-
 
 #' @export
 prep.step_sqrt <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   step_sqrt_new(

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -76,7 +76,7 @@ step_sqrt_new <-
 
 #' @export
 prep.step_sqrt <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   step_sqrt_new(

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -104,7 +104,7 @@ get_ord_lvls <- function(x)
 
 #' @export
 prep.step_string2factor <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   str_check <-
     vapply(
       training[, col_names],

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -104,7 +104,7 @@ get_ord_lvls <- function(x)
 
 #' @export
 prep.step_string2factor <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   str_check <-
     vapply(
       training[, col_names],

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -94,7 +94,7 @@ step_unknown_new <-
 
 #' @export
 prep.step_unknown <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   col_check <- dplyr::filter(info, variable %in% col_names)
   if (any(col_check$type != "nominal"))
     rlang::abort(

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -94,7 +94,7 @@ step_unknown_new <-
 
 #' @export
 prep.step_unknown <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   col_check <- dplyr::filter(info, variable %in% col_names)
   if (any(col_check$type != "nominal"))
     rlang::abort(

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -77,7 +77,7 @@ step_unorder_new <-
 
 #' @export
 prep.step_unorder <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   order_check <- vapply(training[, col_names],
                         is.ordered,
                         logical(1L))

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -77,7 +77,7 @@ step_unorder_new <-
 
 #' @export
 prep.step_unorder <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   order_check <- vapply(training[, col_names],
                         is.ordered,
                         logical(1L))

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -144,7 +144,7 @@ step_upsample_new <-
 
 #' @export
 prep.step_upsample <- function(x, training, info = NULL, ...) {
-  col_name <- eval_step_select(x$terms, training, info)
+  col_name <- eval_select_recipes(x$terms, training, info)
 
   if (length(col_name) != 1)
     rlang::abort("Please select a single factor variable.")

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -144,7 +144,8 @@ step_upsample_new <-
 
 #' @export
 prep.step_upsample <- function(x, training, info = NULL, ...) {
-  col_name <- terms_select(x$terms, info = info)
+  col_name <- eval_step_select(x$terms, training, info)
+
   if (length(col_name) != 1)
     rlang::abort("Please select a single factor variable.")
   if (!is.factor(training[[col_name]]))

--- a/R/window.R
+++ b/R/window.R
@@ -188,7 +188,7 @@ step_window_new <-
 
 #' @export
 prep.step_window <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
 
   if (any(info$type[info$variable %in% col_names] != "numeric"))
     rlang::abort("The selected variables should be numeric")

--- a/R/window.R
+++ b/R/window.R
@@ -188,7 +188,7 @@ step_window_new <-
 
 #' @export
 prep.step_window <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
 
   if (any(info$type[info$variable %in% col_names] != "numeric"))
     rlang::abort("The selected variables should be numeric")

--- a/R/zv.R
+++ b/R/zv.R
@@ -91,7 +91,7 @@ one_unique <- function(x) {
 
 #' @export
 prep.step_zv <- function(x, training, info = NULL, ...) {
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   filter <- vapply(training[, col_names], one_unique, logical(1))
 
   step_zv_new(

--- a/R/zv.R
+++ b/R/zv.R
@@ -91,7 +91,7 @@ one_unique <- function(x) {
 
 #' @export
 prep.step_zv <- function(x, training, info = NULL, ...) {
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   filter <- vapply(training[, col_names], one_unique, logical(1))
 
   step_zv_new(

--- a/inst/boilerplate.R
+++ b/inst/boilerplate.R
@@ -119,7 +119,7 @@ create_generator <- function(name, which) {
 create_prep_method <- function(name, which) {
   glue('
 prep.{which}_{name} <- function(x, training, info = NULL, ...) {{
-  col_names <- eval_step_select(x$terms, training, info)
+  col_names <- eval_select_recipes(x$terms, training, info)
   check_type(training[, col_names])
 
   <prepping action here>

--- a/inst/boilerplate.R
+++ b/inst/boilerplate.R
@@ -119,7 +119,7 @@ create_generator <- function(name, which) {
 create_prep_method <- function(name, which) {
   glue('
 prep.{which}_{name} <- function(x, training, info = NULL, ...) {{
-  col_names <- terms_select(x$terms, info = info)
+  col_names <- eval_step_select(x$terms, training, info)
   check_type(training[, col_names])
 
   <prepping action here>

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -3,7 +3,7 @@
 \name{selections}
 \alias{selections}
 \alias{selection}
-\title{Methods for Select Variables in Step Functions}
+\title{Methods for Selecting Variables in Step Functions}
 \description{
 When selecting variables or model terms in \code{step}
 functions, \code{dplyr}-like tools are used. The \emph{selector} functions
@@ -14,7 +14,7 @@ stated in the step function, this might be similar to:
 
 \preformatted{
   recipe( ~ ., data = USArrests) \%>\%
-    step_pca(Murder, Assault, UrbanPop, Rape, num = 3)
+    step_pca(Murder, Assault, UrbanPop, Rape, num_comp = 3)
 }
 
 The first four arguments indicate which variables should be
@@ -24,8 +24,6 @@ to \code{\link[=step_pca]{step_pca()}}.
 Note that:
 
 \enumerate{
-\item The selector arguments should not contain functions
-beyond those supported (see below).
 \item These arguments are not evaluated until the \code{prep}
 function for the step is executed.
 \item The \code{dplyr}-like syntax allows for negative signs to
@@ -42,6 +40,7 @@ Also, select helpers from the \code{tidyselect} package can also be used:
 \code{\link[tidyselect:starts_with]{tidyselect::num_range()}}, \code{\link[tidyselect:everything]{tidyselect::everything()}},
 \code{\link[tidyselect:one_of]{tidyselect::one_of()}}, \code{\link[tidyselect:all_of]{tidyselect::all_of()}}, and
 \code{\link[tidyselect:all_of]{tidyselect::any_of()}}
+
 For example:
 
 \preformatted{
@@ -51,18 +50,14 @@ For example:
 
 would only select \code{Sepal.Length}
 
-\strong{Inline} functions that specify computations, such as
-\code{log(x)}, should not be used in selectors and will produce an
-error. A list of allowed selector functions is below.
-
 Columns of the design matrix that may not exist when the step
 is coded can also be selected. For example, when using
-\code{step_pca}, the number of columns created by feature extraction
+\code{step_pca()}, the number of columns created by feature extraction
 may not be known when subsequent steps are defined. In this
 case, using \code{matches("^PC")} will select all of the columns
 whose names start with "PC" \emph{once those columns are created}.
 
-There are sets of functions that can be used to select
+There are sets of recipes specific functions that can be used to select
 variables based on their role or type: \code{\link[=has_role]{has_role()}} and
 \code{\link[=has_type]{has_type()}}. For convenience, there are also functions that are
 more specific: \code{\link[=all_numeric]{all_numeric()}}, \code{\link[=all_nominal]{all_nominal()}},
@@ -87,18 +82,11 @@ must be embedded in a model formula (as opposed to a sequence
 of selectors). For example, the interaction specification
 could be \code{~ starts_with("Species"):Sepal.Width}. This can be
 useful if \code{Species} was converted to dummy variables
-previously using \code{\link[=step_dummy]{step_dummy()}}.
-
-The complete list of allowable functions in steps:
-
-\itemize{
-\item \strong{By name}: \code{\link[tidyselect:starts_with]{tidyselect::starts_with()}},
-\code{\link[tidyselect:starts_with]{tidyselect::ends_with()}}, \code{\link[tidyselect:starts_with]{tidyselect::contains()}},
-\code{\link[tidyselect:starts_with]{tidyselect::matches()}}, \code{\link[tidyselect:starts_with]{tidyselect::num_range()}},
-\code{\link[tidyselect:everything]{tidyselect::everything()}}
-\item \strong{By role}: \code{\link[=has_role]{has_role()}},
-\code{\link[=all_predictors]{all_predictors()}}, and \code{\link[=all_outcomes]{all_outcomes()}}
-\item \strong{By type}: \code{\link[=has_type]{has_type()}}, \code{\link[=all_numeric]{all_numeric()}},
-and \code{\link[=all_nominal]{all_nominal()}}
-}
+previously using \code{\link[=step_dummy]{step_dummy()}}. The implementation of
+\code{step_interact()} is special, and is more restricted than
+the other step functions. Only the selector functions from
+recipes and tidyselect are allowed. User defined selector functions
+will not be recognized. Additionally, the tidyselect domain specific
+language is not recognized here, meaning that \code{&}, \code{|}, \code{!}, and \code{-}
+will not work.
 }

--- a/man/summary.recipe.Rd
+++ b/man/summary.recipe.Rd
@@ -34,7 +34,7 @@ row in the summary tibble.
 \examples{
 rec <- recipe( ~ ., data = USArrests)
 summary(rec)
-rec <- step_pca(rec, all_numeric(), num = 3)
+rec <- step_pca(rec, all_numeric(), num_comp = 3)
 summary(rec) # still the same since not yet trained
 rec <- prep(rec, training = USArrests)
 summary(rec)

--- a/tests/testthat/test_bake.R
+++ b/tests/testthat/test_bake.R
@@ -8,3 +8,16 @@ test_that("order of columns after juice and bake",{
   car_preped <- prep(car_rec, training = mtcars)
   expect_equal(colnames(juice(car_preped)), colnames(bake(car_preped, new_data = mtcars)))
 })
+
+test_that("can use tidyselect ops in bake() and juice() column selection", {
+  car_rec <- recipe(cyl ~ ., mtcars) %>%
+    step_center(all_predictors())
+
+  car_prepped <- prep(car_rec, training = mtcars)
+
+  x <- bake(car_prepped, mtcars, where(is.numeric) & starts_with("c") & !cyl)
+  y <- juice(car_prepped, where(is.numeric) & starts_with("c") & !cyl)
+
+  expect_named(x, "carb")
+  expect_named(y, "carb")
+})

--- a/tests/testthat/test_column_order.R
+++ b/tests/testthat/test_column_order.R
@@ -48,10 +48,28 @@ test_that('skipped steps', {
     step_corr(all_predictors(), threshold = .6, skip = TRUE) %>%
     prep()
 
-  cols_1 <- c("hydrogen", "nitrogen", "sulfur", "HHV", "oxygen_o_carbon")
+  cols_1 <- c(
+    "hydrogen",
+    "nitrogen",
+    "sulfur",
+    "HHV",
+    "oxygen_o_carbon"
+  )
 
-  cols_2 <- c("hydrogen", "nitrogen", "sulfur", "HHV", "oxygen_o_carbon",
-              "carbon", "oxygen", "hydrogen_o_carbon", "nitrogen_o_carbon")
+  # Ordering relative to the original specification of the recipe is
+  # preserved (i.e. carbon was the first column specified, and since we
+  # skipped the step that would drop it, it appears first in the result)
+  cols_2 <- c(
+    "carbon",
+    "hydrogen",
+    "oxygen",
+    "nitrogen",
+    "sulfur",
+    "HHV",
+    "hydrogen_o_carbon",
+    "oxygen_o_carbon",
+    "nitrogen_o_carbon"
+  )
 
   expect_equal(
     names(juice(rec_2)),

--- a/tests/testthat/test_interact.R
+++ b/tests/testthat/test_interact.R
@@ -95,6 +95,38 @@ test_that('using selectors', {
   expect_equivalent(te_og, te_new)
 })
 
+test_that("using where() works", {
+  ex_rec <- rec %>%
+    step_dummy(z) %>%
+    step_interact( ~ where(is.numeric):x1)
+
+  x <- prep(ex_rec, dat_tr)
+
+  expr <- x$steps[[2]]$terms[[2]]
+  expect <- expr((x1 + x2 + x3 + x4 + x5 + y + z_b + z_c):x1)
+
+  expect_equal(
+    expr,
+    expect
+  )
+})
+
+test_that("using all_of() works", {
+  xvars <- c("x2", "x3")
+
+  ex_rec <- rec %>%
+    step_interact( ~ all_of(xvars):x1)
+
+  x <- prep(ex_rec, dat_tr)
+
+  expr <- x$steps[[1]]$terms[[2]]
+  expect <- expr((x2 + x3):x1)
+
+  expect_equal(
+    expr,
+    expect
+  )
+})
 
 test_that('printing', {
   int_rec <- rec %>% step_interact(~x1:x2)

--- a/tests/testthat/test_select_terms.R
+++ b/tests/testthat/test_select_terms.R
@@ -122,25 +122,6 @@ test_that('namespaced selectors', {
   )
 })
 
-test_that("tidyselect ops &, |, !, - work", {
-  x <- c("age", "diet")
-
-  expect_identical(
-    terms_select(info = info1, quos(all_of(x) | all_nominal())),
-    c("age", "diet", "location", "Class")
-  )
-
-  expect_identical(
-    terms_select(info = info1, quos(all_of(x), -all_nominal())),
-    "age"
-  )
-
-  expect_identical(
-    terms_select(info = info1, quos(all_predictors() & !all_nominal())),
-    c("age", "height", "date")
-  )
-})
-
 test_that('new dplyr selectors', {
   skip_if(tidyselect_pre_1.0.0())
 

--- a/tests/testthat/test_select_terms.R
+++ b/tests/testthat/test_select_terms.R
@@ -122,7 +122,24 @@ test_that('namespaced selectors', {
   )
 })
 
+test_that("tidyselect ops &, |, !, - work", {
+  x <- c("age", "diet")
 
+  expect_identical(
+    terms_select(info = info1, quos(all_of(x) | all_nominal())),
+    c("age", "diet", "location", "Class")
+  )
+
+  expect_identical(
+    terms_select(info = info1, quos(all_of(x), -all_nominal())),
+    "age"
+  )
+
+  expect_identical(
+    terms_select(info = info1, quos(all_predictors() & !all_nominal())),
+    c("age", "height", "date")
+  )
+})
 
 test_that('new dplyr selectors', {
   skip_if(tidyselect_pre_1.0.0())

--- a/tests/testthat/test_skipping.R
+++ b/tests/testthat/test_skipping.R
@@ -67,15 +67,31 @@ test_that('skips for steps that remove columns (#239)', {
   prep_simple <- prep(simple_ex, iris)
   simple_juiced <- juice(prep_simple)
   simple_baked <- bake(prep_simple, new_data = iris)
+
   expect_equal(
     names(simple_juiced),
-    c("Sepal.Width", "Petal.Length", "Petal.Width", "Species",
-      "Sepal.Length_x_Sepal.Width")
+    c(
+      "Sepal.Width",
+      "Petal.Length",
+      "Petal.Width",
+      "Species",
+      "Sepal.Length_x_Sepal.Width"
+    )
   )
+
+  # Ordering relative to the original specification of the recipe is
+  # preserved (i.e. Sepal.Length was the first column specified, and since we
+  # skipped the step that would drop it, it appears first in the result)
   expect_equal(
     names(simple_baked),
-    c("Sepal.Width", "Petal.Length", "Petal.Width", "Species",
-      "Sepal.Length_x_Sepal.Width", "Sepal.Length")
+    c(
+      "Sepal.Length",
+      "Sepal.Width",
+      "Petal.Length",
+      "Petal.Width",
+      "Species",
+      "Sepal.Length_x_Sepal.Width"
+    )
   )
 
   complex_ex <-
@@ -95,7 +111,7 @@ test_that('skips for steps that remove columns (#239)', {
   )
   expect_equal(
     names(complex_baked),
-    c("Petal.Length", "Petal.Width", "Species", "PC2", "PC1")
+    c("Petal.Length", "Petal.Width", "Species", "PC1", "PC2")
   )
 
   iris_dups <-
@@ -116,6 +132,19 @@ test_that('skips for steps that remove columns (#239)', {
   expect_equal(
     names(corr_juiced),
     c('Sepal.Length', 'Petal.Width', 'dup_2', 'Species')
+  )
+
+  expect_equal(
+    names(corr_baked),
+    c(
+      'Sepal.Length',
+      'Sepal.Width',
+      'Petal.Length',
+      'Petal.Width',
+      'dup_1',
+      'dup_2',
+      'Species'
+    )
   )
 
   expect_equal(


### PR DESCRIPTION
Closes #572 

Don't be alarmed by the number of files changed. Most changes are in `selections.R`, `recipe.R`, and `roles.R`.

With this PR, recipes now supports the entire modern tidyselect DSL. This includes:

- The ops `&`, `|`, `!` and `-`

- The new `where()` function

- Using `c()` to specify multiple variables at once

- User created specified selector functions

- We still support the recipes specific selector functions

This is supported in all of the `step_*()` functions. Additionally, it is supported in `add_role()`, `update_role()`, and `remove_role()`. It is also supported in `bake()` and `juice()`.

Notably, `step_interact()` has gained support for `where()`, but cannot use the tidyselect ops like `&` or `|`. Mixing these with the formula syntax is just too weird. I've updated the selection docs to note that it is more restricted.

This is accomplished by essentially deprecating `terms_select()` in favor of `eval_select_recipes()`. We no longer use `terms_select()` or `element_check()` internally, but since we export `terms_select()`, it has to stick around.

In the process of updating `bake()` and `juice()`, I had to do a little rewriting of those functions. One side effect of this is that when you have a skipped step that would have otherwise dropped columns from the test set, the ordering of those columns that didn't get dropped has now changed slightly. It used to be relative to the training set (where the dropping happened), but now it is relative to the original recipe, which I think is more intuitive.

These are fairly big changes, so it would be nice to run full revdeps with this branch before merging. It would also be nice to run against extrachecks and maybe the book.