### PR TITLE
be consistent with tidyselect::eval_select()

### DIFF
--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -235,7 +235,7 @@ print.step_rollimpute <- print.step_impute_roll
 #' @export
 tidy.step_impute_roll <- function(x, ...) {
   if (is_trained(x)) {
-    res <- tibble(terms = x$columns, window = x$window)
+    res <- tibble(terms = unname(x$columns), window = x$window)
   } else {
     term_names <- sel2char(x$terms)
     res <- tibble(terms = term_names, window = x$window)

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -239,7 +239,7 @@ tidy.step_kpca <- function(x, ...) {
     if (x$num_comp > 0) {
       res <- tibble(terms = colnames(x$res@org.data))
     } else {
-      res <- tibble(terms = x$res$x_vars)
+      res <- tibble(terms = unname(x$res$x_vars))
     }
   } else {
     term_names <- sel2char(x$terms)

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -251,7 +251,7 @@ tidy.step_kpca_poly <- function(x, ...) {
     if (x$num_comp > 0) {
       res <- tibble(terms = colnames(x$res@org.data))
     } else {
-      res <- tibble(terms = x$res$x_vars)
+      res <- tibble(terms = unname(x$res$x_vars))
     }
   } else {
     term_names <- sel2char(x$terms)

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -241,7 +241,7 @@ tidy.step_kpca_rbf <- function(x, ...) {
     if (x$num_comp > 0) {
       res <- tibble(terms = colnames(x$res@org.data))
     } else {
-      res <- tibble(terms = x$res$x_vars)
+      res <- tibble(terms = unname(x$res$x_vars))
     }
   } else {
     term_names <- sel2char(x$terms)

--- a/R/misc.R
+++ b/R/misc.R
@@ -474,7 +474,7 @@ to_character <- function(x) {
 
 simple_terms <- function(x, ...) {
   if (is_trained(x)) {
-    res <- tibble(terms = x$columns)
+    res <- tibble(terms = unname(x$columns))
   } else {
     term_names <- sel2char(x$terms)
     res <- tibble(terms = term_names)

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -189,8 +189,8 @@ denom_vars <- function(...) quos(...)
 #' @export
 tidy.step_ratio <- function(x, ...) {
   if (is_trained(x)) {
-    res <- tibble(terms = x$columns$top,
-                  denom = x$columns$bottom)
+    res <- tibble(terms = unname(x$columns$top),
+                  denom = unname(x$columns$bottom))
   } else {
     res <- tidyr::crossing(terms = sel2char(x$terms),
                            denom = sel2char(x$denom))

--- a/R/roles.R
+++ b/R/roles.R
@@ -203,10 +203,10 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
     last_row_with_var <- dplyr::last(which(recipe$var_info$variable == vars[i]))
     recipe$var_info <- tibble::add_row(
       .data = recipe$var_info,
-      variable = vars[i],
-      type = new_type[i],
+      variable = unname(vars[i]),
+      type = unname(new_type[i]),
       role = new_role,
-      source = source[i],
+      source = unname(source[i]),
       .after = last_row_with_var
     )
   }

--- a/R/selections.R
+++ b/R/selections.R
@@ -127,12 +127,12 @@ eval_select_recipes <- function(quos, data, info, ..., allow_rename = FALSE) {
   # used for both the training and test set and their positions
   # may have changed. If renaming is allowed, add the new names.
   out <- names(data)[sel]
-  if (allow_rename) names(out) <- names(sel)
+  names(out) <- names(sel)
 
   # FIXME: Remove this check when the following issue is fixed,
   # at that point, just pass `allow_rename` to `eval_select()` directly.
   # https://github.com/r-lib/tidyselect/issues/221
-  if (!allow_rename & !identical(out, names(sel))) {
+  if (!allow_rename & !identical(unname(out), names(sel))) {
     abort("Can't rename variables in this context.")
   }
 

--- a/R/selections.R
+++ b/R/selections.R
@@ -127,15 +127,16 @@ eval_select_recipes <- function(quos, data, info, ..., allow_rename = FALSE) {
   # used for both the training and test set and their positions
   # may have changed. If renaming is allowed, add the new names.
   out <- names(data)[sel]
-  names(out) <- names(sel)
+  names <- names(sel)
 
   # FIXME: Remove this check when the following issue is fixed,
   # at that point, just pass `allow_rename` to `eval_select()` directly.
   # https://github.com/r-lib/tidyselect/issues/221
-  if (!allow_rename & !identical(unname(out), names(sel))) {
+  if (!allow_rename & !identical(out, names)) {
     abort("Can't rename variables in this context.")
   }
 
+  names(out) <- names
   out
 }
 


### PR DESCRIPTION
Closes  #654

`eval_select_recipes()` now returns a vector that is _always_ named, for consistency with `tidyselect::eval_select()`