### PR TITLE
Revamp framing of recipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,21 +1,29 @@
 Package: recipes
-Title: Preprocessing Tools to Create Design Matrices
+Title: Preprocessing and Feature Engineering Steps for Modeling
 Version: 0.1.16.9000
-Authors@R: c(
-    person(given = "Max",    family = "Kuhn",    email = "max@rstudio.com",    role = c("aut", "cre")),
-    person(given = "Hadley", family = "Wickham", email = "hadley@rstudio.com", role = c("aut")),
-    person("RStudio", role = "cph"))
-Description: An extensible framework to create and preprocess 
-    design matrices. Recipes consist of one or more data manipulation 
-    and analysis "steps". Statistical parameters for the steps can 
-    be estimated from an initial data set and then applied to 
-    other data sets. The resulting design matrices can then be used 
-    as inputs into statistical or machine learning models. 
+Authors@R: 
+    c(person(given = "Max",
+             family = "Kuhn",
+             role = c("aut", "cre"),
+             email = "max@rstudio.com"),
+      person(given = "Hadley",
+             family = "Wickham",
+             role = "aut",
+             email = "hadley@rstudio.com"),
+      person(given = "RStudio",
+             role = "cph"))
+Description: Recipes get your data ready for modeling. An extensible
+    framework for pipeable sequences of feature engineering steps provides
+    preprocessing tools to be applied to data. Statistical parameters for
+    the steps can be estimated from an initial data set and then applied
+    to other data sets. The resulting processed output can then be used as
+    inputs for statistical or machine learning models.
+License: MIT + file LICENSE
 URL: https://github.com/tidymodels/recipes, https://recipes.tidymodels.org
 BugReports: https://github.com/tidymodels/recipes/issues
 Depends: 
-    R (>= 3.1),
-    dplyr
+    dplyr,
+    R (>= 3.1)
 Imports: 
     ellipsis,
     generics (>= 0.1.0),
@@ -53,9 +61,10 @@ Suggests:
     RSpectra,
     testthat (>= 2.1.0),
     xml2
-License: MIT + file LICENSE
-VignetteBuilder: knitr
+VignetteBuilder: 
+    knitr
+RdMacros: 
+    lifecycle
 Encoding: UTF-8
-RoxygenNote: 7.1.1.9001
 Roxygen: list(markdown = TRUE)
-RdMacros: lifecycle
+RoxygenNote: 7.1.1.9001

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R:
              email = "hadley@rstudio.com"),
       person(given = "RStudio",
              role = "cph"))
-Description: Recipes get your data ready for modeling. An extensible
+Description: Recipes prepares your data for modeling. An extensible
     framework for pipeable sequences of feature engineering steps provides
     preprocessing tools to be applied to data. Statistical parameters for
     the steps can be estimated from an initial data set and then applied

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R:
              email = "hadley@rstudio.com"),
       person(given = "RStudio",
              role = "cph"))
-Description: Recipes prepares your data for modeling. An extensible
+Description: Recipes prepare your data for modeling. An extensible
     framework for pipeable sequences of feature engineering steps provides
     preprocessing tools to be applied to data. Statistical parameters for
     the steps can be estimated from an initial data set and then applied

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,38 +20,37 @@ knitr::opts_chunk$set(
 
 ## Introduction
 
-The `recipes` package is an alternative method for creating and preprocessing design matrices that can be used for modeling or visualization. From [Wikipedia](https://en.wikipedia.org/wiki/Design_matrix):
+With recipes, you can use [dplyr](https://dplyr.tidyverse.org/)-like pipeable sequences of feature engineering steps to get your data ready for modeling. For example, to create a recipe containing an outcome plus two numeric predictors and then center and scale ("normalize") the predictors:
 
- > In statistics, a **design matrix** (also known as regressor matrix or model matrix) is a matrix of values of explanatory variables of a set of objects, often denoted by X. Each row represents an individual object, with the successive columns corresponding to the variables and their specific values for that object.
-
-While R already has long-standing methods for creating these matrices (e.g. [formulas](https://rviews.rstudio.com/2017/02/01/the-r-formula-method-the-good-parts/) and `model.matrix`), there are some [limitations to what the existing infrastructure can do](https://rviews.rstudio.com/2017/03/01/the-r-formula-method-the-bad-parts/). 
-
-The idea of the `recipes` package is to define a recipe or blueprint that can be used to sequentially define the encodings and preprocessing of the data (i.e. "feature engineering"). For example, to create a simple recipe containing only an outcome and predictors and have the predictors centered and scaled:
-
-```{r simple, eval = FALSE}
+```{r simple, message=FALSE}
 library(recipes)
-library(mlbench)
-data(Sonar)
+data(ad_data, package = "modeldata")
 
-sonar_rec <- recipe(Class ~ ., data = Sonar) %>%
-  step_center(all_predictors()) %>%
-  step_scale(all_predictors())
+ad_rec <- recipe(Class ~ tau + VEGF, data = ad_data) %>%
+  step_normalize(all_numeric_predictors())
+
+ad_rec
 ```
 
-More information on `recipes` can be found at the [_Get Started_](https://www.tidymodels.org/start/recipes/) page of [`tidymodels.org`](https://www.tidymodels.org). 
+More information on recipes can be found at the [_Get Started_](https://www.tidymodels.org/start/recipes/) page of [tidymodels.org](https://www.tidymodels.org). 
+
+You may consider recipes as an alternative method for creating and preprocessing design matrices (also known as model matrices) that can be used for modeling or visualization. While R already has long-standing methods for creating such matrices (e.g. [formulas](https://rviews.rstudio.com/2017/02/01/the-r-formula-method-the-good-parts/) and `model.matrix`), there are some [limitations to what the existing infrastructure can do](https://rviews.rstudio.com/2017/03/01/the-r-formula-method-the-bad-parts/). 
 
 ## Installation
 
-To install this package, use:
+There are several ways to install recipes:
 
-```{r install, eval = FALSE}
+```{r, eval = FALSE}
+# The easiest way to get recipes is to install all of tidymodels:
+install.packages("tidymodels")
+
+# Alternatively, install just recipes:
 install.packages("recipes")
 
-## for development version:
-require("devtools")
-install_github("tidymodels/recipes")
+# Or the development version from GitHub:
+# install.packages("devtools")
+devtools::install_github("tidymodels/recipes")
 ```
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,53 +10,60 @@ coverage](https://codecov.io/gh/tidymodels/recipes/branch/master/graph/badge.svg
 
 ## Introduction
 
-The `recipes` package is an alternative method for creating and
-preprocessing design matrices that can be used for modeling or
-visualization. From
-[Wikipedia](https://en.wikipedia.org/wiki/Design_matrix):
+With recipes, you can use [dplyr](https://dplyr.tidyverse.org/)-like
+pipeable sequences of feature engineering steps to get your data ready
+for modeling. For example, to create a recipe containing an outcome plus
+two numeric predictors and then center and scale (“normalize”) the
+predictors:
 
-> In statistics, a **design matrix** (also known as regressor matrix or
-> model matrix) is a matrix of values of explanatory variables of a set
-> of objects, often denoted by X. Each row represents an individual
-> object, with the successive columns corresponding to the variables and
-> their specific values for that object.
+``` r
+library(recipes)
+data(ad_data, package = "modeldata")
 
-While R already has long-standing methods for creating these matrices
+ad_rec <- recipe(Class ~ tau + VEGF, data = ad_data) %>%
+  step_normalize(all_numeric_predictors())
+
+ad_rec
+#> Data Recipe
+#> 
+#> Inputs:
+#> 
+#>       role #variables
+#>    outcome          1
+#>  predictor          2
+#> 
+#> Operations:
+#> 
+#> Centering and scaling for all_numeric_predictors()
+```
+
+More information on recipes can be found at the [*Get
+Started*](https://www.tidymodels.org/start/recipes/) page of
+[tidymodels.org](https://www.tidymodels.org).
+
+You may consider recipes as an alternative method for creating and
+preprocessing design matrices (also known as model matrices) that can be
+used for modeling or visualization. While R already has long-standing
+methods for creating such matrices
 (e.g. [formulas](https://rviews.rstudio.com/2017/02/01/the-r-formula-method-the-good-parts/)
 and `model.matrix`), there are some [limitations to what the existing
 infrastructure can
 do](https://rviews.rstudio.com/2017/03/01/the-r-formula-method-the-bad-parts/).
 
-The idea of the `recipes` package is to define a recipe or blueprint
-that can be used to sequentially define the encodings and preprocessing
-of the data (i.e. “feature engineering”). For example, to create a
-simple recipe containing only an outcome and predictors and have the
-predictors centered and scaled:
-
-``` r
-library(recipes)
-library(mlbench)
-data(Sonar)
-
-sonar_rec <- recipe(Class ~ ., data = Sonar) %>%
-  step_center(all_predictors()) %>%
-  step_scale(all_predictors())
-```
-
-More information on `recipes` can be found at the [*Get
-Started*](https://www.tidymodels.org/start/recipes/) page of
-[`tidymodels.org`](https://www.tidymodels.org).
-
 ## Installation
 
-To install this package, use:
+There are several ways to install recipes:
 
 ``` r
+# The easiest way to get recipes is to install all of tidymodels:
+install.packages("tidymodels")
+
+# Alternatively, install just recipes:
 install.packages("recipes")
 
-## for development version:
-require("devtools")
-install_github("tidymodels/recipes")
+# Or the development version from GitHub:
+# install.packages("devtools")
+devtools::install_github("tidymodels/recipes")
 ```
 
 ## Contributing


### PR DESCRIPTION
Based on our discussions and recent presentations, let's update how we frame what recipes does. This PR edits the DESCRIPTION file plus the README. I also just edited the GitHub description, to:

>  Pipeable steps for feature engineering and data preprocessing to prepare for modeling 


I did not edit the vignettes, although one does talk about design matrices a fair amount.