### PR TITLE
updates to docs for recipe(), prep(), and bake()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,3 +70,6 @@ RdMacros:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
+Remotes:
+    tidymodels/parsnip
+    

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,7 @@ Suggests:
     kernlab,
     knitr,
     modeldata,
+    parsnip (>= 0.1.6.9000),
     RANN,
     RcppRoll,
     rmarkdown,
@@ -60,6 +61,7 @@ Suggests:
     rsample,
     RSpectra,
     testthat (>= 2.1.0),
+    workflows,
     xml2
 VignetteBuilder: 
     knitr

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -1,7 +1,7 @@
 #' Create a Recipe for Preprocessing Data
 #'
-#' A recipe is a description of what steps should be applied to a data set in
-#'   order to get it ready for data analysis.
+#' A recipe is a description of the steps to be applied to a data set in
+#'   order to prepare it for data analysis.
 #'
 #' @aliases recipe recipe.default recipe.formula
 #' @author Max Kuhn
@@ -52,7 +52,7 @@ recipe.default <- function(x, ...)
 #' @export
 #' @examples
 #'
-#' # simple example:
+#' # formula example with single outcome:
 #' library(modeldata)
 #' data(biomass)
 #'
@@ -60,20 +60,20 @@ recipe.default <- function(x, ...)
 #' biomass_tr <- biomass[biomass$dataset == "Training",]
 #' biomass_te <- biomass[biomass$dataset == "Testing",]
 #'
-#' # When only predictors and outcomes, a simplified formula can be used.
+#' # With only predictors and outcomes, use a formula
 #' rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
 #'               data = biomass_tr)
 #'
-#' # Now add preprocessing steps to the recipe.
+#' # Now add preprocessing steps to the recipe
 #' sp_signed <- rec %>%
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_spatialsign(all_numeric_predictors())
 #' sp_signed
 #'
 #' # ---------------------------------------------------------------------------
-#' # multivariate example
-#'
+#' # formula multivariate example:
 #' # no need for `cbind(carbon, hydrogen)` for left-hand side
+#'
 #' multi_y <- recipe(carbon + hydrogen ~ oxygen + nitrogen + sulfur,
 #'                   data = biomass_tr)
 #' multi_y <- multi_y %>%
@@ -81,9 +81,8 @@ recipe.default <- function(x, ...)
 #'   step_scale(all_numeric_predictors())
 #'
 #' # ---------------------------------------------------------------------------
-#' # example with manually updating different roles
-#'
-#' # best choice for high-dimensional data:
+#' # example using `update_role` instead of formula:
+#' # best choice for high-dimensional data
 #'
 #' rec <- recipe(biomass_tr) %>%
 #'   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,
@@ -280,13 +279,13 @@ prep <- function(x, ...)
 #' @details
 #'
 #' Given a data set, this function estimates the required quantities and
-#' statistics required by any operations. [prep()] returns an updated recipe
+#' statistics needed by any operations. [prep()] returns an updated recipe
 #' with the estimates. If you are using a recipe as a preprocessor for modeling,
-#' we **highly recommend** that you use a workflow instead of manually
+#' we **highly recommend** that you use a `workflow()` instead of manually
 #' estimating a recipe (see the example in [recipe()]).
 #'
-#' Note that missing data handling is handled in the steps; there is no global
-#'   `na.rm` option at the recipe-level or in [prep()].
+#' Note that missing data is handled in the steps; there is no global
+#'   `na.rm` option at the recipe level or in [prep()].
 #'
 #' Also, if a recipe has been trained using [prep()] and then steps
 #'   are added, [prep()] will only update the new operations. If
@@ -488,9 +487,9 @@ bake <- function(object, ...)
 #'  resolve to numeric columns (otherwise an error is thrown).
 #' @return A tibble, matrix, or sparse matrix that may have different
 #'  columns than the original columns in `new_data`.
-#' @details [bake()] takes a trained recipe and applies the operations to a
+#' @details [bake()] takes a trained recipe and applies its operations to a
 #'  data set to create a design matrix. If you are using a recipe as a
-#'  preprocessor for modeling, we **highly recommend** that you use a workflow
+#'  preprocessor for modeling, we **highly recommend** that you use a `workflow()`
 #'  instead of manually applying a recipe (see the example in [recipe()]).
 #'
 #' If the data set is not too large, time can be saved by using the

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -47,51 +47,11 @@ recipe.default <- function(x, ...)
 #'   as the data given in the `data` argument but can be different after
 #'   the recipe is trained.}
 #'
-#' @details Recipes are alternative methods for creating design matrices and
-#'   for preprocessing data.
-#'
-#' Variables in recipes can have any type of *role* in subsequent analyses
-#'   such as: outcome, predictor, case weights, stratification variables, etc.
-#'
-#' `recipe` objects can be created in several ways. If the analysis only
-#'   contains outcomes and predictors, the simplest way to create one is to use
-#'   a simple formula (e.g. `y ~ x1 + x2`) that does not contain inline
-#'   functions such as `log(x3)`. An example is given below.
-#'
-#' Alternatively, a `recipe` object can be created by first specifying
-#'   which variables in a data set should be used and then sequentially
-#'   defining their roles (see the last example). This alternative is an
-#'   excellent choice when the number of variables is very high, as the
-#'   formula method is memory-inefficient with many variables.
-#'
-#' There are two different types of operations that can be
-#'  sequentially added to a recipe. **Steps**  can include common
-#'  operations like logging a variable, creating dummy variables or
-#'  interactions and so on. More computationally complex actions
-#'  such as dimension reduction or imputation can also be specified.
-#'  **Checks** are operations that conduct specific tests of the
-#'  data. When the test is satisfied, the data are returned without
-#'  issue or modification. Otherwise, any error is thrown.
-#'
-#' Once a recipe has been defined, the [prep()] function can be
-#'  used to estimate quantities required for the operations using a
-#'  data set (a.k.a. the training data). [prep()] returns another
-#'  recipe.
-#'
-#' To apply the recipe to a data set, the [bake()] function is
-#'   used in the same manner as `predict` would be for models. This
-#'   applies the steps to any data set.
-#'
-#' Note that the data passed to `recipe` need not be the complete data
-#'   that will be used to train the steps (by [prep()]). The recipe
-#'   only needs to know the names and types of data that will be used. For
-#'   large data sets, `head` could be used to pass the recipe a smaller
-#'   data set to save time and memory.
+#' @includeRmd man/rmd/recipes.Rmd details
 #'
 #' @export
 #' @examples
 #'
-#' ###############################################
 #' # simple example:
 #' library(modeldata)
 #' data(biomass)
@@ -105,26 +65,12 @@ recipe.default <- function(x, ...)
 #'               data = biomass_tr)
 #'
 #' # Now add preprocessing steps to the recipe.
-#'
 #' sp_signed <- rec %>%
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_spatialsign(all_numeric_predictors())
 #' sp_signed
 #'
-#' # now estimate required parameters
-#' sp_signed_trained <- prep(sp_signed, training = biomass_tr)
-#' sp_signed_trained
-#'
-#' # apply the preprocessing to a data set
-#' test_set_values <- bake(sp_signed_trained, new_data = biomass_te)
-#'
-#' # or use pipes for the entire workflow:
-#' rec <- biomass_tr %>%
-#'   recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur) %>%
-#'   step_normalize(all_numeric_predictors()) %>%
-#'   step_spatialsign(all_numeric_predictors())
-#'
-#' ###############################################
+#' # ---------------------------------------------------------------------------
 #' # multivariate example
 #'
 #' # no need for `cbind(carbon, hydrogen)` for left-hand side
@@ -134,11 +80,7 @@ recipe.default <- function(x, ...)
 #'   step_center(all_numeric_predictors()) %>%
 #'   step_scale(all_numeric_predictors())
 #'
-#' multi_y_trained <- prep(multi_y, training = biomass_tr)
-#'
-#' results <- bake(multi_y_trained, biomass_te)
-#'
-#' ###############################################
+#' # ---------------------------------------------------------------------------
 #' # example with manually updating different roles
 #'
 #' # best choice for high-dimensional data:
@@ -306,7 +248,7 @@ inline_check <- function(x) {
 prep <- function(x, ...)
   UseMethod("prep")
 
-#' Train a Data Recipe
+#' Estimate a Data Recipe
 #'
 #' For a recipe with at least one preprocessing operation, estimate the required
 #'   parameters from a training set that can be later applied to other data
@@ -335,10 +277,13 @@ prep <- function(x, ...)
 #'   quantities (e.g. parameter estimates, model objects, etc). Also, the
 #'   `term_info` object is likely to be modified as the operations are
 #'   executed.
-#' @details Given a data set, this function estimates the required quantities
-#'   and statistics required by any operations.
+#' @details
 #'
-#' [prep()] returns an updated recipe with the estimates.
+#' Given a data set, this function estimates the required quantities and
+#' statistics required by any operations. [prep()] returns an updated recipe
+#' with the estimates. If you are using a recipe as a preprocessor for modeling,
+#' we **highly recommend** that you use a workflow instead of manually
+#' estimating a recipe (see the example in [recipe()]).
 #'
 #' Note that missing data handling is handled in the steps; there is no global
 #'   `na.rm` option at the recipe-level or in [prep()].
@@ -543,8 +488,10 @@ bake <- function(object, ...)
 #'  resolve to numeric columns (otherwise an error is thrown).
 #' @return A tibble, matrix, or sparse matrix that may have different
 #'  columns than the original columns in `new_data`.
-#' @details [bake()] takes a trained recipe and applies the
-#'   operations to a data set to create a design matrix.
+#' @details [bake()] takes a trained recipe and applies the operations to a
+#'  data set to create a design matrix. If you are using a recipe as a
+#'  preprocessor for modeling, we **highly recommend** that you use a workflow
+#'  instead of manually applying a recipe (see the example in [recipe()]).
 #'
 #' If the data set is not too large, time can be saved by using the
 #'  `retain = TRUE` option of [prep()]. This stores the processed version of the

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -38,9 +38,9 @@ For a recipe with at least one preprocessing operation that has been trained by
 \code{\link[=prep.recipe]{prep.recipe()}}, apply the computations to new data.
 }
 \details{
-\code{\link[=bake]{bake()}} takes a trained recipe and applies the operations to a
+\code{\link[=bake]{bake()}} takes a trained recipe and applies its operations to a
 data set to create a design matrix. If you are using a recipe as a
-preprocessor for modeling, we \strong{highly recommend} that you use a workflow
+preprocessor for modeling, we \strong{highly recommend} that you use a \code{workflow()}
 instead of manually applying a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
 If the data set is not too large, time can be saved by using the

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -38,8 +38,10 @@ For a recipe with at least one preprocessing operation that has been trained by
 \code{\link[=prep.recipe]{prep.recipe()}}, apply the computations to new data.
 }
 \details{
-\code{\link[=bake]{bake()}} takes a trained recipe and applies the
-operations to a data set to create a design matrix.
+\code{\link[=bake]{bake()}} takes a trained recipe and applies the operations to a
+data set to create a design matrix. If you are using a recipe as a
+preprocessor for modeling, we \strong{highly recommend} that you use a workflow
+instead of manually applying a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
 If the data set is not too large, time can be saved by using the
 \code{retain = TRUE} option of \code{\link[=prep]{prep()}}. This stores the processed version of the

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -3,7 +3,7 @@
 \name{prep}
 \alias{prep}
 \alias{prep.recipe}
-\title{Train a Data Recipe}
+\title{Estimate a Data Recipe}
 \usage{
 prep(x, ...)
 
@@ -62,10 +62,11 @@ parameters from a training set that can be later applied to other data
 sets.
 }
 \details{
-Given a data set, this function estimates the required quantities
-and statistics required by any operations.
-
-\code{\link[=prep]{prep()}} returns an updated recipe with the estimates.
+Given a data set, this function estimates the required quantities and
+statistics required by any operations. \code{\link[=prep]{prep()}} returns an updated recipe
+with the estimates. If you are using a recipe as a preprocessor for modeling,
+we \strong{highly recommend} that you use a workflow instead of manually
+estimating a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
 Note that missing data handling is handled in the steps; there is no global
 \code{na.rm} option at the recipe-level or in \code{\link[=prep]{prep()}}.

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -63,13 +63,13 @@ sets.
 }
 \details{
 Given a data set, this function estimates the required quantities and
-statistics required by any operations. \code{\link[=prep]{prep()}} returns an updated recipe
+statistics needed by any operations. \code{\link[=prep]{prep()}} returns an updated recipe
 with the estimates. If you are using a recipe as a preprocessor for modeling,
-we \strong{highly recommend} that you use a workflow instead of manually
+we \strong{highly recommend} that you use a \code{workflow()} instead of manually
 estimating a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
-Note that missing data handling is handled in the steps; there is no global
-\code{na.rm} option at the recipe-level or in \code{\link[=prep]{prep()}}.
+Note that missing data is handled in the steps; there is no global
+\code{na.rm} option at the recipe level or in \code{\link[=prep]{prep()}}.
 
 Also, if a recipe has been trained using \code{\link[=prep]{prep()}} and then steps
 are added, \code{\link[=prep]{prep()}} will only update the new operations. If

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -55,20 +55,19 @@ as the data given in the \code{data} argument but can be different after
 the recipe is trained.}
 }
 \description{
-A recipe is a description of what steps should be applied to a data set in
-order to get it ready for data analysis.
+A recipe is a description of the steps to be applied to a data set in
+order to prepare it for data analysis.
 }
 \details{
 \subsection{Defining recipes}{
 
-Variables in recipes can have any type of \emph{role} in subsequent analyses
-such as: outcome, predictor, case weights, stratification variables,
-etc.
+Variables in recipes can have any type of \emph{role}, including outcome,
+predictor, observation ID, case weights, stratification variables, etc.
 
-\code{recipe} objects can be created in several ways. If the analysis only
+\code{recipe} objects can be created in several ways. If an analysis only
 contains outcomes and predictors, the simplest way to create one is to
-use a simple formula (e.g. \code{y ~ x1 + x2}) that does not contain inline
-functions such as \code{log(x3)}. An example is given below.
+use a formula (e.g. \code{y ~ x1 + x2}) that does not contain inline
+functions such as \code{log(x3)} (see the first example below).
 
 Alternatively, a \code{recipe} object can be created by first specifying
 which variables in a data set should be used and then sequentially
@@ -79,45 +78,43 @@ formula method is memory-inefficient with many variables.
 There are two different types of operations that can be sequentially
 added to a recipe.
 \itemize{
-\item \strong{Steps} can include common operations like logging a variable,
-creating dummy variables or interactions and so on. More
-computationally complex actions such as dimension reduction or
-imputation can also be specified.
+\item \strong{Steps} can include operations like scaling a variable, creating
+dummy variables or interactions, and so on. More computationally
+complex actions such as dimension reduction or imputation can also
+be specified.
 \item \strong{Checks} are operations that conduct specific tests of the data.
 When the test is satisfied, the data are returned without issue or
-modification. Otherwise, any error is thrown.
+modification. Otherwise, an error is thrown.
 }
 
-If you have defined a recipe and want to see which steps are incluced,
+If you have defined a recipe and want to see which steps are included,
 use the \code{tidy()} method on the recipe object.
 
 Note that the data passed to \code{recipe()} need not be the complete data
 that will be used to train the steps (by \code{\link[=prep]{prep()}}). The recipe
 only needs to know the names and types of data that will be used. For
-large data sets, \code{head()} could be used to pass the recipe a smaller
-data set to save time and memory.
+large data sets, \code{head()} could be used to pass a smaller data set to
+save time and memory.
 }
 
 \subsection{Using recipes}{
 
-Most recipe steps have quantities that need to be calculated or
-estimated. For example, \code{step_normalize()} needs to compute the training
-set mean for the selected columns. Also, \code{step_dummy()} needs to
-determine the factor levels of selected columns in order to make the
-apprirate indicator columns.
-
 Once a recipe is defined, it needs to be \emph{estimated} before being
-applied to data. The two most common applicaiton of recipes are modeling
-and stand-alone preprocessing. How we recipe is estimated depends on how
-it is being used.
+applied to data. Most recipe steps have specific quantities that must be
+calculated or estimated. For example, \code{step_normalize()} needs to
+compute the training set’s mean for the selected columns, while
+\code{step_dummy()} needs to determine the factor levels of selected columns
+in order to make the appropriate indicator columns.
+
+The two most common application of recipes are modeling and stand-alone
+preprocessing. How the recipe is estimated depends on how it is being
+used.
 \subsection{Modeling}{
 
-It best way to use use a recipe for modeling is via the \code{workflows}
+The best way to use use a recipe for modeling is via the \code{workflows}
 package. This bundles a model and preprocessor (e.g. a recipe) together
-and gives the user a simple want to train the model/recipe and make
-predictions.
-
-Here is a simple example:\if{html}{\out{<div class="r">}}\preformatted{library(dplyr)
+and gives the user a fluent way to train the model/recipe and make
+predictions.\if{html}{\out{<div class="r">}}\preformatted{library(dplyr)
 library(workflows)
 library(recipes)
 library(parsnip)
@@ -128,11 +125,11 @@ data(biomass, package = "modeldata")
 biomass_tr <- biomass[biomass$dataset == "Training",]
 biomass_te <- biomass[biomass$dataset == "Testing",]
 
-# When only predictors and outcomes, a simplified formula can be used.
+# With only predictors and outcomes, use a formula:
 rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
               data = biomass_tr)
 
-# Now add preprocessing steps to the recipe.
+# Now add preprocessing steps to the recipe:
 sp_signed <- 
   rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
@@ -152,32 +149,33 @@ sp_signed
 ## Spatial sign on  all_numeric_predictors()
 }
 
-We can create a \code{parsnip} model and then a workflow with the model and
-recipe:\if{html}{\out{<div class="r">}}\preformatted{linear_mod <- linear_reg()
+We can create a \code{parsnip} model, and then build a workflow with the
+model and recipe:\if{html}{\out{<div class="r">}}\preformatted{linear_mod <- linear_reg()
 
 linear_sp_sign_wflow <- 
   workflow() \%>\% 
   add_model(linear_mod) \%>\% 
   add_recipe(sp_signed)
+
 linear_sp_sign_wflow
-}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ════════════════════════════════════════════════════════════════════
+}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ══════════════════════════════════════════════════════════
 ## Preprocessor: Recipe
 ## Model: linear_reg()
 ## 
-## ── Preprocessor ────────────────────────────────────────────────────────────────
+## ── Preprocessor ──────────────────────────────────────────────────────
 ## 2 Recipe Steps
 ## 
 ## • step_normalize()
 ## • step_spatialsign()
 ## 
-## ── Model ───────────────────────────────────────────────────────────────────────
+## ── Model ─────────────────────────────────────────────────────────────
 ## Linear Regression Model Specification (regression)
 ## 
 ## Computational engine: lm
 }
 
 To estimate the preprocessing steps and then fit the linear model, a
-simple call to \code{fit()} is used:\if{html}{\out{<div class="r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
+single call to \code{fit()} is used:\if{html}{\out{<div class="r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
 }\if{html}{\out{</div>}}
 
 When predicting, there is no need to do anything other than call
@@ -197,15 +195,15 @@ training set, then gives the data to the linear model prediction code:\if{html}{
 
 \subsection{Stand-alone use of recipes}{
 
-When using a recipe to generate data for a visualization, or to
-troubleshoot any issues, there are functions that can be used to
-estimate the recipe and apply is to new data manually.
+When using a recipe to generate data for a visualization or to
+troubleshoot any problems with the recipe, there are functions that can
+be used to estimate the recipe and apply it to new data manually.
 
 Once a recipe has been defined, the \code{\link[=prep]{prep()}} function can be
 used to estimate quantities required for the operations using a data set
-(a.k.a. the training data). \code{\link[=prep]{prep()}} returns another recipe.
+(a.k.a. the training data). \code{\link[=prep]{prep()}} returns a recipe.
 
-As an example of using PCA to produce a plot:\if{html}{\out{<div class="r">}}\preformatted{# Define the recipe
+As an example of using PCA (perhaps to produce a plot):\if{html}{\out{<div class="r">}}\preformatted{# Define the recipe
 pca_rec <- 
   rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
@@ -226,16 +224,27 @@ pca_rec
 ## 
 ## Operations:
 ## 
-## Centering and scaling for carbon, hydrogen, oxygen, nitrogen, sulfur [trained]
-## PCA extraction with carbon, hydrogen, oxygen, nitrogen, sulfur [trained]
+## Centering and scaling for carbon, hydrogen, oxygen, nitrogen, s... [trained]
+## PCA extraction with carbon, hydrogen, oxygen, nitrogen, su... [trained]
 }
 
 Note that the estimated recipe shows the actual column names captured by
 the selectors.
 
-To apply the recipe to a data set, the \code{\link[=bake]{bake()}} function is
-used in the same manner as \code{predict()} would be for models. This applies
-the estimated steps to any data set.\if{html}{\out{<div class="r">}}\preformatted{bake(pca_rec, head(biomass_te))
+You can \code{\link[=tidy.recipe]{tidy.recipe()}} a recipe, either when it is
+prepped or unprepped, to learn more about its components.\if{html}{\out{<div class="r">}}\preformatted{tidy(pca_rec)
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 x 6
+##   number operation type      trained skip  id             
+##    <int> <chr>     <chr>     <lgl>   <lgl> <chr>          
+## 1      1 step      normalize TRUE    FALSE normalize_d7J7E
+## 2      2 step      pca       TRUE    FALSE pca_I6GjL
+}
+
+You can also \code{tidy()} recipe \emph{steps} with a \code{number} or \code{id} argument.
+
+To apply the prepped recipe to a data set, the \code{\link[=bake]{bake()}}
+function is used in the same manner that \code{predict()} would be for
+models. This applies the estimated steps to any data set.\if{html}{\out{<div class="r">}}\preformatted{bake(pca_rec, head(biomass_te))
 }\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 x 6
 ##     HHV    PC1    PC2     PC3     PC4     PC5
 ##   <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>
@@ -247,14 +256,15 @@ the estimated steps to any data set.\if{html}{\out{<div class="r">}}\preformatte
 ## 6  18.5 0.433   0.127  0.354  -0.0168 -0.0888
 }
 
-In general, the workflow interface to recipes is recommended.
+In general, the workflow interface to recipes is recommended for most
+applications.
 }
 
 }
 }
 \examples{
 
-# simple example:
+# formula example with single outcome:
 library(modeldata)
 data(biomass)
 
@@ -262,20 +272,20 @@ data(biomass)
 biomass_tr <- biomass[biomass$dataset == "Training",]
 biomass_te <- biomass[biomass$dataset == "Testing",]
 
-# When only predictors and outcomes, a simplified formula can be used.
+# With only predictors and outcomes, use a formula
 rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
               data = biomass_tr)
 
-# Now add preprocessing steps to the recipe.
+# Now add preprocessing steps to the recipe
 sp_signed <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_spatialsign(all_numeric_predictors())
 sp_signed
 
 # ---------------------------------------------------------------------------
-# multivariate example
-
+# formula multivariate example:
 # no need for `cbind(carbon, hydrogen)` for left-hand side
+
 multi_y <- recipe(carbon + hydrogen ~ oxygen + nitrogen + sulfur,
                   data = biomass_tr)
 multi_y <- multi_y \%>\%
@@ -283,9 +293,8 @@ multi_y <- multi_y \%>\%
   step_scale(all_numeric_predictors())
 
 # ---------------------------------------------------------------------------
-# example with manually updating different roles
-
-# best choice for high-dimensional data:
+# example using `update_role` instead of formula:
+# best choice for high-dimensional data
 
 rec <- recipe(biomass_tr) \%>\%
   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -59,15 +59,15 @@ A recipe is a description of what steps should be applied to a data set in
 order to get it ready for data analysis.
 }
 \details{
-Recipes are alternative methods for creating design matrices and
-for preprocessing data.
+\subsection{Defining recipes}{
 
 Variables in recipes can have any type of \emph{role} in subsequent analyses
-such as: outcome, predictor, case weights, stratification variables, etc.
+such as: outcome, predictor, case weights, stratification variables,
+etc.
 
 \code{recipe} objects can be created in several ways. If the analysis only
-contains outcomes and predictors, the simplest way to create one is to use
-a simple formula (e.g. \code{y ~ x1 + x2}) that does not contain inline
+contains outcomes and predictors, the simplest way to create one is to
+use a simple formula (e.g. \code{y ~ x1 + x2}) that does not contain inline
 functions such as \code{log(x3)}. An example is given below.
 
 Alternatively, a \code{recipe} object can be created by first specifying
@@ -76,33 +76,184 @@ defining their roles (see the last example). This alternative is an
 excellent choice when the number of variables is very high, as the
 formula method is memory-inefficient with many variables.
 
-There are two different types of operations that can be
-sequentially added to a recipe. \strong{Steps}  can include common
-operations like logging a variable, creating dummy variables or
-interactions and so on. More computationally complex actions
-such as dimension reduction or imputation can also be specified.
-\strong{Checks} are operations that conduct specific tests of the
-data. When the test is satisfied, the data are returned without
-issue or modification. Otherwise, any error is thrown.
+There are two different types of operations that can be sequentially
+added to a recipe.
+\itemize{
+\item \strong{Steps} can include common operations like logging a variable,
+creating dummy variables or interactions and so on. More
+computationally complex actions such as dimension reduction or
+imputation can also be specified.
+\item \strong{Checks} are operations that conduct specific tests of the data.
+When the test is satisfied, the data are returned without issue or
+modification. Otherwise, any error is thrown.
+}
 
-Once a recipe has been defined, the \code{\link[=prep]{prep()}} function can be
-used to estimate quantities required for the operations using a
-data set (a.k.a. the training data). \code{\link[=prep]{prep()}} returns another
-recipe.
+If you have defined a recipe and want to see which steps are incluced,
+use the \code{tidy()} method on the recipe object.
 
-To apply the recipe to a data set, the \code{\link[=bake]{bake()}} function is
-used in the same manner as \code{predict} would be for models. This
-applies the steps to any data set.
-
-Note that the data passed to \code{recipe} need not be the complete data
+Note that the data passed to \code{recipe()} need not be the complete data
 that will be used to train the steps (by \code{\link[=prep]{prep()}}). The recipe
 only needs to know the names and types of data that will be used. For
-large data sets, \code{head} could be used to pass the recipe a smaller
+large data sets, \code{head()} could be used to pass the recipe a smaller
 data set to save time and memory.
+}
+
+\subsection{Using recipes}{
+
+Most recipe steps have quantities that need to be calculated or
+estimated. For example, \code{step_normalize()} needs to compute the training
+set mean for the selected columns. Also, \code{step_dummy()} needs to
+determine the factor levels of selected columns in order to make the
+apprirate indicator columns.
+
+Once a recipe is defined, it needs to be \emph{estimated} before being
+applied to data. The two most common applicaiton of recipes are modeling
+and stand-alone preprocessing. How we recipe is estimated depends on how
+it is being used.
+\subsection{Modeling}{
+
+It best way to use use a recipe for modeling is via the \code{workflows}
+package. This bundles a model and preprocessor (e.g. a recipe) together
+and gives the user a simple want to train the model/recipe and make
+predictions.
+
+Here is a simple example:\if{html}{\out{<div class="r">}}\preformatted{library(dplyr)
+library(workflows)
+library(recipes)
+library(parsnip)
+
+data(biomass, package = "modeldata")
+
+# split data
+biomass_tr <- biomass[biomass$dataset == "Training",]
+biomass_te <- biomass[biomass$dataset == "Testing",]
+
+# When only predictors and outcomes, a simplified formula can be used.
+rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
+              data = biomass_tr)
+
+# Now add preprocessing steps to the recipe.
+sp_signed <- 
+  rec \%>\%
+  step_normalize(all_numeric_predictors()) \%>\%
+  step_spatialsign(all_numeric_predictors())
+sp_signed
+}\if{html}{\out{</div>}}\preformatted{## Data Recipe
+## 
+## Inputs:
+## 
+##       role #variables
+##    outcome          1
+##  predictor          5
+## 
+## Operations:
+## 
+## Centering and scaling for all_numeric_predictors()
+## Spatial sign on  all_numeric_predictors()
+}
+
+We can create a \code{parsnip} model and then a workflow with the model and
+recipe:\if{html}{\out{<div class="r">}}\preformatted{linear_mod <- linear_reg()
+
+linear_sp_sign_wflow <- 
+  workflow() \%>\% 
+  add_model(linear_mod) \%>\% 
+  add_recipe(sp_signed)
+linear_sp_sign_wflow
+}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ════════════════════════════════════════════════════════════════════
+## Preprocessor: Recipe
+## Model: linear_reg()
+## 
+## ── Preprocessor ────────────────────────────────────────────────────────────────
+## 2 Recipe Steps
+## 
+## • step_normalize()
+## • step_spatialsign()
+## 
+## ── Model ───────────────────────────────────────────────────────────────────────
+## Linear Regression Model Specification (regression)
+## 
+## Computational engine: lm
+}
+
+To estimate the preprocessing steps and then fit the linear model, a
+simple call to \code{fit()} is used:\if{html}{\out{<div class="r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
+}\if{html}{\out{</div>}}
+
+When predicting, there is no need to do anything other than call
+\code{predict()}. This preprocesses the new data in the same manner as the
+training set, then gives the data to the linear model prediction code:\if{html}{\out{<div class="r">}}\preformatted{predict(linear_sp_sign_fit, new_data = head(biomass_te))
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 x 1
+##   .pred
+##   <dbl>
+## 1  18.1
+## 2  17.9
+## 3  17.2
+## 4  18.8
+## 5  19.6
+## 6  14.6
+}
+}
+
+\subsection{Stand-alone use of recipes}{
+
+When using a recipe to generate data for a visualization, or to
+troubleshoot any issues, there are functions that can be used to
+estimate the recipe and apply is to new data manually.
+
+Once a recipe has been defined, the \code{\link[=prep]{prep()}} function can be
+used to estimate quantities required for the operations using a data set
+(a.k.a. the training data). \code{\link[=prep]{prep()}} returns another recipe.
+
+As an example of using PCA to produce a plot:\if{html}{\out{<div class="r">}}\preformatted{# Define the recipe
+pca_rec <- 
+  rec \%>\%
+  step_normalize(all_numeric_predictors()) \%>\%
+  step_pca(all_numeric_predictors())
+}\if{html}{\out{</div>}}
+
+Now to estimate the normalization statistics and the PCA loadings:\if{html}{\out{<div class="r">}}\preformatted{pca_rec <- prep(pca_rec, training = biomass_tr)
+pca_rec
+}\if{html}{\out{</div>}}\preformatted{## Data Recipe
+## 
+## Inputs:
+## 
+##       role #variables
+##    outcome          1
+##  predictor          5
+## 
+## Training data contained 456 data points and no missing data.
+## 
+## Operations:
+## 
+## Centering and scaling for carbon, hydrogen, oxygen, nitrogen, sulfur [trained]
+## PCA extraction with carbon, hydrogen, oxygen, nitrogen, sulfur [trained]
+}
+
+Note that the estimated recipe shows the actual column names captured by
+the selectors.
+
+To apply the recipe to a data set, the \code{\link[=bake]{bake()}} function is
+used in the same manner as \code{predict()} would be for models. This applies
+the estimated steps to any data set.\if{html}{\out{<div class="r">}}\preformatted{bake(pca_rec, head(biomass_te))
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 x 6
+##     HHV    PC1    PC2     PC3     PC4     PC5
+##   <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>
+## 1  18.3 0.730   0.412  0.495   0.333   0.253 
+## 2  17.6 0.617  -1.41  -0.118  -0.466   0.815 
+## 3  17.2 0.761  -1.10   0.0550 -0.397   0.747 
+## 4  18.9 0.0400 -0.950 -0.158   0.405  -0.143 
+## 5  20.5 0.792   0.732 -0.204   0.465  -0.148 
+## 6  18.5 0.433   0.127  0.354  -0.0168 -0.0888
+}
+
+In general, the workflow interface to recipes is recommended.
+}
+
+}
 }
 \examples{
 
-###############################################
 # simple example:
 library(modeldata)
 data(biomass)
@@ -116,26 +267,12 @@ rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
               data = biomass_tr)
 
 # Now add preprocessing steps to the recipe.
-
 sp_signed <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_spatialsign(all_numeric_predictors())
 sp_signed
 
-# now estimate required parameters
-sp_signed_trained <- prep(sp_signed, training = biomass_tr)
-sp_signed_trained
-
-# apply the preprocessing to a data set
-test_set_values <- bake(sp_signed_trained, new_data = biomass_te)
-
-# or use pipes for the entire workflow:
-rec <- biomass_tr \%>\%
-  recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur) \%>\%
-  step_normalize(all_numeric_predictors()) \%>\%
-  step_spatialsign(all_numeric_predictors())
-
-###############################################
+# ---------------------------------------------------------------------------
 # multivariate example
 
 # no need for `cbind(carbon, hydrogen)` for left-hand side
@@ -145,11 +282,7 @@ multi_y <- multi_y \%>\%
   step_center(all_numeric_predictors()) \%>\%
   step_scale(all_numeric_predictors())
 
-multi_y_trained <- prep(multi_y, training = biomass_tr)
-
-results <- bake(multi_y_trained, biomass_te)
-
-###############################################
+# ---------------------------------------------------------------------------
 # example with manually updating different roles
 
 # best choice for high-dimensional data:

--- a/man/rmd/recipes.Rmd
+++ b/man/rmd/recipes.Rmd
@@ -1,4 +1,6 @@
 ```{r startup, include = FALSE}
+options(width = 70)
+
 library(dplyr)
 library(workflows)
 library(recipes)
@@ -7,33 +9,31 @@ library(parsnip)
 
 ## Defining recipes
 
-Variables in recipes can have any type of *role* in subsequent analyses such as: outcome, predictor, case weights, stratification variables, etc.
+Variables in recipes can have any type of *role*, including outcome, predictor, observation ID, case weights, stratification variables, etc.
 
-`recipe` objects can be created in several ways. If the analysis only contains outcomes and predictors, the simplest way to create one is to use a simple formula (e.g. `y ~ x1 + x2`) that does not contain inline functions such as `log(x3)`. An example is given below.
+`recipe` objects can be created in several ways. If an analysis only contains outcomes and predictors, the simplest way to create one is to use a formula (e.g. `y ~ x1 + x2`) that does not contain inline functions such as `log(x3)` (see the first example below).
 
 Alternatively, a `recipe` object can be created by first specifying which variables in a data set should be used and then sequentially defining their roles (see the last example). This alternative is an excellent choice when the number of variables is very high, as the formula method is memory-inefficient with many variables. 
 
 There are two different types of operations that can be sequentially added to a recipe. 
 
-- **Steps** can include common operations like logging a variable, creating dummy variables or interactions and so on. More computationally complex actions such as dimension reduction or imputation can also be specified. 
+- **Steps** can include operations like scaling a variable, creating dummy variables or interactions, and so on. More computationally complex actions such as dimension reduction or imputation can also be specified. 
 
-- **Checks** are operations that conduct specific tests of the data. When the test is satisfied, the data are returned without issue or modification. Otherwise, any error is thrown.
+- **Checks** are operations that conduct specific tests of the data. When the test is satisfied, the data are returned without issue or modification. Otherwise, an error is thrown.
 
-If you have defined a recipe and want to see which steps are incluced, use the `tidy()` method on the recipe object. 
+If you have defined a recipe and want to see which steps are included, use the `tidy()` method on the recipe object.
 
-Note that the data passed to `recipe()` need not be the complete data that will be used to train the steps (by [prep()]). The recipe only needs to know the names and types of data that will be used. For large data sets, `head()` could be used to pass the recipe a smaller data set to save time and memory.
+Note that the data passed to `recipe()` need not be the complete data that will be used to train the steps (by [prep()]). The recipe only needs to know the names and types of data that will be used. For large data sets, `head()` could be used to pass a smaller data set to save time and memory.
 
 ## Using recipes
 
-Most recipe steps have quantities that need to be calculated or estimated. For example, `step_normalize()` needs to compute the training set mean for the selected columns. Also, `step_dummy()` needs to determine the factor levels of selected columns in order to make the apprirate indicator columns. 
+Once a recipe is defined, it needs to be _estimated_ before being applied to data. Most recipe steps have specific quantities that must be calculated or estimated. For example, `step_normalize()` needs to compute the training set's mean for the selected columns, while `step_dummy()` needs to determine the factor levels of selected columns in order to make the appropriate indicator columns. 
 
-Once a recipe is defined, it needs to be _estimated_ before being applied to data. The two most common applicaiton of recipes are modeling and stand-alone preprocessing. How we recipe is estimated depends on how it is being used. 
+The two most common application of recipes are modeling and stand-alone preprocessing. How the recipe is estimated depends on how it is being used. 
 
 ### Modeling
 
-It best way to use use a recipe for modeling is via the `workflows` package. This bundles a model and preprocessor (e.g. a recipe) together and gives the user a simple want to train the model/recipe and make predictions. 
-
-Here is a simple example: 
+The best way to use use a recipe for modeling is via the `workflows` package. This bundles a model and preprocessor (e.g. a recipe) together and gives the user a fluent way to train the model/recipe and make predictions. 
 
 ```{r }
 library(dplyr)
@@ -47,11 +47,11 @@ data(biomass, package = "modeldata")
 biomass_tr <- biomass[biomass$dataset == "Training",]
 biomass_te <- biomass[biomass$dataset == "Testing",]
 
-# When only predictors and outcomes, a simplified formula can be used.
+# With only predictors and outcomes, use a formula:
 rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
               data = biomass_tr)
 
-# Now add preprocessing steps to the recipe.
+# Now add preprocessing steps to the recipe:
 sp_signed <- 
   rec %>%
   step_normalize(all_numeric_predictors()) %>%
@@ -59,7 +59,7 @@ sp_signed <-
 sp_signed
 ```
 
-We can create a `parsnip` model and then a workflow with the model and recipe: 
+We can create a `parsnip` model, and then build a workflow with the model and recipe: 
 
 ```{r}
 linear_mod <- linear_reg()
@@ -68,10 +68,11 @@ linear_sp_sign_wflow <-
   workflow() %>% 
   add_model(linear_mod) %>% 
   add_recipe(sp_signed)
+
 linear_sp_sign_wflow
 ```
 
-To estimate the preprocessing steps and then fit the linear model, a simple call to `fit()` is used:
+To estimate the preprocessing steps and then fit the linear model, a single call to `fit()` is used:
 
 ```{r}
 linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
@@ -85,11 +86,11 @@ predict(linear_sp_sign_fit, new_data = head(biomass_te))
 
 ### Stand-alone use of recipes
 
-When using a recipe to generate data for a visualization, or to troubleshoot any issues, there are functions that can be used to estimate the recipe and apply is to new data manually.
+When using a recipe to generate data for a visualization or to troubleshoot any problems with the recipe, there are functions that can be used to estimate the recipe and apply it to new data manually.
 
-Once a recipe has been defined, the [prep()] function can be used to estimate quantities required for the operations using a data set (a.k.a. the training data). [prep()] returns another recipe.
+Once a recipe has been defined, the [prep()] function can be used to estimate quantities required for the operations using a data set (a.k.a. the training data). [prep()] returns a recipe.
 
-As an example of using PCA to produce a plot: 
+As an example of using PCA (perhaps to produce a plot): 
 
 ```{r}
 # Define the recipe
@@ -105,14 +106,23 @@ Now to estimate the normalization statistics and the PCA loadings:
 pca_rec <- prep(pca_rec, training = biomass_tr)
 pca_rec
 ```
+
 Note that the estimated recipe shows the actual column names captured by the selectors. 
 
-To apply the recipe to a data set, the [bake()] function is used in the same manner as `predict()` would be for models. This applies the estimated steps to any data set.
+You can [tidy.recipe()] a recipe, either when it is prepped or unprepped, to learn more about its components.
+
+```{r}
+tidy(pca_rec)
+```
+
+You can also `tidy()` recipe *steps* with a `number` or `id` argument.
+
+To apply the prepped recipe to a data set, the [bake()] function is used in the same manner that `predict()` would be for models. This applies the estimated steps to any data set.
 
 ```{r}
 bake(pca_rec, head(biomass_te))
 ```
 
-In general, the workflow interface to recipes is recommended. 
+In general, the workflow interface to recipes is recommended for most applications. 
 
 

--- a/man/rmd/recipes.Rmd
+++ b/man/rmd/recipes.Rmd
@@ -1,0 +1,118 @@
+```{r startup, include = FALSE}
+library(dplyr)
+library(workflows)
+library(recipes)
+library(parsnip)
+```
+
+## Defining recipes
+
+Variables in recipes can have any type of *role* in subsequent analyses such as: outcome, predictor, case weights, stratification variables, etc.
+
+`recipe` objects can be created in several ways. If the analysis only contains outcomes and predictors, the simplest way to create one is to use a simple formula (e.g. `y ~ x1 + x2`) that does not contain inline functions such as `log(x3)`. An example is given below.
+
+Alternatively, a `recipe` object can be created by first specifying which variables in a data set should be used and then sequentially defining their roles (see the last example). This alternative is an excellent choice when the number of variables is very high, as the formula method is memory-inefficient with many variables. 
+
+There are two different types of operations that can be sequentially added to a recipe. 
+
+- **Steps** can include common operations like logging a variable, creating dummy variables or interactions and so on. More computationally complex actions such as dimension reduction or imputation can also be specified. 
+
+- **Checks** are operations that conduct specific tests of the data. When the test is satisfied, the data are returned without issue or modification. Otherwise, any error is thrown.
+
+If you have defined a recipe and want to see which steps are incluced, use the `tidy()` method on the recipe object. 
+
+Note that the data passed to `recipe()` need not be the complete data that will be used to train the steps (by [prep()]). The recipe only needs to know the names and types of data that will be used. For large data sets, `head()` could be used to pass the recipe a smaller data set to save time and memory.
+
+## Using recipes
+
+Most recipe steps have quantities that need to be calculated or estimated. For example, `step_normalize()` needs to compute the training set mean for the selected columns. Also, `step_dummy()` needs to determine the factor levels of selected columns in order to make the apprirate indicator columns. 
+
+Once a recipe is defined, it needs to be _estimated_ before being applied to data. The two most common applicaiton of recipes are modeling and stand-alone preprocessing. How we recipe is estimated depends on how it is being used. 
+
+### Modeling
+
+It best way to use use a recipe for modeling is via the `workflows` package. This bundles a model and preprocessor (e.g. a recipe) together and gives the user a simple want to train the model/recipe and make predictions. 
+
+Here is a simple example: 
+
+```{r }
+library(dplyr)
+library(workflows)
+library(recipes)
+library(parsnip)
+
+data(biomass, package = "modeldata")
+
+# split data
+biomass_tr <- biomass[biomass$dataset == "Training",]
+biomass_te <- biomass[biomass$dataset == "Testing",]
+
+# When only predictors and outcomes, a simplified formula can be used.
+rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
+              data = biomass_tr)
+
+# Now add preprocessing steps to the recipe.
+sp_signed <- 
+  rec %>%
+  step_normalize(all_numeric_predictors()) %>%
+  step_spatialsign(all_numeric_predictors())
+sp_signed
+```
+
+We can create a `parsnip` model and then a workflow with the model and recipe: 
+
+```{r}
+linear_mod <- linear_reg()
+
+linear_sp_sign_wflow <- 
+  workflow() %>% 
+  add_model(linear_mod) %>% 
+  add_recipe(sp_signed)
+linear_sp_sign_wflow
+```
+
+To estimate the preprocessing steps and then fit the linear model, a simple call to `fit()` is used:
+
+```{r}
+linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
+```
+
+When predicting, there is no need to do anything other than call `predict()`. This preprocesses the new data in the same manner as the training set, then gives the data to the linear model prediction code: 
+
+```{r}
+predict(linear_sp_sign_fit, new_data = head(biomass_te))
+```
+
+### Stand-alone use of recipes
+
+When using a recipe to generate data for a visualization, or to troubleshoot any issues, there are functions that can be used to estimate the recipe and apply is to new data manually.
+
+Once a recipe has been defined, the [prep()] function can be used to estimate quantities required for the operations using a data set (a.k.a. the training data). [prep()] returns another recipe.
+
+As an example of using PCA to produce a plot: 
+
+```{r}
+# Define the recipe
+pca_rec <- 
+  rec %>%
+  step_normalize(all_numeric_predictors()) %>%
+  step_pca(all_numeric_predictors())
+```
+
+Now to estimate the normalization statistics and the PCA loadings: 
+
+```{r}
+pca_rec <- prep(pca_rec, training = biomass_tr)
+pca_rec
+```
+Note that the estimated recipe shows the actual column names captured by the selectors. 
+
+To apply the recipe to a data set, the [bake()] function is used in the same manner as `predict()` would be for models. This applies the estimated steps to any data set.
+
+```{r}
+bake(pca_rec, head(biomass_te))
+```
+
+In general, the workflow interface to recipes is recommended. 
+
+

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -79,7 +79,7 @@ class variable.
 \details{
 Data depth metrics attempt to measure how close data a
 data point is to the center of its distribution. There are a
-number of methods for calculating death but a simple example is
+number of methods for calculating depth but a simple example is
 the inverse of the distance of a data point to the centroid of
 the distribution. Generally, small values indicate that a data
 point not close to the centroid. \code{step_depth} can compute a


### PR DESCRIPTION
closes #733

Related to #733 and tidymodels/TMwR#163, these changed highlight the use of `tidy()` on a recipe and also let users know that, for modeling, a workflow is the recommended approach. 