### PR TITLE
Advice about using `allow_novel_levels` with `step_novel()`

### DIFF
--- a/R/novel.R
+++ b/R/novel.R
@@ -39,6 +39,11 @@
 #' If `new_level` is already in the data given to `prep`, an error
 #'  is thrown.
 #'
+#' When fitting a model that can deal with new factor levels, consider using
+#'  [workflows::add_recipe()] with `allow_novel_levels = TRUE` set in
+#'  [hardhat::default_recipe_blueprint()]. This will allow your model to handle
+#'  new levels at prediction time, instead of throwing warnings or errors.
+#'
 #' @seealso [step_factor2string()], [step_string2factor()],
 #'  [dummy_names()], [step_regex()], [step_count()],
 #'  [step_ordinalscore()], [step_unorder()], [step_other()]

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -76,6 +76,11 @@ Missing values will remain missing.
 
 If \code{new_level} is already in the data given to \code{prep}, an error
 is thrown.
+
+When fitting a model that can deal with new factor levels, consider using
+\code{\link[workflows:add_recipe]{workflows::add_recipe()}} with \code{allow_novel_levels = TRUE} set in
+\code{\link[hardhat:default_recipe_blueprint]{hardhat::default_recipe_blueprint()}}. This will allow your model to handle
+new levels at prediction time, instead of throwing warnings or errors.
 }
 \examples{
 library(modeldata)


### PR DESCRIPTION
Closes #627 

This PR adds advice to the docs for `step_novel()` about how to use `allow_novel_levels` when fitting a model. I decided against any more explicit text saying anything like "your training data doesn't have these levels in it" because I think that's pretty well covered by the first paragraph of `@Details`.