### PR TITLE
Add warning when `step_unknown()` creates new NA values

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -231,14 +231,14 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   )
 }
 
-warn_new_levels <- function(dat, lvl, ...) {
+warn_new_levels <- function(dat, lvl, details = NULL) {
   ind <- which(!(dat %in% lvl))
   if (length(ind) > 0) {
     lvl2 <- unique(dat[ind])
     rlang::warn(
       paste0("There are new levels in a factor: ",
             paste0(lvl2, collapse = ", "),
-            ...
+            details
             )
       )
   }

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -231,13 +231,14 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   )
 }
 
-warn_new_levels <- function(dat, lvl) {
+warn_new_levels <- function(dat, lvl, ...) {
   ind <- which(!(dat %in% lvl))
   if (length(ind) > 0) {
     lvl2 <- unique(dat[ind])
     rlang::warn(
       paste0("There are new levels in a factor: ",
-            paste0(lvl2, collapse = ", ")
+            paste0(lvl2, collapse = ", "),
+            ...
             )
       )
   }

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -135,9 +135,20 @@ bake.step_unknown <- function(object, new_data, ...) {
     new_data[[i]] <-
       ifelse(is.na(new_data[[i]]), object$new_level, as.character(new_data[[i]]))
 
+    new_levels <- c(object$object[[i]], object$new_level)
+
+    if (!all(new_data[[i]] %in% new_levels)) {
+      warn_new_levels(
+        new_data[[i]],
+        new_levels,
+        paste0("\nNew levels will be coerced to `NA` by `step_unknown()`",
+               "\nConsider using `step_novel()` before `step_unknown()`")
+      )
+    }
+
     new_data[[i]] <-
       factor(new_data[[i]],
-             levels = c(object$object[[i]], object$new_level),
+             levels = new_levels,
              ordered = attributes(object$object[[i]])$is_ordered)
   }
   if (!is_tibble(new_data)) {

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -141,8 +141,8 @@ bake.step_unknown <- function(object, new_data, ...) {
       warn_new_levels(
         new_data[[i]],
         new_levels,
-        paste0("\nNew levels will be coerced to `NA` by `step_unknown()`",
-               "\nConsider using `step_novel()` before `step_unknown()`")
+        paste0("\nNew levels will be coerced to `NA` by `step_unknown()`.",
+               "\nConsider using `step_novel()` before `step_unknown()`.")
       )
     }
 

--- a/tests/testthat/test_unknown.R
+++ b/tests/testthat/test_unknown.R
@@ -29,7 +29,10 @@ test_that('basic functionality', {
   expect_equal(loc_lvl, levels(tr_1$location))
 
 
-  te_1 <- bake(rec_1, okc_te)
+  expect_warning(
+    te_1 <- bake(rec_1, okc_te),
+    "There are new levels in a factor: port costa"
+  )
   te_diet <- te_1$diet[is.na(okc_te$diet)]
   te_diet <- unique(as.character(te_diet))
   expect_true(all(te_diet == "unknown"))


### PR DESCRIPTION
Closes #494 

The point of `step_unknown()` is to replace `NA` values, but when applied to new data that has a novel factor level, the novel factor level is coerced to `NA`, after the "original" `NA` values have been replaced. This is largely as intended/designed, but can be confusing. This PR adds a warning:

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step

a <- tibble(y = 1:4, x = factor(c(letters[1:3], NA)))
b <- tibble(y = 1:5, x = factor(c(letters[1:4], NA)))

## new warning generated
recipe(y ~ ., data = a) %>% 
  step_unknown(all_nominal(), new_level = "missing") %>%
  step_novel(all_nominal()) %>%
  prep() %>% 
  bake(b)
#> Warning: There are new levels in a factor: d
#> New levels will be coerced to `NA` by `step_unknown()`
#> Consider using `step_novel()` before `step_unknown()`
#> # A tibble: 5 x 2
#>   x           y
#>   <fct>   <int>
#> 1 a           1
#> 2 b           2
#> 3 c           3
#> 4 <NA>        4
#> 5 missing     5

## working great; no warning
recipe(y ~ ., data = a) %>% 
  step_novel(all_nominal()) %>%
  step_unknown(all_nominal(), new_level = "missing") %>%
  prep() %>% 
  bake(b)
#> # A tibble: 5 x 2
#>   x           y
#>   <fct>   <int>
#> 1 a           1
#> 2 b           2
#> 3 c           3
#> 4 new         4
#> 5 missing     5
```

<sup>Created on 2020-12-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>