### PR TITLE
Update docs, tidy method for step_dummy

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -88,31 +88,37 @@
 #' data(okc)
 #' okc <- okc[complete.cases(okc),]
 #'
+#' # Original data: diet has 18 levels
+#' length(unique(okc$diet))
+#' unique(okc$diet) %>% sort()
+#'
 #' rec <- recipe(~ diet + age + height, data = okc)
 #'
-#' dummies <- rec %>% step_dummy(diet)
-#' dummies <- prep(dummies, training = okc)
+#' # Default dummy coding: 17 dummy variables
+#' dummies <- rec %>%
+#'     step_dummy(diet) %>%
+#'     prep(training = okc)
 #'
-#' dummy_data <- bake(dummies, new_data = okc)
+#' dummy_data <- bake(dummies, new_data = NULL)
 #'
-#' unique(okc$diet)
-#' grep("^diet", names(dummy_data), value = TRUE)
+#' dummy_data %>%
+#'     select(starts_with("diet")) %>%
+#'     names() # level "anything" is the reference level
 #'
-#' # Obtain the full set of dummy variables using `one_hot` option
-#' rec %>%
-#'   step_dummy(diet, one_hot = TRUE) %>%
-#'   prep(training = okc) %>%
-#'   bake(new_data = NULL, starts_with("diet")) %>%
-#'   names() %>%
-#'   length()
+#' # Obtain the full set of 18 dummy variables using `one_hot` option
+#' dummies_one_hot <- rec %>%
+#'     step_dummy(diet, one_hot = TRUE) %>%
+#'     prep(training = okc)
 #'
-#' length(unique(okc$diet))
+#' dummy_data_one_hot <- bake(dummies_one_hot, new_data = NULL)
 #'
-#' # Without one_hot
-#' length(grep("^diet", names(dummy_data), value = TRUE))
+#' dummy_data_one_hot %>%
+#'     select(starts_with("diet")) %>%
+#'     names() # no reference level
 #'
 #'
 #' tidy(dummies, number = 1)
+#' tidy(dummies_one_hot, number = 1)
 
 
 step_dummy <-
@@ -353,6 +359,9 @@ tidy.step_dummy <- function(x, ...) {
   if (is_trained(x)) {
     if (length(x$levels) > 0) {
       res <- purrr::map_dfr(x$levels, get_dummy_columns, .id = "terms")
+      if (!x$one_hot) {
+        res <- dplyr::slice(res, -1)
+      }
     } else {
       res <- tibble(terms = rlang::na_chr, columns = rlang::na_chr)
     }

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -347,8 +347,10 @@ print.step_dummy <-
   }
 
 
-get_dummy_columns <- function(x) {
-  tibble(columns = attr(x, "values"))
+get_dummy_columns <- function(x, one_hot) {
+  x <- attr(x, "values")
+  if (!one_hot) x <- x[-1]
+  tibble(columns = x)
 }
 
 
@@ -358,10 +360,7 @@ get_dummy_columns <- function(x) {
 tidy.step_dummy <- function(x, ...) {
   if (is_trained(x)) {
     if (length(x$levels) > 0) {
-      res <- purrr::map_dfr(x$levels, get_dummy_columns, .id = "terms")
-      if (!x$one_hot) {
-        res <- dplyr::slice(res, -1)
-      }
+      res <- purrr::map_dfr(x$levels, get_dummy_columns, x$one_hot, .id = "terms")
     } else {
       res <- tibble(terms = rlang::na_chr, columns = rlang::na_chr)
     }

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -123,31 +123,37 @@ library(modeldata)
 data(okc)
 okc <- okc[complete.cases(okc),]
 
+# Original data: diet has 18 levels
+length(unique(okc$diet))
+unique(okc$diet) \%>\% sort()
+
 rec <- recipe(~ diet + age + height, data = okc)
 
-dummies <- rec \%>\% step_dummy(diet)
-dummies <- prep(dummies, training = okc)
+# Default dummy coding: 17 dummy variables
+dummies <- rec \%>\%
+    step_dummy(diet) \%>\%
+    prep(training = okc)
 
-dummy_data <- bake(dummies, new_data = okc)
+dummy_data <- bake(dummies, new_data = NULL)
 
-unique(okc$diet)
-grep("^diet", names(dummy_data), value = TRUE)
+dummy_data \%>\%
+    select(starts_with("diet")) \%>\%
+    names() # level "anything" is the reference level
 
-# Obtain the full set of dummy variables using `one_hot` option
-rec \%>\%
-  step_dummy(diet, one_hot = TRUE) \%>\%
-  prep(training = okc) \%>\%
-  bake(new_data = NULL, starts_with("diet")) \%>\%
-  names() \%>\%
-  length()
+# Obtain the full set of 18 dummy variables using `one_hot` option
+dummies_one_hot <- rec \%>\%
+    step_dummy(diet, one_hot = TRUE) \%>\%
+    prep(training = okc)
 
-length(unique(okc$diet))
+dummy_data_one_hot <- bake(dummies_one_hot, new_data = NULL)
 
-# Without one_hot
-length(grep("^diet", names(dummy_data), value = TRUE))
+dummy_data_one_hot \%>\%
+    select(starts_with("diet")) \%>\%
+    names() # no reference level
 
 
 tidy(dummies, number = 1)
+tidy(dummies_one_hot, number = 1)
 }
 \seealso{
 \code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -46,13 +46,13 @@ test_that('dummy variables with factor inputs', {
       terms = "diet",
       columns = attributes(dummy_trained$steps[[1]]$levels$diet)$values,
       id = ""
-    )
+    ) %>% slice(-1)
   dum_tibble_prepped_2 <-
     tibble(
       terms = "location",
       columns = attributes(dummy_trained$steps[[1]]$levels$location)$values,
       id = ""
-    )
+    ) %>% slice(-1)
   expect_equal(tidy(dummy, 1), dum_tibble)
   expect_equal(
     tidy(dummy_trained, 1),

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -84,7 +84,7 @@ test_that('dummy variables with non-factor inputs', {
 
 test_that('create all dummy variables', {
   rec <- recipe(age ~ location + diet + height, data = okc_fac)
-  dummy <- rec %>% step_dummy(diet, location, one_hot = TRUE)
+  dummy <- rec %>% step_dummy(diet, location, one_hot = TRUE, id = "")
   dummy_trained <- prep(dummy, training = okc_fac, verbose = FALSE, strings_as_factors = FALSE)
   dummy_pred <- bake(dummy_trained, new_data = okc_fac, all_predictors())
   dummy_pred <- dummy_pred[, order(colnames(dummy_pred))]
@@ -101,6 +101,26 @@ test_that('create all dummy variables', {
   exp_res <- as.data.frame(exp_res)
   rownames(exp_res) <- NULL
   expect_equivalent(dummy_pred, exp_res)
+
+  dum_tibble <-
+    tibble(terms = c("diet", "location"), columns = rep(rlang::na_chr, 2), id = "")
+  dum_tibble_prepped_1 <-
+    tibble(
+      terms = "diet",
+      columns = attributes(dummy_trained$steps[[1]]$levels$diet)$values,
+      id = ""
+    )
+  dum_tibble_prepped_2 <-
+    tibble(
+      terms = "location",
+      columns = attributes(dummy_trained$steps[[1]]$levels$location)$values,
+      id = ""
+    )
+  expect_equal(
+    tidy(dummy_trained, 1),
+    bind_rows(dum_tibble_prepped_1, dum_tibble_prepped_2)
+  )
+
 })
 
 test_that('tests for issue #91', {


### PR DESCRIPTION
Closes #622 

This PR changes the `tidy() method for `step_dummy()` so it gives _different_ results for one hot vs. "regular" dummy variables:

``` r
library(tidymodels)
data(okc)
okc <- okc[complete.cases(okc),]

rec <- recipe(~ diet + age + height, data = okc)

dummies <- rec %>% 
  step_dummy(diet) %>%
  prep(training = okc)

dummies_one_hot <- rec %>% 
  step_dummy(diet, one_hot = TRUE) %>%
  prep(training = okc)

tidy(dummies, number = 1)
#> # A tibble: 17 x 3
#>    terms columns             id         
#>    <chr> <chr>               <chr>      
#>  1 diet  halal               dummy_lP97k
#>  2 diet  kosher              dummy_lP97k
#>  3 diet  mostly anything     dummy_lP97k
#>  4 diet  mostly halal        dummy_lP97k
#>  5 diet  mostly kosher       dummy_lP97k
#>  6 diet  mostly other        dummy_lP97k
#>  7 diet  mostly vegan        dummy_lP97k
#>  8 diet  mostly vegetarian   dummy_lP97k
#>  9 diet  other               dummy_lP97k
#> 10 diet  strictly anything   dummy_lP97k
#> 11 diet  strictly halal      dummy_lP97k
#> 12 diet  strictly kosher     dummy_lP97k
#> 13 diet  strictly other      dummy_lP97k
#> 14 diet  strictly vegan      dummy_lP97k
#> 15 diet  strictly vegetarian dummy_lP97k
#> 16 diet  vegan               dummy_lP97k
#> 17 diet  vegetarian          dummy_lP97k
tidy(dummies_one_hot, number = 1)
#> # A tibble: 18 x 3
#>    terms columns             id         
#>    <chr> <chr>               <chr>      
#>  1 diet  anything            dummy_16VRw
#>  2 diet  halal               dummy_16VRw
#>  3 diet  kosher              dummy_16VRw
#>  4 diet  mostly anything     dummy_16VRw
#>  5 diet  mostly halal        dummy_16VRw
#>  6 diet  mostly kosher       dummy_16VRw
#>  7 diet  mostly other        dummy_16VRw
#>  8 diet  mostly vegan        dummy_16VRw
#>  9 diet  mostly vegetarian   dummy_16VRw
#> 10 diet  other               dummy_16VRw
#> 11 diet  strictly anything   dummy_16VRw
#> 12 diet  strictly halal      dummy_16VRw
#> 13 diet  strictly kosher     dummy_16VRw
#> 14 diet  strictly other      dummy_16VRw
#> 15 diet  strictly vegan      dummy_16VRw
#> 16 diet  strictly vegetarian dummy_16VRw
#> 17 diet  vegan               dummy_16VRw
#> 18 diet  vegetarian          dummy_16VRw
```

<sup>Created on 2020-12-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

It also updates the docs for `step_dummy()` similar to how @mine-cetinkaya-rundel laid out, to more clearly show what the `one_hot` option is doing.