### PR TITLE
Turn off parallel processing for NMF, do not load pkgs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 
 * Fixed behavior of the retain flag in `prep()` (#652).
 
-* The `tidy()` methods for `step_nnmf()` was rewritten since it was not great. (#665)
+* The `tidy()` methods for `step_nnmf()` was rewritten since it was not great (#665), and `step_nnmf()` now no longer fully loads underlying packages (#685). 
 
 ## Improvements and Other Changes
 

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -22,7 +22,8 @@
 #'  to obtain a consensus projection.
 #' @param options A list of options to `nmf()` in the NMF package by way of the
 #'  `NNMF()` function in the `dimRed` package. **Note** that the arguments
-#'  `data` and `ndim` should not be passed here.
+#'  `data` and `ndim` should not be passed here, and that NMF's parallel
+#'  processing is turned off in favor of resample-level parallelization.
 #' @param res The `NNMF()` object is stored
 #'  here once this preprocessing step has been trained by
 #'  [prep.recipe()].
@@ -146,12 +147,8 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
     opts$.mute <- c("message", "output")
     opts$.data <- dimRed::dimRedData(as.data.frame(training[, col_names, drop = FALSE]))
     opts$.method <- "NNMF"
-
-    for (i in nmf_pkg) {
-      suppressPackageStartupMessages(
-        require(i, character.only = TRUE)
-      )
-    }
+    nmf_opts <- list(parallel = FALSE, parallel.required = FALSE)
+    opts$options <- list(.options = nmf_opts)
 
     nnm <- try(do.call(dimRed::embed, opts), silent = TRUE)
     if (inherits(nnm, "try-error")) {
@@ -252,8 +249,6 @@ tunable.step_nnmf <- function(x, ...) {
   )
 }
 
-
-nmf_pkg <- c("dimRed", "NMF")
 #' @rdname required_pkgs.step
 #' @export
 required_pkgs.step_nnmf <- function(x, ...) {

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -50,7 +50,8 @@ to obtain a consensus projection.}
 
 \item{options}{A list of options to \code{nmf()} in the NMF package by way of the
 \code{NNMF()} function in the \code{dimRed} package. \strong{Note} that the arguments
-\code{data} and \code{ndim} should not be passed here.}
+\code{data} and \code{ndim} should not be passed here, and that NMF's parallel
+processing is turned off in favor of resample-level parallelization.}
 
 \item{res}{The \code{NNMF()} object is stored
 here once this preprocessing step has been trained by

--- a/tests/testthat/test_nnmf.R
+++ b/tests/testthat/test_nnmf.R
@@ -13,9 +13,6 @@ test_that('Correct values', {
   for (i in req)
     skip_if_not_installed(i)
 
-  for (i in req)
-    require(i, character.only = TRUE)
-
   # # make test cases
   # dat <- loadDataSet("Iris")
   # factorization <- embed(dat, "NNMF", seed = 2432, nrun = 3)


### PR DESCRIPTION
Closes #681 

This PR turns off the parallelization that NMF has on by default, which allows us to use NMF and dimRed without fully loading them as before. This solves the problem with `fit()`:

``` r
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip
data(biomass)

rec <- recipe(HHV ~ ., data = biomass) %>%
  update_role(sample, new_role = "id var") %>%
  update_role(dataset, new_role = "split variable") %>%
  step_nnmf(all_numeric_predictors(), num_comp = 2, seed = 473, num_run = 2) %>%
  prep(training = biomass)

linear_reg() %>% fit(mpg ~ ., data = mtcars)
#> Warning: Engine set to `lm`.
#> parsnip model object
#> 
#> Fit time:  3ms 
#> 
#> Call:
#> stats::lm(formula = mpg ~ ., data = data)
#> 
#> Coefficients:
#> (Intercept)          cyl         disp           hp         drat           wt  
#>    12.30337     -0.11144      0.01334     -0.02148      0.78711     -3.71530  
#>        qsec           vs           am         gear         carb  
#>     0.82104      0.31776      2.52023      0.65541     -0.19942
```

<sup>Created on 2021-04-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

In the future, we could consider exposing some kind of parallel option for `step_nnmf()` for folks who use it outside of our tuning infrastructure and want to run it in parallel.