### PR TITLE
Suggest `step_novel()` when no pooling is done by `step_other()`

### DIFF
--- a/R/other.R
+++ b/R/other.R
@@ -43,11 +43,13 @@
 #'   thrown. If `other` is in the list of discarded levels, no error
 #'   occurs.
 #'
-#' If no pooling is done, novel factor levels are converted to missing. If
-#'  pooling is needed, they will be placed into the other category.
+#' If pooling is needed, novel factor levels will be placed into the `other`
+#'  category. If no pooling is needed, novel factor levels are converted to
+#'  missing; if desired, these can be handled by [step_novel()] before
+#'  pooling via `step_other()`.
 #'
 #' When data to be processed contains novel levels (i.e., not
-#' contained in the training set), the other category is assigned.
+#'  contained in the training set), the other category is assigned.
 #'
 #' When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  columns that will be affected) and `retained` (the factor

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -78,8 +78,10 @@ If the retained categories include the value of \code{other}, an error is
 thrown. If \code{other} is in the list of discarded levels, no error
 occurs.
 
-If no pooling is done, novel factor levels are converted to missing. If
-pooling is needed, they will be placed into the other category.
+If pooling is needed, novel factor levels will be placed into the \code{other}
+category. If no pooling is needed, novel factor levels are converted to
+missing; if desired, these can be handled by \code{\link[=step_novel]{step_novel()}} before
+pooling via \code{step_other()}.
 
 When data to be processed contains novel levels (i.e., not
 contained in the training set), the other category is assigned.


### PR DESCRIPTION
Closes #740 

Make a more specific recommendation to use `step_novel()` before `step_other()` for when `step_other()` does not do anything. I would say let's not add yet _more_ to those examples (our examples tend to be standalone for each step anyway) and instead keep this in "Details".