### PR TITLE
Advice for `NA` values in step_dummy()

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -67,7 +67,8 @@
 #' contrast option via `options`.
 #'
 #' When the factor being converted has a missing value, all of the
-#'  corresponding dummy variables are also missing.
+#'  corresponding dummy variables are also missing. See [step_unknown()] for
+#'  a solution.
 #'
 #' When data to be processed contains novel levels (i.e., not
 #' contained in the training set), a missing value is assigned to

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -273,7 +273,8 @@ bake.step_dummy <- function(object, new_data, ...) {
 
     if (length(attr(object$levels[[i]], "values")) == 1)
       rlang::abort(
-        paste0("Only one factor level in ", orig_var)
+        paste0("Only one factor level in ", orig_var, ": ",
+               attr(object$levels[[i]], "values"))
         )
 
     warn_new_levels(

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -106,7 +106,8 @@ To change the type of contrast being used, change the global
 contrast option via \code{options}.
 
 When the factor being converted has a missing value, all of the
-corresponding dummy variables are also missing.
+corresponding dummy variables are also missing. See \code{\link[=step_unknown]{step_unknown()}} for
+a solution.
 
 When data to be processed contains novel levels (i.e., not
 contained in the training set), a missing value is assigned to


### PR DESCRIPTION
Closes #547 

This PR adds more explicit advice to `step_dummy()`'s documentation about what to do when there are `NA` values in the factor, as well as a little more detail in the error message.

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
df <- tibble(x = factor(rep(c("a", NA), 50), exclude = NULL), 
             y = runif(100))
training_df <- df[1:90, ]
testing_df <- df[91:100, ]

rec <- recipe(y ~ x, training_df) %>% 
  step_dummy(all_predictors())

prep(rec)
#> Error: Only one factor level in x: a
```

<sup>Created on 2020-12-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>