### PR TITLE
Specify which step produces error with withCallingHandlers()

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -440,7 +440,7 @@ prep.recipe <-
           expr = prep(x$steps[[i]], training = training, info = x$term_info),
           error = function(c) {
             c$call <- call(attr(x$steps[[i]], "class")[1])
-            stop(c)
+            rlang::cnd_signal(c)
           }
         )
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -439,9 +439,7 @@ prep.recipe <-
         x$steps[[i]] <- withCallingHandlers(
           expr = prep(x$steps[[i]], training = training, info = x$term_info),
           error = function(c) {
-            c$message <- paste0(
-              "[in ", attr(x$steps[[i]], "class")[1], "()] ",c$message
-            )
+            c$call <- call(attr(x$steps[[i]], "class")[1])
             stop(c)
           }
         )

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -436,10 +436,16 @@ prep.recipe <-
 
         # Compute anything needed for the preprocessing steps
         # then apply it to the current training set
-        x$steps[[i]] <-
-          prep(x$steps[[i]],
-               training = training,
-               info = x$term_info)
+        x$steps[[i]] <- withCallingHandlers(
+          expr = prep(x$steps[[i]], training = training, info = x$term_info),
+          error = function(c) {
+            c$message <- paste0(
+              "[in ", attr(x$steps[[i]], "class")[1], "()] ",c$message
+            )
+            stop(c)
+          }
+        )
+
         training <- bake(x$steps[[i]], new_data = training)
         x$term_info <-
           merge_term_info(get_types(training), x$term_info)


### PR DESCRIPTION
This PR tries to close #420 by using `withCallingHandlers()` to modify the error message to include the name of the step which produces the error. Specifically when the error happens when the step is `prep()`ed in `prep.recipe()`.

I would like some feedback on the error message modification as well as I'm not 100% happy with it.

Pro: It appears to work where I have tested it.

Con: The traceback gets slightly more complicated. See `11:` and `4:` below.

``` r
library(recipes)

recipe(~ ., data = iris) %>%
  step_scale(all_predictors()) %>%
  prep()
#> Error: [in step_scale()] All columns selected for the step should be numeric
```

Traceback:

``` r
12: stop(c) at recipe.R#446
11: (function (c) 
    {
        c$message <- paste0("[in ", attr(x$steps[[i]], "class")[1], 
            "()] ", c$message)
        stop(c)
    })(structure(list(message = "All columns selected for the step should be numeric", 
        trace = structure(list(calls = list(recipe(~., data = iris) %>% 
            step_scale(all_predictors()) %>% prep(), recipes::prep(.), 
            recipes::prep.recipe(.), base::withCallingHandlers(expr = prep(x$steps[[i]], 
                training = training, info = x$term_info), error = function(c) {
                c$message <- paste0("[in ", attr(x$steps[[i]], "class")[1], 
                    "()] ", c$message)
                stop(c)
            }), recipes::prep(x$steps[[i]], training = training, 
                info = x$term_info), recipes::prep.step_scale(x$steps[[i]], 
                training = training, info = x$term_info), recipes::check_type(training[, 
                col_names])), parents = c(0L, 0L, 0L, 3L, 3L, 3L, 
        6L), indices = 1:7), class = "rlang_trace", version = 1L), 
        parent = NULL), class = c("rlang_error", "error", "condition"
    )))
10: signalCondition(cnd)
9: signal_abort(cnd)
8: rlang::abort(paste0("All columns selected for the step", " should be ", 
       label)) at misc.R#427
7: check_type(training[, col_names]) at scale.R#107
6: prep.step_scale(x$steps[[i]], training = training, info = x$term_info) at recipe.R#306
5: prep(x$steps[[i]], training = training, info = x$term_info) at recipe.R#439
4: withCallingHandlers(expr = prep(x$steps[[i]], training = training, 
       info = x$term_info), error = function(c) {
       c$message <- paste0("[in ", attr(x$steps[[i]], "class")[1], 
           "()] ", c$message)
       stop(c)
   }) at recipe.R#439
3: prep.recipe(.) at recipe.R#306
2: prep(.)
1: recipe(~., data = iris) %>% step_scale(all_predictors()) %>% 
       prep()
```

This is the traceback for the same error without the fix

``` r
9: stop(fallback)
8: signal_abort(cnd)
7: rlang::abort(paste0("All columns selected for the step", " should be ", 
       label)) at misc.R#427
6: check_type(training[, col_names]) at scale.R#107
5: prep.step_scale(x$steps[[i]], training = training, info = x$term_info) at recipe.R#306
4: prep(x$steps[[i]], training = training, info = x$term_info) at recipe.R#439
3: prep.recipe(.) at recipe.R#306
2: prep(.)
1: recipe(~., data = iris) %>% step_scale(all_predictors()) %>% 
       prep()
```

`check_type()`s error message should be modified if this PR goes through as it is half-baked right now

https://github.com/tidymodels/recipes/blob/a2155c52193a8238a5b06cbd2ab34bade39684ad/R/misc.R#L428-L433