### PR TITLE
Warnings for non-positive input to `step_BoxCox`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Reorganize documentation for all recipe step `tidy` methods (#701).
 
+* Generate warning when user attempts a Box-Cox transformation of non-positive data (@LiamBlake, #713).
+
 # recipes 0.1.16
 
 ## New Steps

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -121,7 +121,7 @@ prep.step_BoxCox <- function(x, training, info = NULL, ...) {
     var_names <- names(values[is.na(values)])
     vars <- glue::glue_collapse(glue::backtick(var_names), sep = ", ")
     rlang::warn(paste(
-      "No Box-Cox transformation will be made to:", glue::glue("{vars}")
+      "No Box-Cox transformation could be estimated for:", glue::glue("{vars}")
     ))
   }
   values <- values[!is.na(values)]

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -151,7 +151,7 @@ print.step_BoxCox <-
 ## computes the new data
 bc_trans <- function(x, lambda, eps = .001) {
   # Raise a warning if the data contains non-positive values
-  if (any(x) <= 0) 
+  if (any(x <= 0)) 
     rlang::warn("Applying Box-Cox transformation to non-positive data.")
 
   if (is.na(lambda))

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -192,7 +192,11 @@ estimate_bc <- function(dat,
   if (length(unique(dat)) < num_unique)
     return(NA)
   if (any(dat[complete.cases(dat)] <= 0)) {
-    rlang::warn("Non-positive values in data to be Box-Cox transformed. No transformation will be made.")
+    rlang::warn(
+      paste0(
+        "Non-positive values in data to be Box-Cox transformed. ",
+        "No transformation will be made to column."
+      )
     return(NA)
   }
   res <- optimize(

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -118,7 +118,8 @@ prep.step_BoxCox <- function(x, training, info = NULL, ...) {
     num_unique = x$num_unique
   )
   if (any(is.na(values))) {
-    vars <- glue::glue_collapse(glue::single_quote(names(values[is.na(values)])), sep = ", ")
+    var_names <- names(values[is.na(values)])
+    vars <- glue::glue_collapse(glue::backtick(var_names), sep = ", ")
     rlang::warn(paste(
       "No Box-Cox transformation will be made to:", glue::glue("{vars}")
     ))
@@ -158,9 +159,9 @@ print.step_BoxCox <-
 bc_trans <- function(x, lambda, eps = .001) {
 
   if (any(x <= 0))
-    rlang::warn(paste(
-      "Applying Box-Cox transformation to non-positive data in column",
-      names(lambda)
+    rlang::warn(paste0(
+      "Applying Box-Cox transformation to non-positive data in column `",
+      names(lambda), "`"
       ))
 
   if (is.na(lambda))

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -150,6 +150,10 @@ print.step_BoxCox <-
 
 ## computes the new data
 bc_trans <- function(x, lambda, eps = .001) {
+  # Raise a warning if the data contains non-positive values
+  if (any(x) <= 0) 
+    rlang::warn("Applying Box-Cox transformation to non-positive data.")
+
   if (is.na(lambda))
     return(x)
   if (abs(lambda) < eps)
@@ -185,9 +189,12 @@ estimate_bc <- function(dat,
                         limits = c(-5, 5),
                         num_unique = 5) {
   eps <- .001
-  if (length(unique(dat)) < num_unique |
-      any(dat[complete.cases(dat)] <= 0))
+  if (length(unique(dat)) < num_unique)
     return(NA)
+  if (any(dat[complete.cases(dat)] <= 0)) {
+    rlang::warn("Non-positive values in data to be Box-Cox transformed. No transformation will be made.")
+    return(NA)
+  }
   res <- optimize(
     bc_obj,
     interval = limits,

--- a/man/step_BoxCox.Rd
+++ b/man/step_BoxCox.Rd
@@ -36,8 +36,8 @@ is \code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.}
 \item{limits}{A length 2 numeric vector defining the range to
 compute the transformation parameter lambda.}
 
-\item{num_unique}{An integer where data that have less possible
-values will not be evaluated for a transformation.}
+\item{num_unique}{An integer to specify minimum required unique
+values to evaluate for a transformation.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -49,7 +49,10 @@ test_that('simple Box Cox', {
            id = rec$steps[[1]]$id)
   expect_equal(bc_tibble_un, tidy(rec, number = 1))
 
-  rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
+  expect_warning(
+    rec_trained <- prep(rec, training = ex_dat, verbose = FALSE),
+    "Non-positive values in selected"
+  )
   rec_trans <- bake(rec_trained, new_data = ex_dat)
 
   expect_equal(names(exp_lambda)[!is.na(exp_lambda)], names(rec_trained$steps[[1]]$lambdas))
@@ -62,6 +65,6 @@ test_that('printing', {
   rec <- recipe(~., data = ex_dat) %>%
     step_BoxCox(x1, x2, x3, x4)
   expect_output(print(rec))
-  expect_output(prep(rec, training = ex_dat, verbose = TRUE))
+  expect_output(expect_warning(prep(rec, training = ex_dat, verbose = TRUE)))
 })
 


### PR DESCRIPTION
Closes #705. Warnings should appear whenever `prep` or `bake` is called on the Box-Cox step with non-positive data.