### PR TITLE
made the threshold argument of step_pca() tunable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* The `threshold`argument of `step_pca()` is now `tunable()` (#534).
+
 # recipes 0.1.15
 
 * The full tidyselect DSL is now allowed inside recipes `step_*()` functions. This includes the operators `&`, `|`, `-` and `!` and the new `where()` function. Additionally, the restriction preventing user defined selectors from being used has been lifted (#572).

--- a/R/pca.R
+++ b/R/pca.R
@@ -316,8 +316,11 @@ tidy.step_pca <- function(x, type = "coef", ...) {
 #' @export
 tunable.step_pca <- function(x, ...) {
   tibble::tibble(
-    name = "num_comp",
-    call_info = list(list(pkg = "dials", fun = "num_comp", range = c(1L, 4L))),
+    name = c("num_comp", "threshold"),
+    call_info = list(
+      list(pkg = "dials", fun = "num_comp", range = c(1L, 4L))
+      list(pkg = "dials", fun = "threshold")
+    ),
     source = "recipe",
     component = "step_pca",
     component_id = x$id

--- a/R/pca.R
+++ b/R/pca.R
@@ -318,7 +318,7 @@ tunable.step_pca <- function(x, ...) {
   tibble::tibble(
     name = c("num_comp", "threshold"),
     call_info = list(
-      list(pkg = "dials", fun = "num_comp", range = c(1L, 4L))
+      list(pkg = "dials", fun = "num_comp", range = c(1L, 4L)),
       list(pkg = "dials", fun = "threshold")
     ),
     source = "recipe",

--- a/tests/testthat/test_pca.R
+++ b/tests/testthat/test_pca.R
@@ -147,10 +147,10 @@ test_that('tunable', {
     recipe(~ ., data = iris) %>%
     step_pca(all_predictors())
   rec_param <- tunable.step_pca(rec$steps[[1]])
-  expect_equal(rec_param$name, c("num_comp"))
+  expect_equal(rec_param$name, c("num_comp", "threshold"))
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
-  expect_equal(nrow(rec_param), 1)
+  expect_equal(nrow(rec_param), 2)
   expect_equal(
     names(rec_param),
     c('name', 'call_info', 'source', 'component', 'component_id')


### PR DESCRIPTION

This is related to Issue #534 

Set `step_pca(... , threshold = tune())` to call `dials::threshold()`

```r
library(tune)
library(recipes)

rcp <-
   recipe(mtcars, mpg ~ .) %>%
   step_pca(cyl, disp, hp, threshold = tune())

tunable(rcp)

# A tibble: 2 x 5
  name      call_info        source component component_id
  <chr>     <list>           <chr>  <chr>     <chr>
1 num_comp  <named list [3]> recipe step_pca  pca_zMvdl
2 threshold <named list [2]> recipe step_pca  pca_zMvdl
```

As the function documentation does not mention which arguments are tunable, I left it as is.