### PR TITLE
Create and use new template for step return value

### DIFF
--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -16,8 +16,7 @@
 #'  compute the transformation parameter lambda.
 #' @param num_unique An integer to specify minimum required unique
 #'  values to evaluate for a transformation.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -16,8 +16,7 @@
 #'  compute the transformation parameter lambda.
 #' @param num_unique An integer where data that have less possible
 #'  values will not be evaluated for a transformation.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -10,8 +10,7 @@
 #' @param role Not used by this step since no new variables are
 #'  created.
 #' @param inputs Quosure of values given by `...`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!!`)

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -16,8 +16,7 @@
 #' 1's, be the factor reference level?
 #' @param columns A vector with the selected variable names. This
 #'  is `NULL` until computed by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details This operation may be useful for situations where a
 #'  binary piece of information may need to be represented as
 #'  categorical instead of numeric. For example, naive Bayes models

--- a/R/bs.R
+++ b/R/bs.R
@@ -21,8 +21,7 @@
 #' @param degree Degree of polynomial spline (integer).
 #' @param options A list of options for [splines::bs()]
 #'  which should not include `x`, `degree`, or `df`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion

--- a/R/center.R
+++ b/R/center.R
@@ -23,8 +23,7 @@
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
 #' @param id A character string that is unique to this step to identify it.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #'
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/class.R
+++ b/R/class.R
@@ -26,8 +26,7 @@
 #' @param class_list A named list of column classes. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @param id A character string that is unique to this step to identify it.
-#' @return An updated version of `recipe` with the new check
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #'
 #' @keywords datagen
 #' @concept preprocessing normalization_methods

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -25,8 +25,7 @@
 #'  new distance columns. Defaults to `"classdist_"`. See Details below.
 #' @param objects Statistics are stored here once this step has
 #'  been trained by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept dimension_reduction

--- a/R/corr.R
+++ b/R/corr.R
@@ -21,8 +21,7 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @author Original R code for filtering algorithm by Dong Li,
 #'  modified by Max Kuhn. Contributions by Reynald Lescarbeau (for

--- a/R/count.R
+++ b/R/count.R
@@ -27,8 +27,7 @@
 #' @param input A single character value for the name of the
 #'  variable being searched. This is `NULL` until computed by
 #'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `result` (the
 #'  new column name) is returned.

--- a/R/cut.R
+++ b/R/cut.R
@@ -20,8 +20,7 @@
 #'  processing the outcome variable(s)). Care should be taken when using `skip =
 #'  TRUE` as it may affect the computations for subsequent operations
 #' @param id A character string that is unique to this step to identify it.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @export

--- a/R/date.R
+++ b/R/date.R
@@ -37,8 +37,7 @@
 #'  populated once [prep.recipe()] is used.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
-#' @return For `step_date`, an updated version of recipe with
-#'  the new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept model_specification

--- a/R/depth.R
+++ b/R/depth.R
@@ -32,8 +32,7 @@
 #'  new depth columns. Defaults to `"depth_"`. See Details below.
 #' @param data The training data are stored here once after
 #'  [prep.recipe()] is executed.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept dimension_reduction

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -234,9 +234,7 @@ print.discretize <-
 #'  one or more selector functions to choose which variables are
 #'  affected by the step. See [selections()] for more
 #'  details.
-#' @return `step_discretize` returns an updated version of
-#'  `recipe` with the new step added to the sequence of
-#'  existing steps (if any).
+#' @template step-return
 #' @details  When you [`tidy()`] this step, a tibble
 #'  with columns `terms` (the selectors or variables selected)
 #'  and `value` (the breaks) is returned.

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -28,10 +28,7 @@
 #' @param target An integer that will be used to subsample. This
 #'  should not be set by the user and will be populated by `prep`.
 #' @param seed An integer that will be used as the seed when downsampling.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any). For the
-#'  `tidy` method, a tibble with columns `terms` which is
-#'  the variable used to sample.
+#' @template step-return
 #' @details
 #' Down-sampling is intended to be performed on the _training_ set alone. For
 #'  this reason, the default is `skip = TRUE`. It is advisable to use

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -27,8 +27,7 @@
 #'  [prep.recipe()].
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept dummy_variables

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -13,10 +13,7 @@
 #' @param columns A character string of variables that will be
 #'  converted. This is `NULL` until computed by
 #'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any). For the
-#'  `tidy` method, a tibble with columns `terms` (the
-#'  columns that will be affected).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_encodings
@@ -26,6 +23,10 @@
 #'  defaults to `TRUE`. If this step is used with the default
 #'  option, the string(s() produced by this step will be converted
 #'  to factors after all of the steps have been prepped.
+#'
+#' When you [`tidy()`] this step, a tibble with columns `terms` (the
+#'  columns that will be affected) is returned.
+#'
 #' @seealso [step_string2factor()] [step_dummy()]
 #' @examples
 #' library(modeldata)

--- a/R/filter.R
+++ b/R/filter.R
@@ -17,8 +17,7 @@
 #'  when [prep.recipe()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!`) to embed

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -23,8 +23,7 @@
 #' @param name A single character value to use for the new
 #'  predictor column. If a column exists with this name, an error is
 #'  issued.
-#' @return An updated version of `recipe` with the new step added
-#'  to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns echoing the
 #'  values of `lat`, `lon`, `ref_lat`, `ref_lon`, `is_lat_lon`, `name`, and `id`
 #'  is returned.

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -22,8 +22,7 @@
 #'  populated once [prep.recipe()] is used.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept model_specification

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -15,8 +15,7 @@
 #' @param inverse A logical: should the inverse function be used?
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/ica.R
+++ b/R/ica.R
@@ -28,8 +28,7 @@
 #'  output. Defaults to `FALSE`.
 #' @param prefix A character string that will be the prefix to the
 #'  resulting new variables. See notes below.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ica

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -23,8 +23,7 @@
 #'  is used across all imputation models.
 #' @param models The [ipred::ipredbagg()] objects are stored here once this
 #'  bagged trees have be trained by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -23,8 +23,7 @@
 #'  is trained by [prep.recipe()].
 #' @param columns The column names that will be imputed and used for
 #'  imputation. This is `NULL` until the step is trained by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -18,8 +18,7 @@
 #'  will be removed from the latter and not used to impute itself.
 #' @param models The [lm()] objects are stored here once the linear models
 #'  have been trained by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -14,8 +14,7 @@
 #'  created.
 #' @param threshold A named numeric vector of lower bounds. This is
 #'  `NULL` until computed by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -14,8 +14,7 @@
 #' @param trim The fraction (0 to 0.5) of observations to be trimmed from each
 #'  end of the variables before the mean is computed. Values of trim outside
 #'  that range are taken as the nearest endpoint.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -11,8 +11,7 @@
 #' @param medians A named numeric vector of medians. This is `NULL` until
 #'  computed by [prep.recipe()]. Note that, if the original data are integers,
 #'  the median will be converted to an integer to maintain the same data type.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -14,8 +14,7 @@
 #'  `NULL` until computed by [prep.recipe()].
 #' @param ptype A data frame prototype to cast new data sets to. This is
 #'  commonly a 0-row slice of the training set.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -19,8 +19,7 @@
 #' @param statistic A function with a single argument for the data to compute
 #'  the imputed value. Only complete values will be passed to the function and
 #'  it should return a double precision value.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation

--- a/R/integer.R
+++ b/R/integer.R
@@ -21,8 +21,7 @@
 #'  integers (as opposed to double).
 #' @param zero_based A logical for whether the integers should start at zero and
 #'  new values be appended as the largest integer.
-#' @return An updated version of `recipe` with the new step added
-#'  to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_encodings

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -18,8 +18,7 @@
 #' @param sep A character value used to delineate variables in an
 #'  interaction (e.g. `var1_x_var2` instead of the more
 #'  traditional `var1:var2`).
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept model_specification

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -20,9 +20,7 @@
 #'   have been estimated. Again included for consistency.
 #' @param name Character name for newly added column
 #' @param value A numeric constant to fill the intercept column. Defaults to 1.
-#'
-#' @return An updated version of `recipe` with the
-#'   new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @export
 #'
 #' @examples

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -13,8 +13,7 @@
 #'  logging (to avoid `1/0`).
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -12,8 +12,7 @@
 #'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -26,8 +26,7 @@
 #'  resulting new variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept isomap

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -27,8 +27,7 @@
 #'  [prep.recipe()].
 #' @param prefix A character string that will be the prefix to the
 #'  resulting new variables. See notes below.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen internal
 #' @concept preprocessing
 #' @concept pca

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -25,8 +25,7 @@
 #'  resulting new variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept pca

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -25,8 +25,7 @@
 #'  resulting new variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept pca

--- a/R/lag.R
+++ b/R/lag.R
@@ -28,8 +28,7 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations
-#' @return An updated version of `recipe` with the
-#'   new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details The step assumes that the data are already _in the proper sequential
 #'  order_ for lagging.
 #' @export

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -14,8 +14,7 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters

--- a/R/log.R
+++ b/R/log.R
@@ -17,8 +17,7 @@
 #' @param signed A logical indicating whether to take the signed log.
 #'  This is sign(x) * abs(log(x)) when abs(x) => 1 or 0 if abs(x) < 1.
 #'  If `TRUE` the `offset` argument will be ignored.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/logit.R
+++ b/R/logit.R
@@ -11,8 +11,7 @@
 #'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/missing.r
+++ b/R/missing.r
@@ -21,8 +21,7 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations.
-#' @return An updated version of `recipe` with the new check
-#'  added to the sequence of existing operations (if any).
+#' @template step-return
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain `NA` values. If the check passes, nothing is changed

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -12,8 +12,7 @@
 #'  that the new dimension columns created by the original variables
 #'  will be used as predictors in a model.
 #' @param inputs Quosure(s) of `...`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!`) to embed

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -12,8 +12,7 @@
 #'  columns created by the original variables will be used as predictors in a
 #'  model.
 #' @param inputs A vector of column names populated by `prep()`.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with
 #'  column `terms` which contains the columns being transformed is returned.
 #' @keywords datagen

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -25,8 +25,7 @@
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations.
 #' @param id A character string that is unique to this step to identify it.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @details  When you [`tidy()`] this step, a tibble with
 #'  columns `terms` (the selectors or variables selected) and `model` (the
 #'  median value) is returned.

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -23,8 +23,7 @@
 #'
 #' @template row-ops
 #' @rdname step_naomit
-#' @return An updated version of `recipe` with the
-#'   new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @export
 #'
 #' @examples

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -33,7 +33,7 @@
 #'  columns does contain values it did not contain when `prep` was called
 #'  on the recipe. If the check passes, nothing is changed to the data.
 #'
-#'  When you [`tidy()`] this step, a tibble with columns `terms` (the
+#'  When you [`tidy()`] this check, a tibble with columns `terms` (the
 #'  selectors or variables selected) is returned.
 #'
 #' @examples

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -26,14 +26,16 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations.
-#' @return An updated version of `recipe` with the new check
-#'  added to the sequence of existing operations (if any). For the
-#'  `tidy` method, a tibble with columns `terms` (the
-#'  selectors or variables selected).
+#' @return An updated version of `recipe` with the new check added to the
+#'  sequence of any existing operations.
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain values it did not contain when `prep` was called
 #'  on the recipe. If the check passes, nothing is changed to the data.
+#'
+#'  When you [`tidy()`] this step, a tibble with columns `terms` (the
+#'  selectors or variables selected) is returned.
+#'
 #' @examples
 #' library(modeldata)
 #' data(credit_data)

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -32,8 +32,7 @@
 #'  when computing the factorization.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept nnmf

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -16,8 +16,7 @@
 #'  is `NULL` until computed by [prep.recipe()].
 #' @param na_rm A logical value indicating whether `NA`
 #'  values should be removed when computing the standard deviation and mean.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods

--- a/R/novel.R
+++ b/R/novel.R
@@ -16,8 +16,7 @@
 #'  to new factor levels.
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors

--- a/R/ns.R
+++ b/R/ns.R
@@ -20,8 +20,7 @@
 #'  created once the step has been trained.
 #' @param options A list of options for [splines::ns()]
 #'  which should not include `x` or `df`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -18,8 +18,7 @@
 #'  These are the numeric data converted to character and ordered. This is
 #'  modified once [prep.recipe()] is executed.
 #' @param ordered A single logical value; should the factor(s) be ordered?
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `ordered` is returned.
 #' @keywords datagen

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -17,8 +17,7 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -15,8 +15,7 @@
 #'  [prep.recipe()].
 #' @param convert A function that takes an ordinal factor vector
 #'  as an input and outputs a single numeric variable.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data

--- a/R/other.R
+++ b/R/other.R
@@ -20,8 +20,7 @@
 #' @param objects A list of objects that contain the information
 #'  to pool infrequent levels that is determined by
 #'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors

--- a/R/pca.R
+++ b/R/pca.R
@@ -29,8 +29,7 @@
 #'  new variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept pca

--- a/R/pls.R
+++ b/R/pls.R
@@ -30,8 +30,7 @@
 #'  resulting new variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept pls

--- a/R/poly.R
+++ b/R/poly.R
@@ -20,8 +20,7 @@
 #'  which should not include `x`, `degree`, or `simple`. Note that
 #'  the option `raw = TRUE` will produce the regular polynomial
 #'  values (not orthogonalized).
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion

--- a/R/profile.R
+++ b/R/profile.R
@@ -49,8 +49,7 @@
 #'  is the columns that will be affected) and `type` (fixed or
 #'  profiled) is returned.
 #'
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @export

--- a/R/range.R
+++ b/R/range.R
@@ -18,8 +18,7 @@
 #'  normalized. Note that this is ignored until the values are
 #'  determined by [prep.recipe()]. Setting this value will
 #'  be ineffective.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -29,7 +29,7 @@
 #' @param upper A named numeric vector of maximum values in the train set.
 #'   This is `NULL` until computed by [prep.recipe()].
 #' @return An updated version of `recipe` with the new check
-#'  added to the sequence of existing steps (if any).
+#'  added to the sequence of any existing operations.
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -28,8 +28,7 @@
 #'  executed.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `denom` is returned.
 #' @keywords datagen

--- a/R/regex.R
+++ b/R/regex.R
@@ -24,8 +24,7 @@
 #' @param input A single character value for the name of the
 #'  variable being searched. This is `NULL` until computed by
 #'  [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `result` (the
 #'  new column name) is returned.

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -19,8 +19,7 @@
 #'  relevel the factor column(s) (if the level is present).
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #'
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/relu.R
+++ b/R/relu.R
@@ -22,8 +22,7 @@
 #'   transformations.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the
-#'   new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @export
 #' @rdname step_relu
 #'

--- a/R/rename.R
+++ b/R/rename.R
@@ -11,8 +11,7 @@
 #'  columns created by the original variables will be used as predictors in a
 #'  model.
 #' @param inputs Quosure(s) of `...`.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is referenced in
 #'  the expression defining the new variable(s), it is a good idea to use
 #'  quasiquotation (e.g. `!!`) to embed the value of the object in the

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -12,8 +12,7 @@
 #'  columns created by the original variables will be used as predictors in a
 #'  model.
 #' @param inputs A vector of column names populated by `prep()`.
-#' @return An updated version of `recipe` with the new step added to the
-#'  sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with
 #'  columns `terms` which contains the columns being transformed is returned.
 #' @keywords datagen

--- a/R/rm.R
+++ b/R/rm.R
@@ -12,8 +12,7 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #'  columns that will be removed) is returned.
 #' @keywords datagen

--- a/R/sample.R
+++ b/R/sample.R
@@ -21,8 +21,7 @@
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = FALSE`.
 #' @param replace Sample with or without replacement?
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `size`,
 #' `replace`, and `id` is returned.
 #' @keywords datagen

--- a/R/scale.R
+++ b/R/scale.R
@@ -19,8 +19,7 @@
 #'  binary inputs. Defaults to `1`. More in reference below.
 #' @param na_rm A logical value indicating whether `NA`
 #'  values should be removed when computing the standard deviation.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods

--- a/R/select.R
+++ b/R/select.R
@@ -9,8 +9,7 @@
 #'  [selections()] for more details.
 #' @param role For model terms selected by this step, what analysis
 #'  role should they be assigned?
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!`) to embed

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -14,8 +14,7 @@
 #' @param columns A character string that contains the names of
 #'  columns that should be shuffled. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #' columns that will be affected) is returned.
 #' @keywords datagen

--- a/R/slice.R
+++ b/R/slice.R
@@ -15,8 +15,7 @@
 #'  when [prep.recipe()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = FALSE`.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!`)

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -15,8 +15,7 @@
 #'  norm computation?
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept projection_methods

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -12,8 +12,7 @@
 #'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -15,8 +15,7 @@
 #'  values present when `bake` is called will be used.
 #' @param ordered A single logical value; should the factor(s) be
 #'  ordered?
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_encodings

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -15,8 +15,7 @@
 #'  to new factor levels.
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -11,8 +11,7 @@
 #'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -28,10 +28,7 @@
 #' @param target An integer that will be used to subsample. This
 #'  should not be set by the user and will be populated by `prep`.
 #' @param seed An integer that will be used as the seed when upsampling.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any). For the
-#'  `tidy` method, a tibble with columns `terms` which is
-#'  the variable used to sample.
+#' @template step-return
 #' @details
 #' Up-sampling is intended to be performed on the _training_ set alone. For
 #'  this reason, the default is `skip = TRUE`. It is advisable to use

--- a/R/window.R
+++ b/R/window.R
@@ -30,8 +30,7 @@
 #'  are not sure what columns will be selected, use the
 #'  `summary` function (see the example below). These will be
 #'  the names of the new columns created by the step.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept moving_windows

--- a/R/zv.R
+++ b/R/zv.R
@@ -13,8 +13,7 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @return An updated version of `recipe` with the new step
-#'  added to the sequence of existing steps (if any).
+#' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #'  columns that will be removed) is returned.
 #' @keywords datagen

--- a/man-roxygen/step-return.R
+++ b/man-roxygen/step-return.R
@@ -1,0 +1,2 @@
+#' @return An updated version of `recipe` with the new step added to the
+#'  sequence of any existing steps.

--- a/man/check_class.Rd
+++ b/man/check_class.Rd
@@ -50,8 +50,8 @@ the computations for subsequent operations.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new check
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{check_class} creates a \emph{specification} of a recipe

--- a/man/check_missing.Rd
+++ b/man/check_missing.Rd
@@ -41,8 +41,8 @@ the computations for subsequent operations.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new check
-added to the sequence of existing operations (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{check_missing} creates a \emph{specification} of a recipe

--- a/man/check_new_values.Rd
+++ b/man/check_new_values.Rd
@@ -62,7 +62,7 @@ This check will break the \code{bake} function if any of the checked
 columns does contain values it did not contain when \code{prep} was called
 on the recipe. If the check passes, nothing is changed to the data.
 
-When you \code{\link[=tidy]{tidy()}} this step, a tibble with columns \code{terms} (the
+When you \code{\link[=tidy]{tidy()}} this check, a tibble with columns \code{terms} (the
 selectors or variables selected) is returned.
 }
 \examples{

--- a/man/check_new_values.Rd
+++ b/man/check_new_values.Rd
@@ -50,10 +50,8 @@ the computations for subsequent operations.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new check
-added to the sequence of existing operations (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-selectors or variables selected).
+An updated version of \code{recipe} with the new check added to the
+sequence of any existing operations.
 }
 \description{
 \code{check_new_values} creates a \emph{specification} of a recipe
@@ -63,6 +61,9 @@ operation that will check if variables contain new values.
 This check will break the \code{bake} function if any of the checked
 columns does contain values it did not contain when \code{prep} was called
 on the recipe. If the check passes, nothing is changed to the data.
+
+When you \code{\link[=tidy]{tidy()}} this step, a tibble with columns \code{terms} (the
+selectors or variables selected) is returned.
 }
 \examples{
 library(modeldata)

--- a/man/check_range.Rd
+++ b/man/check_range.Rd
@@ -54,7 +54,7 @@ This is \code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.
 }
 \value{
 An updated version of \code{recipe} with the new check
-added to the sequence of existing steps (if any).
+added to the sequence of any existing operations.
 }
 \description{
 \code{check_range} creates a \emph{specification} of a recipe

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -170,13 +170,12 @@ linear_sp_sign_wflow
 ## 
 ## ── Model ─────────────────────────────────────────────────────────────
 ## Linear Regression Model Specification (regression)
-## 
-## Computational engine: lm
 }
 
 To estimate the preprocessing steps and then fit the linear model, a
 single call to \code{fit()} is used:\if{html}{\out{<div class="r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
-}\if{html}{\out{</div>}}
+}\if{html}{\out{</div>}}\preformatted{## Warning: Engine set to `lm`.
+}
 
 When predicting, there is no need to do anything other than call
 \code{predict()}. This preprocesses the new data in the same manner as the
@@ -236,8 +235,8 @@ prepped or unprepped, to learn more about its components.\if{html}{\out{<div cla
 }\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 x 6
 ##   number operation type      trained skip  id             
 ##    <int> <chr>     <chr>     <lgl>   <lgl> <chr>          
-## 1      1 step      normalize TRUE    FALSE normalize_d7J7E
-## 2      2 step      pca       TRUE    FALSE pca_I6GjL
+## 1      1 step      normalize TRUE    FALSE normalize_tNqMr
+## 2      2 step      pca       TRUE    FALSE pca_Ge1rB
 }
 
 You can also \code{tidy()} recipe \emph{steps} with a \code{number} or \code{id} argument.

--- a/man/step_BoxCox.Rd
+++ b/man/step_BoxCox.Rd
@@ -49,8 +49,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_BoxCox} creates a \emph{specification} of a recipe

--- a/man/step_YeoJohnson.Rd
+++ b/man/step_YeoJohnson.Rd
@@ -53,8 +53,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_YeoJohnson} creates a \emph{specification} of a

--- a/man/step_arrange.Rd
+++ b/man/step_arrange.Rd
@@ -40,8 +40,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_arrange} creates a \emph{specification} of a recipe step

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -49,8 +49,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_bin2factor} creates a \emph{specification} of a

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -56,8 +56,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_bs} creates a \emph{specification} of a recipe step

--- a/man/step_center.Rd
+++ b/man/step_center.Rd
@@ -45,8 +45,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_center} creates a \emph{specification} of a recipe

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -65,8 +65,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_classdist} creates a \emph{specification} of a

--- a/man/step_corr.Rd
+++ b/man/step_corr.Rd
@@ -56,8 +56,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_corr} creates a \emph{specification} of a recipe

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -63,8 +63,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_count} creates a \emph{specification} of a recipe

--- a/man/step_cut.Rd
+++ b/man/step_cut.Rd
@@ -42,7 +42,7 @@ processing the outcome variable(s)). Care should be taken when using \code{skip 
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_cut()} creates a \emph{specification} of a recipe step that cuts a numeric

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -74,8 +74,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-For \code{step_date}, an updated version of recipe with
-the new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_date} creates a \emph{specification} of a recipe

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -67,8 +67,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_depth} creates a \emph{specification} of a recipe

--- a/man/step_discretize.Rd
+++ b/man/step_discretize.Rd
@@ -60,9 +60,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-\code{step_discretize} returns an updated version of
-\code{recipe} with the new step added to the sequence of
-existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_discretize} creates a \emph{specification} of a recipe

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -66,10 +66,8 @@ the computations for subsequent operations}
 \item{x}{A \code{step_downsample} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} which is
-the variable used to sample.
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -62,8 +62,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_dummy()} creates a \emph{specification} of a recipe

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -42,10 +42,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} (the
-columns that will be affected).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_factor2string} will convert one or more factor
@@ -56,6 +54,9 @@ vectors to strings.
 defaults to \code{TRUE}. If this step is used with the default
 option, the string(s() produced by this step will be converted
 to factors after all of the steps have been prepped.
+
+When you \code{\link[=tidy]{tidy()}} this step, a tibble with columns \code{terms} (the
+columns that will be affected) is returned.
 }
 \examples{
 library(modeldata)

--- a/man/step_filter.Rd
+++ b/man/step_filter.Rd
@@ -40,8 +40,8 @@ Care should be taken when using \code{skip = FALSE}.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_filter} creates a \emph{specification} of a recipe step

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -62,8 +62,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step added
-to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_geodist} creates a \emph{specification} of a

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -54,8 +54,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_holiday} creates a \emph{specification} of a

--- a/man/step_hyperbolic.Rd
+++ b/man/step_hyperbolic.Rd
@@ -48,8 +48,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_hyperbolic} creates a \emph{specification} of a

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -64,8 +64,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_ica} creates a \emph{specification} of a recipe step

--- a/man/step_impute_bag.Rd
+++ b/man/step_impute_bag.Rd
@@ -79,7 +79,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_bag} creates a \emph{specification} of a recipe step that will

--- a/man/step_impute_knn.Rd
+++ b/man/step_impute_knn.Rd
@@ -76,7 +76,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_knn} creates a \emph{specification} of a recipe step that will

--- a/man/step_impute_linear.Rd
+++ b/man/step_impute_linear.Rd
@@ -50,7 +50,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_linear} creates a \emph{specification} of a recipe step that will

--- a/man/step_impute_lower.Rd
+++ b/man/step_impute_lower.Rd
@@ -52,8 +52,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_lower} creates a \emph{specification} of a recipe step

--- a/man/step_impute_mean.Rd
+++ b/man/step_impute_mean.Rd
@@ -58,7 +58,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_mean} creates a \emph{specification} of a recipe step that will

--- a/man/step_impute_median.Rd
+++ b/man/step_impute_median.Rd
@@ -52,7 +52,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_median} creates a \emph{specification} of a recipe step that will

--- a/man/step_impute_mode.Rd
+++ b/man/step_impute_mode.Rd
@@ -57,8 +57,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_mode} creates a \emph{specification} of a

--- a/man/step_impute_roll.Rd
+++ b/man/step_impute_roll.Rd
@@ -65,8 +65,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_impute_roll} creates a \emph{specification} of a

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -47,7 +47,7 @@ the computations for subsequent operations.}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_indicate_na} creates a \emph{specification} of a recipe step that will

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -53,8 +53,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step added
-to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_integer} creates a \emph{specification} of a recipe

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -49,8 +49,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_interact} creates a \emph{specification} of a recipe

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -44,8 +44,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the
-new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_intercept} creates a \emph{specification} of a recipe step that

--- a/man/step_inverse.Rd
+++ b/man/step_inverse.Rd
@@ -45,8 +45,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_inverse} creates a \emph{specification} of a recipe

--- a/man/step_invlogit.Rd
+++ b/man/step_invlogit.Rd
@@ -41,8 +41,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_invlogit} creates a \emph{specification} of a recipe

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -64,8 +64,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_isomap} creates a \emph{specification} of a recipe

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -61,8 +61,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_kpca} a \emph{specification} of a recipe step that

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -63,8 +63,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_kpca_poly} a \emph{specification} of a recipe step that

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -61,8 +61,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_kpca_rbf} a \emph{specification} of a recipe step that

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -50,8 +50,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the
-new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_lag} creates a \emph{specification} of a recipe step that

--- a/man/step_lincomb.Rd
+++ b/man/step_lincomb.Rd
@@ -45,8 +45,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_lincomb} creates a \emph{specification} of a recipe

--- a/man/step_log.Rd
+++ b/man/step_log.Rd
@@ -53,8 +53,8 @@ If \code{TRUE} the \code{offset} argument will be ignored.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_log} creates a \emph{specification} of a recipe step

--- a/man/step_logit.Rd
+++ b/man/step_logit.Rd
@@ -41,8 +41,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_logit} creates a \emph{specification} of a recipe

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -42,8 +42,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_mutate} creates a \emph{specification} of a recipe step

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -48,7 +48,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_mutate_at} creates a \emph{specification} of a recipe step that will modify

--- a/man/step_naomit.Rd
+++ b/man/step_naomit.Rd
@@ -39,8 +39,8 @@ Care should be taken when using \code{skip = FALSE}.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the
-new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_naomit} creates a \emph{specification} of a recipe step that

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -72,8 +72,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_nnmf} creates a \emph{specification} of a recipe step

--- a/man/step_normalize.Rd
+++ b/man/step_normalize.Rd
@@ -49,8 +49,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_normalize} creates a \emph{specification} of a recipe

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -46,8 +46,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_novel} creates a \emph{specification} of a recipe

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -53,8 +53,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_ns} creates a \emph{specification} of a recipe step

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -51,7 +51,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_num2factor} will convert one or more numeric vectors to factors

--- a/man/step_nzv.Rd
+++ b/man/step_nzv.Rd
@@ -51,8 +51,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_nzv} creates a \emph{specification} of a recipe step

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -46,8 +46,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_ordinalscore} creates a \emph{specification} of a

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -52,8 +52,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_other} creates a \emph{specification} of a recipe

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -68,7 +68,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_pca} creates a \emph{specification} of a recipe step that will convert

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -73,8 +73,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_pls} creates a \emph{specification} of a recipe step that will

--- a/man/step_poly.Rd
+++ b/man/step_poly.Rd
@@ -52,8 +52,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_poly} creates a \emph{specification} of a recipe

--- a/man/step_profile.Rd
+++ b/man/step_profile.Rd
@@ -75,8 +75,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_profile} creates a \emph{specification} of a recipe step that

--- a/man/step_range.Rd
+++ b/man/step_range.Rd
@@ -51,8 +51,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_range} creates a \emph{specification} of a recipe

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -65,8 +65,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_ratio} creates a \emph{specification} of a recipe

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -59,8 +59,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_regex} creates a \emph{specification} of a recipe step that will

--- a/man/step_relevel.Rd
+++ b/man/step_relevel.Rd
@@ -46,8 +46,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_relevel} creates a \emph{specification} of a recipe

--- a/man/step_relu.Rd
+++ b/man/step_relu.Rd
@@ -55,8 +55,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the
-new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_relu} creates a \emph{specification} of a recipe step that

--- a/man/step_rename.Rd
+++ b/man/step_rename.Rd
@@ -42,7 +42,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_rename} creates a \emph{specification} of a recipe step that will add

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -48,7 +48,7 @@ the computations for subsequent operations}
 }
 \value{
 An updated version of \code{recipe} with the new step added to the
-sequence of existing steps (if any).
+sequence of any existing steps.
 }
 \description{
 \code{step_rename_at} creates a \emph{specification} of a recipe step that will rename

--- a/man/step_rm.Rd
+++ b/man/step_rm.Rd
@@ -42,8 +42,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_rm} creates a \emph{specification} of a recipe step

--- a/man/step_sample.Rd
+++ b/man/step_sample.Rd
@@ -45,8 +45,8 @@ Care should be taken when using \code{skip = FALSE}.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_sample} creates a \emph{specification} of a recipe step

--- a/man/step_scale.Rd
+++ b/man/step_scale.Rd
@@ -52,8 +52,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_scale} creates a \emph{specification} of a recipe

--- a/man/step_select.Rd
+++ b/man/step_select.Rd
@@ -37,8 +37,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_select()} creates a \emph{specification} of a recipe step

--- a/man/step_shuffle.Rd
+++ b/man/step_shuffle.Rd
@@ -42,8 +42,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_shuffle} creates a \emph{specification} of a recipe

--- a/man/step_slice.Rd
+++ b/man/step_slice.Rd
@@ -38,8 +38,8 @@ Care should be taken when using \code{skip = FALSE}.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_slice} creates a \emph{specification} of a recipe step

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -45,8 +45,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_spatialsign} is a \emph{specification} of a recipe

--- a/man/step_sqrt.Rd
+++ b/man/step_sqrt.Rd
@@ -41,8 +41,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_sqrt} creates a \emph{specification} of a recipe

--- a/man/step_string2factor.Rd
+++ b/man/step_string2factor.Rd
@@ -46,8 +46,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_string2factor} will convert one or more character

--- a/man/step_unknown.Rd
+++ b/man/step_unknown.Rd
@@ -46,8 +46,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_unknown} creates a \emph{specification} of a recipe

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -41,8 +41,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_unorder} creates a \emph{specification} of a recipe

--- a/man/step_upsample.Rd
+++ b/man/step_upsample.Rd
@@ -66,10 +66,8 @@ the computations for subsequent operations}
 \item{x}{A \code{step_upsample} object.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any). For the
-\code{tidy} method, a tibble with columns \code{terms} which is
-the variable used to sample.
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -67,8 +67,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_window} creates a \emph{specification} of a recipe

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -42,8 +42,8 @@ the computations for subsequent operations}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step
-added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing steps.
 }
 \description{
 \code{step_zv} creates a \emph{specification} of a recipe step


### PR DESCRIPTION
We've been chatting about a revamp of the recipes documentation in general, to use templating to reduce repetition and make it easier to change things in one place vs. _many_. This is a first step toward that, just making a template for what recipe steps return.