### PR TITLE
Revamp ordering of steps vignette

### DIFF
--- a/vignettes/Ordering.Rmd
+++ b/vignettes/Ordering.Rmd
@@ -8,16 +8,35 @@ output:
     toc: yes
 ---
 
-In recipes, there are no constraints related to the order in which steps are added to the recipe. However, there are some general suggestions that you should consider:
+In the recipes package, there are no constraints on the order in which steps are added to the recipe; you as a user are free to apply steps in the order appropriate to your data preprocessing needs. However, the **order of steps matters** and there are some general suggestions that you should consider.
 
-* If using a Box-Cox transformation, don't center the data first or do any operations that might make the data non-positive. Alternatively, use the Yeo-Johnson transformation so you don't have to worry about this. 
-* Recipes do not automatically create dummy variables (unlike _most_ formula methods). If you want to center, scale, or do any other operations on _all_ of the predictors, run `step_dummy` first so that numeric columns are in the data set instead of factors. 
-* As noted in the help file for `step_interact`, you should make dummy variables _before_ creating the interactions.
-* If you are lumping infrequently categories together with `step_other`, call `step_other` before `step_dummy`.
+## Transforming a variable
 
-While your project's needs may vary, here is a suggested order of _potential_ steps that should work for most problems:
+* If using a Box-Cox transformation, don't center the data first or do any operations that might make the data non-positive. 
+* Alternatively, use the Yeo-Johnson transformation so you don't have to worry about this. 
+
+## Handling levels in categorical data
+
+The order of steps for handling categorical levels is important, because each step sets levels for the next step to use as input. These steps create _factor_ output, even if the input is of character type.
+
+* Typically use `step_novel()` before other steps for changing factor levels, so that the new factor level can be set as you desire rather than coerced to `NA` by other factor handling steps.
+* Use steps like `step_unknown()` and `step_other()` after other steps for changing factor levels. 
+* If you are creating dummy variables from a categorical variable (see below), complete handling of the categorical variable's levels _before_ `step_dummy()`.
+
+## Dummy variables
+
+Recipes do not automatically create dummy variables (unlike _most_ formula methods). 
+
+* If you want to center, scale, or do any other operations on _all_ of the predictors, run `step_dummy()` first so that numeric columns are in the data set instead of factors. 
+* As noted in the [help file for `step_interact()`](https://recipes.tidymodels.org/reference/step_interact.html), you should make dummy variables _before_ creating the interactions.
+
+
+## Recommended preprocessing outline
+
+While every individual project's needs are different, here is a suggested order of _potential_ steps that should work for most problems:
 
 1. Impute
+1. Handle factor levels
 1. Individual transformations for skewness and other issues
 1. Discretize (if needed and if you have no other choice) 
 1. Create dummy variables
@@ -25,4 +44,4 @@ While your project's needs may vary, here is a suggested order of _potential_ st
 1. Normalization steps (center, scale, range, etc) 
 1. Multivariate transformation (e.g. PCA, spatial sign, etc) 
 
-Again, your milage may vary for your particular problem. 
+Again, your mileage may vary for your particular problem. 


### PR DESCRIPTION
Closes #656 
Closes #641 

This PR reorganizes and extends the ["Ordering of Steps"](https://recipes.tidymodels.org/articles/Ordering.html) vignette, especially with regards to factor handling. Take a look and see what you think! Hopefully this can be something to point folks toward.

Especially note _where_ I put factor level handling in this sequence:

1. Impute
1. Handle factor levels
1. Individual transformations for skewness and other issues
1. Discretize (if needed and if you have no other choice) 
1. Create dummy variables
1. Create interactions
1. Normalization steps (center, scale, range, etc) 
1. Multivariate transformation (e.g. PCA, spatial sign, etc) 

Thoughts?