### PR TITLE
Geo latlon

### DIFF
--- a/R/depth.R
+++ b/R/depth.R
@@ -40,7 +40,7 @@
 #' @export
 #' @details Data depth metrics attempt to measure how close data a
 #'  data point is to the center of its distribution. There are a
-#'  number of methods for calculating death but a simple example is
+#'  number of methods for calculating depth but a simple example is
 #'  the inverse of the distance of a data point to the centroid of
 #'  the distribution. Generally, small values indicate that a data
 #'  point not close to the centroid. `step_depth` can compute a

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -12,6 +12,9 @@
 #' @param role or model term created by this step, what analysis
 #'  role should be assigned?. By default, the function assumes
 #'  that resulting distance will be used as a predictor in a model.
+#' @param is_lat_lon A logical: Are coordinates in latitude and longitude? If
+#'  TRUE the Haversine formula is used and the returned result is meters. If
+#'  FALSE the Pythagorean formula is used. Default is TRUE.
 #' @param log A logical: should the distance be transformed by
 #'  the natural log function?
 #' @param columns A character string of variable names that will
@@ -22,7 +25,8 @@
 #' @return An updated version of `recipe` with the new step added
 #'  to the sequence of existing steps (if any).
 #' @details When you [`tidy()`] this step, a tibble with columns echoing the
-#'  values of `lat`, `lon`, `ref_lat`, `ref_lon`, `name`, and `id` is returned.
+#'  values of `lat`, `lon`, `ref_lat`, `ref_lon`, `is_lat_lon`, `name`, and `id`
+#'  is returned.
 #' @keywords datagen
 #' @concept preprocessing
 #' @export
@@ -37,7 +41,8 @@
 #' near_station <- recipe( ~ ., data = Smithsonian) %>%
 #'   update_role(name, new_role = "location") %>%
 #'   step_geodist(lat = latitude, lon = longitude, log = FALSE,
-#'                ref_lat = 38.8986312, ref_lon = -77.0062457) %>%
+#'                ref_lat = 38.8986312, ref_lon = -77.0062457,
+#'                is_lat_lon = TRUE) %>%
 #'   prep(training = Smithsonian)
 #'
 #' bake(near_station, new_data = NULL) %>%
@@ -51,6 +56,7 @@ step_geodist <- function(recipe,
                          trained = FALSE,
                          ref_lat = NULL,
                          ref_lon = NULL,
+                         is_lat_lon = TRUE,
                          log = FALSE,
                          name = "geo_dist",
                          columns = NULL,
@@ -60,6 +66,8 @@ step_geodist <- function(recipe,
     rlang::abort("`ref_lon` should be a single numeric value.")
   if (length(ref_lat) != 1 || !is.numeric(ref_lat))
     rlang::abort("`ref_lat` should be a single numeric value.")
+  if (length(is_lat_lon) != 1 || !is.logical(is_lat_lon))
+    rlang::abort("`is_lat_lon` should be a single logical value.")
   if (length(log) != 1 || !is.logical(log))
     rlang::abort("`log` should be a single logical value.")
   if (length(name) != 1 || !is.character(name))
@@ -74,6 +82,7 @@ step_geodist <- function(recipe,
       trained = trained,
       ref_lon = ref_lon,
       ref_lat = ref_lat,
+      is_lat_lon = is_lat_lon,
       log = log,
       name = name,
       columns = columns,
@@ -84,7 +93,7 @@ step_geodist <- function(recipe,
 }
 
 step_geodist_new <-
-  function(lon, lat, role, trained, ref_lon, ref_lat,
+  function(lon, lat, role, trained, ref_lon, ref_lat, is_lat_lon,
            log, name, columns, skip, id) {
     step(
       subclass = "geodist",
@@ -94,6 +103,7 @@ step_geodist_new <-
       trained = trained,
       ref_lon = ref_lon,
       ref_lat = ref_lat,
+      is_lat_lon = is_lat_lon,
       log = log,
       name = name,
       columns = columns,
@@ -126,6 +136,7 @@ prep.step_geodist <- function(x, training, info = NULL, ...) {
     trained = TRUE,
     ref_lon = x$ref_lon,
     ref_lat = x$ref_lat,
+    is_lat_lon = x$is_lat_lon,
     log = x$log,
     name = x$name,
     columns = c(lat_name, lon_name),
@@ -134,19 +145,53 @@ prep.step_geodist <- function(x, training, info = NULL, ...) {
   )
 }
 
-geo_dist_calc <- function(x, a, b)
-  apply(x, 1, function(x, a, b) sqrt((x[1] - a) ^ 2 + (x[2] - b) ^ 2),
-        a = a, b = b)
+geo_dist_calc_xy <- function(x_1, y_1, x_2, y_2)
+  sqrt((x_1 - x_2) ^ 2L + (y_1 - y_2) ^ 2L)
+
+geo_dist_calc_lat_lon <- function(x_1, y_1, x_2, y_2, earth_radius = 6371e3) {
+
+  to_rad <- pi / 180.0
+
+  y_1 <- y_1 * to_rad
+  y_2 <- y_2 * to_rad
+
+  x_1 <- x_1 * to_rad
+  x_2 <- x_2 * to_rad
+
+  delta_lat <- (y_2 - y_1) / 2.0
+  delta_lon <- (x_2 - x_1) / 2.0
+
+  a <- sin(delta_lat) ^ 2L + cos(y_1) * cos(y_2) * sin(delta_lon) ^ 2L
+  c <- 2.0 * atan2(sqrt(a), sqrt(1-a))
+
+  earth_radius * c
+
+}
+
 
 #' @export
 bake.step_geodist <- function(object, new_data, ...) {
-  dist_vals <-
-    geo_dist_calc(new_data[, object$columns], object$ref_lat, object$ref_lon)
+
+  if(object$is_lat_lon) {
+    dist_vals <-
+      geo_dist_calc_lat_lon(new_data[[object$columns[2]]], # lon
+                            new_data[[object$columns[1]]], # lat
+                            object$ref_lon,
+                            object$ref_lat)
+  } else {
+    dist_vals <-
+      geo_dist_calc_xy(new_data[[object$columns[2]]], # lon
+                       new_data[[object$columns[1]]], # lat
+                       object$ref_lon,
+                       object$ref_lat)
+  }
+
   if (object$log) {
     new_data[, object$name] <- log(dist_vals)
   } else {
     new_data[, object$name] <- dist_vals
   }
+
   new_data
 }
 
@@ -170,6 +215,7 @@ tidy.step_geodist <- function(x, ...) {
       longitude = x$columns[2],
       ref_latitude = x$ref_lat,
       ref_longitude = x$ref_lon,
+      is_lat_lon = x$is_lat_lon,
       name = x$name
     )
   } else {
@@ -178,6 +224,7 @@ tidy.step_geodist <- function(x, ...) {
       longitude = sel2char(x$lon),
       ref_latitude = x$ref_lat,
       ref_longitude = x$ref_lon,
+      is_lat_lon = x$is_lat_lon,
       name = x$name
     )
   }

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -79,7 +79,7 @@ class variable.
 \details{
 Data depth metrics attempt to measure how close data a
 data point is to the center of its distribution. There are a
-number of methods for calculating death but a simple example is
+number of methods for calculating depth but a simple example is
 the inverse of the distance of a data point to the centroid of
 the distribution. Generally, small values indicate that a data
 point not close to the centroid. \code{step_depth} can compute a

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -12,6 +12,7 @@ step_geodist(
   trained = FALSE,
   ref_lat = NULL,
   ref_lon = NULL,
+  is_lat_lon = TRUE,
   log = FALSE,
   name = "geo_dist",
   columns = NULL,
@@ -35,6 +36,10 @@ preprocessing have been estimated.}
 
 \item{ref_lon, ref_lat}{Single numeric values for the location
 of the reference point.}
+
+\item{is_lat_lon}{A logical: Are coordinates in latitude and longitude? If
+TRUE the Haversine formula is used and the returned result is meters. If
+FALSE the Pythagorean formula is used. Default is TRUE.}
 
 \item{log}{A logical: should the distance be transformed by
 the natural log function?}
@@ -66,7 +71,8 @@ points on a map to a reference location.
 }
 \details{
 When you \code{\link[=tidy]{tidy()}} this step, a tibble with columns echoing the
-values of \code{lat}, \code{lon}, \code{ref_lat}, \code{ref_lon}, \code{name}, and \code{id} is returned.
+values of \code{lat}, \code{lon}, \code{ref_lat}, \code{ref_lon}, \code{is_lat_lon}, \code{name}, and \code{id}
+is returned.
 
 \code{step_geodist} will create a
 }
@@ -79,7 +85,8 @@ data(Smithsonian)
 near_station <- recipe( ~ ., data = Smithsonian) \%>\%
   update_role(name, new_role = "location") \%>\%
   step_geodist(lat = latitude, lon = longitude, log = FALSE,
-               ref_lat = 38.8986312, ref_lon = -77.0062457) \%>\%
+               ref_lat = 38.8986312, ref_lon = -77.0062457,
+               is_lat_lon = TRUE) \%>\%
   prep(training = Smithsonian)
 
 bake(near_station, new_data = NULL) \%>\%

--- a/tests/testthat/test_geodist.R
+++ b/tests/testthat/test_geodist.R
@@ -17,7 +17,8 @@ dists <-
 
 test_that('basic functionality', {
   rec <- recipe( ~ x + y, data = rand_data) %>%
-    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25, log = FALSE)
+    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25, is_lat_lon = FALSE,
+                 log = FALSE)
   rec_trained <- prep(rec, traning = rand_data)
 
   tr_int <- juice(rec_trained, all_predictors())
@@ -27,7 +28,8 @@ test_that('basic functionality', {
   expect_equal(te_int[["geo_dist"]], dists)
 
   rec_log <- recipe( ~ x + y, data = rand_data) %>%
-    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25, log = TRUE)
+    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25,  is_lat_lon = FALSE,
+                 log = TRUE)
   rec_log_trained <- prep(rec_log, traning = rand_data)
 
   tr_log_int <- juice(rec_log_trained, all_predictors())
@@ -35,6 +37,20 @@ test_that('basic functionality', {
 
   expect_equal(tr_log_int[["geo_dist"]], log(dists))
   expect_equal(te_log_int[["geo_dist"]], log(dists))
+
+})
+
+test_that('lat lon', {
+  postal <- tibble(latitude = 38.8981014, longitude = -77.0104265)
+  near_station <- recipe( ~ ., data = postal) %>%
+    step_geodist(lat = latitude, lon = longitude, log = FALSE,
+                 ref_lat = 38.8986312, ref_lon = -77.0062457,
+                 is_lat_lon = TRUE) %>%
+    prep() %>%
+    bake(new_data = NULL)
+
+  expect_equal(near_station[["geo_dist"]], 367, tolerance = 1)
+
 
 })
 
@@ -78,7 +94,8 @@ test_that('bad args', {
 
 test_that('printing', {
   rec <- recipe( ~ x + y, data = rand_data) %>%
-    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25, log = FALSE)
+    step_geodist(x, y, ref_lat = 0.5, ref_lon = 0.25, is_lat_lon = FALSE,
+                 log = FALSE)
   expect_output(print(rec))
   expect_output(prep(rec, training = rand_data, verbose = TRUE))
 })


### PR DESCRIPTION
- `step_depth`  typo.

- `step_geodist` used Pythagorean theorem which is misleading for latitude and longitude.  The method currently allows for one ref_lon and ref_lat so the use of `apply` was computationally disadvantageous in the previous code.  If the goal is to allow for multiple ref_lon and ref_lat, distance matrices, or bearing I can create another pull request.
- `step_geodist` Added the Haversine function for great circle distances.  You may want to switch to a geospatial package if you want other methods, but this should cover many common cases.
- `step_geodist` The Haversine or Pythagorean is chosen through a new argument is_lat_lon.

