### PR TITLE
Escalate deprecation for up- and down-sampling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,29 @@
 # recipes (development version)
 
-* Two new selectors that combine role and data type were added: `all_numeric_predictors()` and `all_nominal_predictors()`. (#620)
 
-* The `threshold`argument of `step_pca()` is now `tunable()` (#534).
+## New Steps
 
 * Added a new step called `step_indicate_na()`, which will create and append additional binary columns to the dataset to indicate which observations are missing (#623).
 
-* Changed the names of all imputation steps, for example, from `step_knnimpute()` or `step_medianimpute()` (old) to `step_impute_knn()` or `step_impute_median()` (new) (#614).
+* Added new `step_select()` (#199).
+
+## Bug Fixes
+
+* The `threshold` argument of `step_pca()` is now `tunable()` (#534).
 
 * Integer variables used in `step_profile()` are now kept as integers (and not doubles). 
 
 * Preserve multiple roles in `last_term_info` so `bake` can correctly respond to `has_roles`. (#632)
+
+* Fixed behavior of the retain flag in `prep()` (#652).
+
+* The `tidy()` methods for `step_nnmf()` was rewritten since it was not great. (#665)
+
+## Improvements and Other Changes
+
+* Two new selectors that combine role and data type were added: `all_numeric_predictors()` and `all_nominal_predictors()`. (#620)
+
+* Changed the names of all imputation steps, for example, from `step_knnimpute()` or `step_medianimpute()` (old) to `step_impute_knn()` or `step_impute_median()` (new) (#614).
 
 * Added `keep_original_cols` argument to several steps: 
   * `step_pca`, `step_ica`, `step_nnmf`, `step_kpca_rbf`, `step_kpca_poly`, `step_pls`, `step_isomap` which all default to `FALSE` (#635).
@@ -18,17 +31,12 @@
 
 * Added `allow_rename` argument to `eval_select_recipes()` (#646).
 
-* Fixed behaviour of the retain flag in `prep()` (#652).
-
-* Added `keep_original_cols` argument to `step_pca()`, `step_ica()`, `step_nnmf()`, `step_kpca_rbf()`, `step_kpca_poly()`, `step_pls()`, and `step_isomap()` (#635).
-
 * Performance improvements for `step_bs()` and `step_ns()`. The `prep()` step no longer evaluates the basis functions on the training set and the `bake()` steps only evaluates the basis functions once for each unique input value (#574)
-
-* Added new `step_select()` (#199).
 
 * The `neighbors` parameter's default range for `step_isomap()` was changed to be 20-80.
 
-* The `tidy()` methods for `step_nnmf()` was rewritten since it was not great. (#665)
+* The deprecation for `step_upsample()` and `step_downsample()` has been escalated from a soft deprecation to a regular deprecation; these functions are available in the themis package.  
+
 
 # recipes 0.1.15
 

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -1,7 +1,7 @@
 #' Down-Sample a Data Set Based on a Factor Variable
 #'
 #' @description
-#' \if{html}{\figure{lifecycle-soft-deprecated.svg}{alt="lifecycle-soft-deprecated"}}
+#' `r lifecycle::badge("deprecated")`
 #'
 #' `step_downsample` is now available as `themis::step_downsample()`. This
 #'  function creates a *specification* of a recipe step that will remove
@@ -59,7 +59,7 @@
 #'  option `skip = TRUE` so that the extra sampling is _not_
 #'  conducted outside of the training set.
 #'
-#' @keywords datagen
+#' @keywords internal
 #' @concept preprocessing
 #' @concept subsampling
 #' @export
@@ -84,7 +84,7 @@ step_downsample <-
            column = NULL, target = NA, skip = TRUE,
            seed = sample.int(10^5, 1), id = rand_id("downsample")) {
 
-    lifecycle::deprecate_soft("0.1.13",
+    lifecycle::deprecate_warn("0.1.13",
                               "recipes::step_downsample()",
                               "themis::step_downsample()")
 

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -1,7 +1,7 @@
 #' Up-Sample a Data Set Based on a Factor Variable
 #'
 #' @description
-#' \if{html}{\figure{lifecycle-soft-deprecated.svg}{alt="lifecycle-soft-deprecated"}}
+#' `r lifecycle::badge("deprecated")`
 #'
 #' `step_upsample` is now available as `themis::step_upsample()`. This
 #'  function creates a *specification* of a recipe step that
@@ -54,7 +54,7 @@
 #'  option `skip = TRUE` so that the extra sampling is _not_
 #'  conducted outside of the training set.
 #'
-#' @keywords datagen
+#' @keywords internal
 #' @concept preprocessing
 #' @concept subsampling
 #' @export
@@ -93,7 +93,7 @@ step_upsample <-
            seed = sample.int(10^5, 1),
            id = rand_id("upsample")) {
 
-    lifecycle::deprecate_soft("0.1.13",
+    lifecycle::deprecate_warn("0.1.13",
                               "recipes::step_upsample()",
                               "themis::step_upsample()")
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -109,7 +109,6 @@ reference:
   - title: Step Functions - Row Operations
     contents:
     - step_arrange
-    - step_downsample
     - step_filter
     - step_lag
     - step_naomit
@@ -117,7 +116,6 @@ reference:
     - step_sample
     - step_shuffle
     - step_slice
-    - step_upsample
   - title: Step Functions - Others
     contents:
     - step_intercept

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -72,7 +72,7 @@ added to the sequence of existing steps (if any). For the
 the variable used to sample.
 }
 \description{
-\if{html}{\figure{lifecycle-soft-deprecated.svg}{alt="lifecycle-soft-deprecated"}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 \code{step_downsample} is now available as \code{themis::step_downsample()}. This
 function creates a \emph{specification} of a recipe step that will remove
@@ -124,4 +124,4 @@ table(baked_okc$diet, useNA = "always")
 }
 \concept{preprocessing}
 \concept{subsampling}
-\keyword{datagen}
+\keyword{internal}

--- a/man/step_upsample.Rd
+++ b/man/step_upsample.Rd
@@ -72,7 +72,7 @@ added to the sequence of existing steps (if any). For the
 the variable used to sample.
 }
 \description{
-\if{html}{\figure{lifecycle-soft-deprecated.svg}{alt="lifecycle-soft-deprecated"}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 \code{step_upsample} is now available as \code{themis::step_upsample()}. This
 function creates a \emph{specification} of a recipe step that
@@ -132,4 +132,4 @@ data.frame(
 }
 \concept{preprocessing}
 \concept{subsampling}
-\keyword{datagen}
+\keyword{internal}


### PR DESCRIPTION
This PR escalate the deprecation for `step_upsample()` and `step_downsample()` to [`deprecate_warn()`](https://lifecycle.r-lib.org/articles/communicate.html#gradual-deprecation-1). It also incorporates the README changes from #675.