### PR TITLE
Update documentation for many variable situations, step_interact()

### DIFF
--- a/R/bs.R
+++ b/R/bs.R
@@ -15,7 +15,10 @@
 #'  used as predictors in a model.
 #' @param objects A list of [splines::bs()] objects
 #'  created once the step has been trained.
-#' @param deg_free The degrees of freedom.
+#' @param deg_free The degrees of freedom for the spline. As the
+#'  degrees of freedom for a spline increase, more flexible and
+#'  complex curves can be generated. When a single degree of freedom is used,
+#'  the result is a rescaled version of the original data.
 #' @param degree Degree of polynomial spline (integer).
 #' @param options A list of options for [splines::bs()]
 #'  which should not include `x`, `degree`, or `df`.

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -63,24 +63,24 @@
 
 #' @examples
 #' library(modeldata)
-#' data(okc)
-#' okc <- okc[complete.cases(okc),]
+#' data(penguins)
+#' penguins <- penguins %>% na.omit()
 #'
-#' rec <- recipe(~ diet + age + height, data = okc)
+#' rec <- recipe(flipper_length_mm ~., data = penguins)
 #'
 #' int_mod_1 <- rec %>%
-#'   step_interact(terms = ~ age:height)
+#'   step_interact(terms = ~ bill_depth_mm:bill_length_mm)
 #'
 #' # specify all dummy variables succinctly with `starts_with()`
 #' int_mod_2 <- rec %>%
-#'   step_dummy(diet) %>%
-#'   step_interact(terms = ~ age:starts_with("diet"))
+#'   step_dummy(sex, species, island) %>%
+#'   step_interact(terms = ~ body_mass_g:starts_with("species"))
 #'
-#' int_mod_1 <- prep(int_mod_1, training = okc)
-#' int_mod_2 <- prep(int_mod_2, training = okc)
+#' int_mod_1 <- prep(int_mod_1, training = penguins)
+#' int_mod_2 <- prep(int_mod_2, training = penguins)
 #'
-#' dat_1 <- bake(int_mod_1, okc)
-#' dat_2 <- bake(int_mod_2, okc)
+#' dat_1 <- bake(int_mod_1, penguins)
+#' dat_2 <- bake(int_mod_2, penguins)
 #'
 #' names(dat_1)
 #' names(dat_2)

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -7,7 +7,8 @@
 #' @inheritParams step_center
 #' @param ... One or more selector functions to choose which
 #'  variables are affected by the step. See [selections()]
-#'  for more details. For the `tidy` method, these are not
+#'  for more details, and consider using [tidyselect::starts_with()] when
+#'  dummy variables have been created. For the `tidy` method, these are not
 #'  currently used.
 #' @param terms A traditional R formula that contains interaction
 #'  terms. This can include `.` and selectors.
@@ -62,31 +63,30 @@
 
 #' @examples
 #' library(modeldata)
-#' data(biomass)
+#' data(okc)
+#' okc <- okc[complete.cases(okc),]
 #'
-#' biomass_tr <- biomass[biomass$dataset == "Training",]
-#' biomass_te <- biomass[biomass$dataset == "Testing",]
-#'
-#' rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
-#'               data = biomass_tr)
+#' rec <- recipe(~ diet + age + height, data = okc)
 #'
 #' int_mod_1 <- rec %>%
-#'   step_interact(terms = ~ carbon:hydrogen)
+#'   step_interact(terms = ~ age:height)
 #'
+#' # specify all dummy variables succinctly with `starts_with()`
 #' int_mod_2 <- rec %>%
-#'   step_interact(terms = ~ (matches("gen$") + sulfur)^2)
+#'   step_dummy(diet) %>%
+#'   step_interact(terms = ~ age:starts_with("diet"))
 #'
-#' int_mod_1 <- prep(int_mod_1, training = biomass_tr)
-#' int_mod_2 <- prep(int_mod_2, training = biomass_tr)
+#' int_mod_1 <- prep(int_mod_1, training = okc)
+#' int_mod_2 <- prep(int_mod_2, training = okc)
 #'
-#' dat_1 <- bake(int_mod_1, biomass_te)
-#' dat_2 <- bake(int_mod_2, biomass_te)
+#' dat_1 <- bake(int_mod_1, okc)
+#' dat_2 <- bake(int_mod_2, okc)
 #'
 #' names(dat_1)
 #' names(dat_2)
 #'
 #' tidy(int_mod_1, number = 1)
-#' tidy(int_mod_2, number = 1)
+#' tidy(int_mod_2, number = 2)
 
 step_interact <-
   function(recipe,

--- a/R/ns.R
+++ b/R/ns.R
@@ -13,7 +13,9 @@
 #'  role should they be assigned?. By default, the function assumes
 #'  that the new columns created from the original variables will be
 #'  used as predictors in a model.
-#' @param deg_free The degrees of freedom.
+#' @param deg_free The degrees of freedom for the natural spline. As the
+#'  degrees of freedom for a natural spline increase, more flexible and
+#'  complex curves can be generated.
 #' @param objects A list of [splines::ns()] objects
 #'  created once the step has been trained.
 #' @param options A list of options for [splines::ns()]

--- a/R/ns.R
+++ b/R/ns.R
@@ -15,7 +15,8 @@
 #'  used as predictors in a model.
 #' @param deg_free The degrees of freedom for the natural spline. As the
 #'  degrees of freedom for a natural spline increase, more flexible and
-#'  complex curves can be generated.
+#'  complex curves can be generated. When a single degree of freedom is used,
+#'  the result is a rescaled version of the original data.
 #' @param objects A list of [splines::ns()] objects
 #'  created once the step has been trained.
 #' @param options A list of options for [splines::ns()]

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -30,7 +30,8 @@ recipe.default <- function(x, ...)
 #'  (e.g. `log(x)`, `x:y`, etc.) and minus signs are not allowed. These types of
 #'  transformations should be enacted using `step` functions in this package.
 #'  Dots are allowed as are simple multivariate outcome terms (i.e. no need for
-#'  `cbind`; see Examples).
+#'  `cbind`; see Examples). A model formula may not be the best choice for
+#'  high-dimensional data with many columns, because of problems with memory.
 #' @param x,data A data frame or tibble of the *template* data set
 #'   (see below).
 #' @return An object of class `recipe` with sub-objects:
@@ -59,7 +60,9 @@ recipe.default <- function(x, ...)
 #'
 #' Alternatively, a `recipe` object can be created by first specifying
 #'   which variables in a data set should be used and then sequentially
-#'   defining their roles (see the last example).
+#'   defining their roles (see the last example). This alternative is an
+#'   excellent choice when the number of variables is very high, as the
+#'   formula method is memory-inefficient with many variables.
 #'
 #' There are two different types of operations that can be
 #'  sequentially added to a recipe. **Steps**  can include common
@@ -136,7 +139,9 @@ recipe.default <- function(x, ...)
 #' results <- bake(multi_y_trained, biomass_te)
 #'
 #' ###############################################
-#' # Creating a recipe manually with different roles
+#' # example with manually updating different roles
+#'
+#' # best choice for high-dimensional data:
 #'
 #' rec <- recipe(biomass_tr) %>%
 #'   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -29,7 +29,8 @@ used).}
 (e.g. \code{log(x)}, \code{x:y}, etc.) and minus signs are not allowed. These types of
 transformations should be enacted using \code{step} functions in this package.
 Dots are allowed as are simple multivariate outcome terms (i.e. no need for
-\code{cbind}; see Examples).}
+\code{cbind}; see Examples). A model formula may not be the best choice for
+high-dimensional data with many columns, because of problems with memory.}
 
 \item{vars}{A character string of column names corresponding to variables
 that will be used in any context (see below)}
@@ -71,7 +72,9 @@ functions such as \code{log(x3)}. An example is given below.
 
 Alternatively, a \code{recipe} object can be created by first specifying
 which variables in a data set should be used and then sequentially
-defining their roles (see the last example).
+defining their roles (see the last example). This alternative is an
+excellent choice when the number of variables is very high, as the
+formula method is memory-inefficient with many variables.
 
 There are two different types of operations that can be
 sequentially added to a recipe. \strong{Steps}  can include common
@@ -147,7 +150,9 @@ multi_y_trained <- prep(multi_y, training = biomass_tr)
 results <- bake(multi_y_trained, biomass_te)
 
 ###############################################
-# Creating a recipe manually with different roles
+# example with manually updating different roles
+
+# best choice for high-dimensional data:
 
 rec <- recipe(biomass_tr) \%>\%
   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -37,7 +37,10 @@ used as predictors in a model.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{deg_free}{The degrees of freedom.}
+\item{deg_free}{The degrees of freedom for the spline. As the
+degrees of freedom for a spline increase, more flexible and
+complex curves can be generated. When a single degree of freedom is used,
+the result is a rescaled version of the original data.}
 
 \item{degree}{Degree of polynomial spline (integer).}
 

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -104,6 +104,7 @@ all two-way interactions are created.
 \examples{
 library(modeldata)
 data(okc)
+okc <- okc[complete.cases(okc),]
 
 rec <- recipe(~ diet + age + height, data = okc)
 

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -103,24 +103,24 @@ all two-way interactions are created.
 }
 \examples{
 library(modeldata)
-data(okc)
-okc <- okc[complete.cases(okc),]
+data(penguins)
+penguins <- penguins \%>\% na.omit()
 
-rec <- recipe(~ diet + age + height, data = okc)
+rec <- recipe(flipper_length_mm ~., data = penguins)
 
 int_mod_1 <- rec \%>\%
-  step_interact(terms = ~ age:height)
+  step_interact(terms = ~ bill_depth_mm:bill_length_mm)
 
 # specify all dummy variables succinctly with `starts_with()`
 int_mod_2 <- rec \%>\%
-  step_dummy(diet) \%>\%
-  step_interact(terms = ~ age:starts_with("diet"))
+  step_dummy(sex, species, island) \%>\%
+  step_interact(terms = ~ body_mass_g:starts_with("species"))
 
-int_mod_1 <- prep(int_mod_1, training = okc)
-int_mod_2 <- prep(int_mod_2, training = okc)
+int_mod_1 <- prep(int_mod_1, training = penguins)
+int_mod_2 <- prep(int_mod_2, training = penguins)
 
-dat_1 <- bake(int_mod_1, okc)
-dat_2 <- bake(int_mod_2, okc)
+dat_1 <- bake(int_mod_1, penguins)
+dat_2 <- bake(int_mod_2, penguins)
 
 names(dat_1)
 names(dat_2)

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -53,7 +53,8 @@ the computations for subsequent operations}
 
 \item{...}{One or more selector functions to choose which
 variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details. For the \code{tidy} method, these are not
+for more details, and consider using \code{\link[tidyselect:starts_with]{tidyselect::starts_with()}} when
+dummy variables have been created. For the \code{tidy} method, these are not
 currently used.}
 }
 \value{
@@ -102,31 +103,29 @@ all two-way interactions are created.
 }
 \examples{
 library(modeldata)
-data(biomass)
+data(okc)
 
-biomass_tr <- biomass[biomass$dataset == "Training",]
-biomass_te <- biomass[biomass$dataset == "Testing",]
-
-rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
-              data = biomass_tr)
+rec <- recipe(~ diet + age + height, data = okc)
 
 int_mod_1 <- rec \%>\%
-  step_interact(terms = ~ carbon:hydrogen)
+  step_interact(terms = ~ age:height)
 
+# specify all dummy variables succinctly with `starts_with()`
 int_mod_2 <- rec \%>\%
-  step_interact(terms = ~ (matches("gen$") + sulfur)^2)
+  step_dummy(diet) \%>\%
+  step_interact(terms = ~ age:starts_with("diet"))
 
-int_mod_1 <- prep(int_mod_1, training = biomass_tr)
-int_mod_2 <- prep(int_mod_2, training = biomass_tr)
+int_mod_1 <- prep(int_mod_1, training = okc)
+int_mod_2 <- prep(int_mod_2, training = okc)
 
-dat_1 <- bake(int_mod_1, biomass_te)
-dat_2 <- bake(int_mod_2, biomass_te)
+dat_1 <- bake(int_mod_1, okc)
+dat_2 <- bake(int_mod_2, okc)
 
 names(dat_1)
 names(dat_2)
 
 tidy(int_mod_1, number = 1)
-tidy(int_mod_2, number = 1)
+tidy(int_mod_2, number = 2)
 }
 \concept{model_specification}
 \concept{preprocessing}

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -39,7 +39,9 @@ preprocessing have been estimated.}
 \item{objects}{A list of \code{\link[splines:ns]{splines::ns()}} objects
 created once the step has been trained.}
 
-\item{deg_free}{The degrees of freedom.}
+\item{deg_free}{The degrees of freedom for the natural spline. As the
+degrees of freedom for a natural spline increase, more flexible and
+complex curves can be generated.}
 
 \item{options}{A list of options for \code{\link[splines:ns]{splines::ns()}}
 which should not include \code{x} or \code{df}.}

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -41,7 +41,8 @@ created once the step has been trained.}
 
 \item{deg_free}{The degrees of freedom for the natural spline. As the
 degrees of freedom for a natural spline increase, more flexible and
-complex curves can be generated.}
+complex curves can be generated. When a single degree of freedom is used,
+the result is a rescaled version of the original data.}
 
 \item{options}{A list of options for \code{\link[splines:ns]{splines::ns()}}
 which should not include \code{x} or \code{df}.}


### PR DESCRIPTION
This PR contains two updates to documentation:

## Advice to avoid formula interface for high-dimensional data

Closes #548 and #567 
The changes in the documentation for `recipe()` guide folks to use `update_role()` instead of the formula interface when they have many variables, to avoid problems with excessive memory use.

## Info on selectors for `step_interact()`

Closes #610
This new example and improvements to documentation more explicitly show folks how to use `starts_with()` when they have dummy variables.