### PR TITLE
Fix for width formatting/printing

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -10,18 +10,7 @@ format_ch_vec <-
   function(x,
            sep = ", ",
            width = options()$width - 9) {
-    widths <- nchar(x)
-    sep_wd <- nchar(sep)
-    adj_wd <- widths + sep_wd
-    if (sum(adj_wd) >= width) {
-      keepers <- max(which(cumsum(adj_wd) < width)) - 1
-      if (length(keepers) == 0 || keepers < 1) {
-        x <- paste(length(x), "items")
-      } else {
-        x <- c(x[1:keepers], "...")
-      }
-    }
-    paste0(x, collapse = sep)
+    glue::glue_collapse(x, sep = sep, width = width)
   }
 
 

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -19,7 +19,8 @@ test_that("format_ch_vec handles a vector with long items", {
     long_vec <- paste(long_vec, as.character(i))
   }
 
-  expect_equal(format_ch_vec(c("1", long_vec)), "2 items")
+  expect_equal(format_ch_vec(c("1", long_vec), width = 20),
+               "1,  1 2 3 4 5 6 7...")
 })
 
 test_that("format_selectors handles small numbers of selectors", {
@@ -42,5 +43,6 @@ test_that("format_ch_vec handles a long expression", {
     long_vec <- paste(long_vec, as.character(i))
   }
 
-  expect_equal(format_ch_vec(c(expr(1), expr(!!long_vec))), "2 items")
+  expect_equal(format_ch_vec(c(expr(1), expr(!!long_vec)), width = 20),
+               "1,  1 2 3 4 5 6 7...")
 })


### PR DESCRIPTION
Closes #720 

This PR replaces the hand-crafted formatting with `glue::glue_collapse()`, so results now look like this:

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
options(width = 30)
recipe(mpg ~ ., data = mtcars) %>%
  step_center(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor         10
#> 
#> Operations:
#> 
#> Centering for aaaaaaaaaaaaaaaaa...

recipe(mpg ~ ., data = mtcars) %>%
  step_center(all_numeric_predictors())
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor         10
#> 
#> Operations:
#> 
#> Centering for all_numeric_predi...

recipe(mpg ~ ., data = mtcars) %>%
  step_center(cyl, disp, hp, drat, wt, qsec)
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor         10
#> 
#> Operations:
#> 
#> Centering for cyl, disp, hp, dr...
```

<sup>Created on 2021-06-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

It will be much more robust to use glue but I kept the function `format_ch_vec()` as a very thin wrapper since it is used throughout recipes.