### PR TITLE
Reduce repetition in documentation with `@inheritParams`

### DIFF
--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -5,11 +5,6 @@
 #'  transformation.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param lambdas A numeric vector of transformation values. This
 #'  is `NULL` until computed by [prep.recipe()].
 #' @param limits A length 2 numeric vector defining the range to

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -5,11 +5,6 @@
 #'  transformation.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param lambdas A numeric vector of transformation values. This
 #'  is `NULL` until computed by [prep.recipe()].
 #' @param limits A length 2 numeric vector defining the range to

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -7,8 +7,6 @@
 #' @param ... Comma separated list of unquoted variable names.
 #'  Use `desc()`` to sort a variable in descending order. See
 #'  [dplyr::arrange()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param inputs Quosure of values given by `...`.
 #' @template step-return
 #' @details When an object in the user's global environment is

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -4,11 +4,6 @@
 #'  recipe step that will create a two-level factor from a single
 #'  dummy variable.
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... Selector functions that choose which variables will
-#'  be converted. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param levels A length 2 character string that indicates the
 #'  factor levels for the 1's (in the first position) and the zeros
 #'  (second)

--- a/R/bs.R
+++ b/R/bs.R
@@ -4,14 +4,8 @@
 #'  that will create new columns that are basis expansions of
 #'  variables using B-splines.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
 #' @param objects A list of [splines::bs()] objects
 #'  created once the step has been trained.
 #' @param deg_free The degrees of freedom for the spline. As the

--- a/R/center.R
+++ b/R/center.R
@@ -5,9 +5,8 @@
 #'
 #' @param recipe A recipe object. The step will be added to the
 #'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
+#' @param ... One or more selector functions to choose variables
+#'  for this step. See [selections()] for more details.
 #' @param role Not used by this step since no new variables are
 #'  created.
 #' @param trained A logical to indicate if the quantities for

--- a/R/class.R
+++ b/R/class.R
@@ -3,21 +3,7 @@
 #' `check_class` creates a *specification* of a recipe
 #'  check that will check if a variable is of a designated class.
 #'
-#' @param recipe A recipe object. The check will be added to the
-#'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the check. See [selections()]
-#'  for more details.
-#' @param role Not used by this check since no new variables are
-#'  created.
-#' @param trained A logical to indicate if the quantities for
-#'  preprocessing have been estimated.
-#' @param skip A logical. Should the check be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = TRUE` as it may affect
-#'  the computations for subsequent operations.
+#' @inheritParams check_missing
 #' @param class_nm A character vector that will be used in `inherits` to
 #'  check the class. If `NULL` the classes will be learned in `prep`.
 #'  Can contain more than one class.
@@ -25,8 +11,7 @@
 #'  have additional classes to the one(s) that are checked.
 #' @param class_list A named list of column classes. This is
 #'  `NULL` until computed by [prep.recipe()].
-#' @param id A character string that is unique to this step to identify it.
-#' @template step-return
+#' @template check-return
 #'
 #' @keywords datagen
 #' @concept preprocessing normalization_methods

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -5,15 +5,10 @@
 #'  distance measurements to the data centroid. This is done for
 #'  each value of a categorical class variable.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
 #' @param class A single character string that specifies a single
 #'  categorical variable to be used as the class.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that resulting distances will be used as predictors in a model.
 #' @param mean_func A function to compute the center of the
 #'  distribution.
 #' @param cov_func A function that computes the covariance matrix
@@ -21,8 +16,6 @@
 #'  by pooling the data for all of the classes?
 #' @param log A logical: should the distances be transformed by
 #'  the natural log function?
-#' @param prefix A character string that defines the naming convention for
-#'  new distance columns. Defaults to `"classdist_"`. See Details below.
 #' @param objects Statistics are stored here once this step has
 #'  been trained by [prep.recipe()].
 #' @template step-return

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -5,8 +5,8 @@
 #'  present in the new data.
 #'
 #' @inheritParams check_missing
+#' @template check-return
 #' @export
-#' @param id A character string that is unique to this step to identify it.
 #' @details This check will break the `bake` function if any of the specified
 #' columns is not present in the data. If the check passes, nothing is changed
 #'  to the data.

--- a/R/corr.R
+++ b/R/corr.R
@@ -5,11 +5,6 @@
 #'  absolute correlations with other variables.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param threshold A value for the threshold of absolute
 #'  correlation values. The step will try to remove the minimum
 #'  number of columns so that all the resulting absolute

--- a/R/count.R
+++ b/R/count.R
@@ -4,16 +4,11 @@
 #'  step that will create a variable that counts instances of a
 #'  regular expression pattern in text.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... A single selector functions to choose which variable
-#'  will be searched for the pattern. The selector should resolve
-#'  into a single variable. See [selections()] for more
-#'  details.
-#' @param role For a variable created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new dummy variable column created by the original
-#'  variable will be used as a predictor in a model.
+#' @param ... A single selector function to choose which variable
+#'  will be searched for the regex pattern. The selector should
+#'  resolve to a single variable. See [selections()] for more details.
 #' @param pattern A character string containing a regular
 #'  expression (or character string for `fixed = TRUE`) to be
 #'  matched in the given character vector. Coerced by

--- a/R/cut.R
+++ b/R/cut.R
@@ -3,23 +3,11 @@
 #' `step_cut()` creates a *specification* of a recipe step that cuts a numeric
 #'  variable into a factor based on provided boundary values
 #'
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'  operations for this recipe.
-#' @param ... One or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
-#' @param trained A logical to indicate if the quantities for preprocessing
-#'  have been estimated.
+#' @inheritParams step_center
 #' @param breaks A numeric vector with at least one cut point.
 #' @param include_outside_range Logical, indicating if values outside the
 #'  range in the train set should be included in the lowest or highest bucket.
 #'  Defaults to `FALSE`, values outside the original range will be set to `NA`.
-#' @param skip A logical. Should the step be skipped when the recipe is baked
-#'  by [bake.recipe()]? While all operations are baked when [prep.recipe()] is
-#'  run, some operations may not be able to be conducted on new data (e.g.
-#'  processing the outcome variable(s)). Care should be taken when using `skip =
-#'  TRUE` as it may affect the computations for subsequent operations
-#' @param id A character string that is unique to this step to identify it.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/date.R
+++ b/R/date.R
@@ -4,16 +4,11 @@
 #'  step that will convert date data into one or more factor or
 #'  numeric variables.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will be used to create the new variables. The
-#'  selected variables should have class `Date` or
+#' @param ... One or more selector functions to choose variables
+#'  for this step. The selected variables should have class `Date` or
 #'  `POSIXct`. See [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new variable columns created by the original variables
-#'  will be used as predictors in a model.
 #' @param features A character string that includes at least one
 #'  of the following values: `month`, `dow` (day of week),
 #'  `doy` (day of year), `week`, `month`,

--- a/R/depth.R
+++ b/R/depth.R
@@ -5,17 +5,10 @@
 #'  *data depth*. This is done for each value of a categorical
 #'  class variable.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will be used to create the new features. See
-#'  [selections()] for more details.
 #' @param class A single character string that specifies a single
 #'  categorical variable to be used as the class.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that resulting depth estimates will be used as predictors in a
-#'  model.
 #' @param metric A character string specifying the depth metric.
 #'  Possible values are "potential", "halfspace", "Mahalanobis",
 #'  "simplicialVolume", "spatial", and "zonoid".
@@ -28,8 +21,6 @@
 #'  [ddalpha::depth.simplicialVolume()],
 #'  [ddalpha::depth.spatial()],
 #'  [ddalpha::depth.zonoid()].
-#' @param prefix A character string that defines the naming convention for
-#'  new depth columns. Defaults to `"depth_"`. See Details below.
 #' @param data The training data are stored here once after
 #'  [prep.recipe()] is executed.
 #' @template step-return

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -214,8 +214,6 @@ print.discretize <-
 #'  on a training set).
 #'
 #' @inheritParams step_center
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param num_breaks An integer defining how many cuts to make of the
 #'  data.
 #' @param min_unique An integer defining a sample size line of
@@ -230,10 +228,6 @@ print.discretize <-
 #'  the options `prefix` and `labels` when more than one
 #'  variable is being transformed might be problematic as all
 #'  variables inherit those values.
-#' @param ... For `step_discretize`, the dots specify
-#'  one or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more
-#'  details.
 #' @template step-return
 #' @details  When you [`tidy()`] this step, a tibble
 #'  with columns `terms` (the selectors or variables selected)

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -9,13 +9,6 @@
 #'  level equal.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variable is used to sample the data. See [selections()]
-#'  for more details. The selection should result in _single
-#'  factor variable_. For the `tidy` method, these are not
-#'  currently used.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param under_ratio A numeric value for the ratio of the

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -5,16 +5,11 @@
 #'  into one or more numeric binary model terms for the levels of
 #'  the original data.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  _factor_ variables will be used to create the dummy variables. See
-#'  [selections()] for more details. The selected
-#'  variables must be factors.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the binary dummy variable columns created by the original
-#'  variables will be used as predictors in a model.
+#' @param ... One or more selector functions to choose variables
+#'  for this step. See [selections()] for more details. The selected
+#'  variables _must_ be factors.
 #' @param one_hot A logical. For C levels, should C dummy variables be created
 #' rather than C-1?
 #' @param preserve Use `keep_original_cols` to specify whether the selected
@@ -25,8 +20,6 @@
 #'  create dummy variables for each variable contained in
 #'  `terms`. This is `NULL` until the step is trained by
 #'  [prep.recipe()].
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -4,12 +4,6 @@
 #'  vectors to strings.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be converted to strings. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variables that will be
 #'  converted. This is `NULL` until computed by
 #'  [prep.recipe()].

--- a/R/filter.R
+++ b/R/filter.R
@@ -9,14 +9,7 @@
 #'  in the data. Multiple conditions are combined with `&`. Only
 #'  rows where the condition evaluates to `TRUE` are kept. See
 #'  [dplyr::filter()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param inputs Quosure of values given by `...`.
-#' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = FALSE`.
 #' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -4,14 +4,12 @@
 #'  recipe step that will calculate the distance between
 #'  points on a map to a reference location.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param lon,lat Selector functions to choose which variables are
 #'  used by the step. See [selections()] for more details.
 #' @param ref_lon,ref_lat Single numeric values for the location
 #'  of the reference point.
-#' @param role or model term created by this step, what analysis
-#'  role should be assigned?. By default, the function assumes
-#'  that resulting distance will be used as a predictor in a model.
 #' @param is_lat_lon A logical: Are coordinates in latitude and longitude? If
 #'  `TRUE` the Haversine formula is used and the returned result is meters. If
 #'  `FALSE` the Pythagorean formula is used. Default is `TRUE` and for recipes

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -4,16 +4,9 @@
 #'  recipe step that will convert date data into one or more binary
 #'  indicator variables for common holidays.
 #'
+#' @inheritParams step_date
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to create the new variables. The selected
-#'  variables should have class `Date` or `POSIXct`. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new variable columns created by the original variables
-#'  will be used as predictors in a model.
 #' @param holidays A character string that includes at least one
 #'  holiday supported by the `timeDate` package. See
 #'  [timeDate::listHolidays()] for a complete list.

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -5,11 +5,6 @@
 #'  function.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param func A character value for the function. Valid values
 #'  are "sin", "cos", or "tan".
 #' @param inverse A logical: should the inverse function be used?

--- a/R/ica.R
+++ b/R/ica.R
@@ -4,15 +4,8 @@
 #'  that will convert numeric data into one or more independent
 #'  components.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the components. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new independent component columns created by the
-#'  original variables will be used as predictors in a model.
 #' @param num_comp The number of ICA components to retain as new
 #'  predictors. If `num_comp` is greater than the number of columns
 #'  or the number of possible components, a smaller value will be
@@ -24,10 +17,6 @@
 #' @param res The [fastICA::fastICA()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -4,12 +4,10 @@
 #'  create bagged tree models to impute missing data.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose variables. For
-#'  `step_impute_bag`, this indicates the variables to be imputed. When used
-#'  with `imp_vars`, the dots indicate which variables are used to predict the
-#'  missing data in each variable. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
+#' @param ... One or more selector functions to choose variables to be imputed.
+#'  When used with `imp_vars`, these dots indicate which variables are used to
+#'  predict the missing data in each variable. See [selections()] for more
+#'  details.
 #' @param impute_with A call to `imp_vars` to specify which variables are used
 #'  to impute the variables that can include specific variable names separated
 #'  by commas or different selectors (see [selections()]). If a column is

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -3,18 +3,8 @@
 #' `step_impute_knn` creates a *specification* of a recipe step that will
 #'  impute missing data using nearest neighbors.
 #'
+#' @inheritParams step_impute_bag
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose variables. For
-#'  `step_impute_knn`, this indicates the variables to be imputed. When used
-#'  with `imp_vars`, the dots indicate which variables are used to predict the
-#'  missing data in each variable. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
-#' @param impute_with A call to `imp_vars` to specify which variables are used
-#'  to impute the variables that can include specific variable names separated
-#'  by commas or different selectors (see [selections()]). If a column is
-#'  included in both lists to be imputed and to be an imputation predictor, it
-#'  will be removed from the latter and not used to impute itself.
 #' @param neighbors The number of neighbors.
 #' @param options A named list of options to pass to [gower::gower_topn()].
 #'  Available options are currently `nthread` and `eps`.

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -5,7 +5,6 @@
 #'
 #' @inheritParams step_impute_bag
 #' @inheritParams step_center
-#' @inherit step_center return
 #' @param ... One or more selector functions to choose variables to be imputed;
 #' these variables **must** be of type `numeric`. When used with `imp_vars`,
 #' these dots indicate which variables are used to predict the missing data

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -8,7 +8,7 @@
 #' @inherit step_center return
 #' @param ... One or more selector functions to choose variables to be imputed;
 #' these variables **must** be of type `numeric`. When used with `imp_vars`,
-#' these dots indicates which variables are used to predict the missing data
+#' these dots indicate which variables are used to predict the missing data
 #' in each variable. See [selections()] for more details.
 #' @param models The [lm()] objects are stored here once the linear models
 #'  have been trained by [prep.recipe()].

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -3,19 +3,13 @@
 #' `step_impute_linear` creates a *specification* of a recipe step that will
 #'  create linear regression models to impute missing data.
 #'
+#' @inheritParams step_impute_bag
 #' @inheritParams step_center
 #' @inherit step_center return
-#' @param ... One or more selector functions to choose variables. For
-#' `step_impute_linear`, this indicates the variables to be imputed; these variables
-#' **must** be of type `numeric`. When used with `imp_vars`, the dots indicates
-#' which variables are used to predict the missing data in each variable. See
-#' [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
-#' @param impute_with A call to `imp_vars` to specify which variables are used
-#'  to impute the variables that can include specific variable names separated
-#'  by commas or different selectors (see [selections()]). If a column is
-#'  included in both lists to be imputed and to be an imputation predictor, it
-#'  will be removed from the latter and not used to impute itself.
+#' @param ... One or more selector functions to choose variables to be imputed;
+#' these variables **must** be of type `numeric`. When used with `imp_vars`,
+#' these dots indicates which variables are used to predict the missing data
+#' in each variable. See [selections()] for more details.
 #' @param models The [lm()] objects are stored here once the linear models
 #'  have been trained by [prep.recipe()].
 #' @template step-return

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -7,11 +7,6 @@
 #'  random uniform number between zero and the truncation point.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param threshold A named numeric vector of lower bounds. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @template step-return

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -5,9 +5,6 @@
 #'  those variables.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
 #' @param means A named numeric vector of means. This is `NULL` until computed
 #'  by [prep.recipe()]. Note that, if the original data are integers, the mean
 #'  will be converted to an integer to maintain the same data type.

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -5,9 +5,6 @@
 #'  those variables.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
 #' @param medians A named numeric vector of medians. This is `NULL` until
 #'  computed by [prep.recipe()]. Note that, if the original data are integers,
 #'  the median will be converted to an integer to maintain the same data type.

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -5,11 +5,6 @@
 #'  variables by the training set mode of those variables.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param modes A named character vector of modes. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @param ptype A data frame prototype to cast new data sets to. This is

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -5,12 +5,9 @@
 #'  variables by the measure of location (e.g. median) within a moving window.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()] for more
-#'  details. These columns should be non-integer numerics (i.e.,
-#'  double precision).
-#' @param role Not used by this step since no new variables are
-#'  created.
+#' @param ... One or more selector functions to choose variables to be imputed;
+#'  these columns must be non-integer numerics (i.e., double precision).
+#'  See [selections()] for more details.
 #' @param columns A named numeric vector of columns. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @param window The size of the window around a point to be imputed. Should be

--- a/R/integer.R
+++ b/R/integer.R
@@ -4,15 +4,8 @@
 #'  step that will convert new data into a set of integers based
 #'  on the original data values.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to create the integer variables. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created by the original variables will be
-#'  used as predictors in a model.
 #' @param key A list that contains the information needed to
 #'  create integer variables for each variable contained in
 #'  `terms`. This is `NULL` until the step is trained by

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -4,15 +4,12 @@
 #'  step that will create new columns that are interaction terms
 #'  between two or more variables.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param terms A traditional R formula that contains interaction
 #'  terms. This can include `.` and selectors. See [selections()]
 #'  for more details, and consider using [tidyselect::starts_with()] when
 #'  dummy variables have been created.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
 #' @param objects A list of `terms` objects for each
 #'  individual interaction.
 #' @param sep A character value used to delineate variables in an

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -7,17 +7,12 @@
 #'   unintentional transformations when calling steps with
 #'   `all_predictors`.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'   operations for this recipe.
 #' @param ... Argument ignored; included for consistency with other step
 #'   specification functions.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
 #' @param trained A logical to indicate if the quantities for preprocessing
-#'   have been estimated. Again included for consistency.
+#'   have been estimated. Again included only for consistency.
 #' @param name Character name for newly added column
 #' @param value A numeric constant to fill the intercept column. Defaults to 1.
 #' @template step-return

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -4,11 +4,6 @@
 #'  step that will inverse transform the data.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param offset An optional value to add to the data prior to
 #'  logging (to avoid `1/0`).
 #' @param columns A character string of variable names that will

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -5,11 +5,6 @@
 #'  zero and one.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -4,15 +4,8 @@
 #'  step that will convert numeric data into one or more new
 #'  dimensions.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the dimensions. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new dimension columns created by the original variables
-#'  will be used as predictors in a model.
 #' @param num_terms The number of isomap dimensions to retain as new
 #'  predictors. If `num_terms` is greater than the number of columns
 #'  or the number of possible dimensions, a smaller value will be
@@ -22,10 +15,6 @@
 #' @param res The [dimRed::Isomap()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -4,15 +4,8 @@
 #'  will convert numeric data into one or more principal components
 #'  using a kernel basis expansion.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the components. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned? By default, the function assumes
-#'  that the new principal component columns created by the original
-#'  variables will be used as predictors in a model.
 #' @param num_comp The number of PCA components to retain as new
 #'  predictors. If `num_comp` is greater than the number of columns
 #'  or the number of possible components, a smaller value will be
@@ -25,8 +18,6 @@
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
 #' @template step-return
 #' @keywords datagen internal
 #' @concept preprocessing

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -4,15 +4,8 @@
 #'  will convert numeric data into one or more principal components
 #'  using a polynomial kernel basis expansion.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the components. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned? By default, the function assumes
-#'  that the new principal component columns created by the original
-#'  variables will be used as predictors in a model.
 #' @param num_comp The number of PCA components to retain as new
 #'  predictors. If `num_comp` is greater than the number of columns
 #'  or the number of possible components, a smaller value will be
@@ -21,10 +14,6 @@
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -4,15 +4,8 @@
 #'  will convert numeric data into one or more principal components
 #'  using a radial basis function kernel basis expansion.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the components. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned? By default, the function assumes
-#'  that the new principal component columns created by the original
-#'  variables will be used as predictors in a model.
 #' @param num_comp The number of PCA components to retain as new
 #'  predictors. If `num_comp` is greater than the number of columns
 #'  or the number of possible components, a smaller value will be
@@ -21,10 +14,6 @@
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/lag.R
+++ b/R/lag.R
@@ -7,13 +7,8 @@
 #'   specify an alternative filler value with the `default`
 #'   argument.
 #'
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'   operations for this recipe.
-#' @param ... One or more selector functions to choose which variables are
-#'   affected by the step. See [selections()] for more details.
-#' @param role Defaults to "predictor"
-#' @param trained A logical to indicate if the quantities for preprocessing
-#'   have been estimated.
+#' @inheritParams step_pca
+#' @inheritParams step_center
 #' @param lag A vector of positive integers. Each specified column will be
 #'  lagged for each value in the vector.
 #' @param prefix A prefix for generated column names, default to "lag_".
@@ -21,13 +16,6 @@
 #'  be populated (eventually) by the `terms` argument.
 #' @param default Passed to `dplyr::lag`, determines what fills empty rows
 #'   left by lagging (defaults to NA).
-#' @param id A character string that is unique to this step to identify it.
-#' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = TRUE` as it may affect
-#'  the computations for subsequent operations
 #' @template step-return
 #' @details The step assumes that the data are already _in the proper sequential
 #'  order_ for lagging.

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -5,12 +5,7 @@
 #'  linear combinations between them.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
-#' @param max_steps A value.
+#' @param max_steps The number of times to apply the algorithm.
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.

--- a/R/log.R
+++ b/R/log.R
@@ -4,11 +4,6 @@
 #'  that will log transform data.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param base A numeric value for the base.
 #' @param offset An optional value to add to the data prior to
 #'  logging (to avoid `log(0)`).

--- a/R/logit.R
+++ b/R/logit.R
@@ -4,11 +4,6 @@
 #'  step that will logit transform the data.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return

--- a/R/missing.r
+++ b/R/missing.r
@@ -5,23 +5,22 @@
 #'
 #' @param recipe A recipe object. The check will be added to the
 #'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables are checked in the check See [selections()]
-#'  for more details.
+#' @param ... One or more selector functions to choose variables
+#'  for this check. See [selections()] for more details.
 #' @param role Not used by this check since no new variables are
 #'  created.
 #' @param trained A logical for whether the selectors in `...`
 #' have been resolved by [prep()].
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the terms argument.
-#' @param id A character string that is unique to this step to identify it.
+#' @param id A character string that is unique to this check to identify it.
 #' @param skip A logical. Should the check be skipped when the
 #'  recipe is baked by [bake.recipe()]? While all operations are baked
 #'  when [prep.recipe()] is run, some operations may not be able to be
 #'  conducted on new data (e.g. processing the outcome variable(s)).
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations.
-#' @template step-return
+#' @template check-return
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain `NA` values. If the check passes, nothing is changed

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -3,14 +3,11 @@
 #' `step_mutate` creates a *specification* of a recipe step
 #'  that will add variables using [dplyr::mutate()].
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... Name-value pairs of expressions. See [dplyr::mutate()].
 #' If the argument is not named, the expression is converted to
 #' a column name.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned? By default, the function assumes
-#'  that the new dimension columns created by the original variables
-#'  will be used as predictors in a model.
 #' @param inputs Quosure(s) of `...`.
 #' @template step-return
 #' @details When an object in the user's global environment is

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -3,14 +3,11 @@
 #' `step_mutate_at` creates a *specification* of a recipe step that will modify
 #' the selected variables using a common function via [dplyr::mutate_at()].
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param fn A function fun, a quosure style lambda `~ fun(.)`` or a list of
 #' either form. (see [dplyr::mutate_at()]). **Note that this argument must be
 #' named**.
-#' @param role For model terms created by this step, what analysis role should
-#'  they be assigned? By default, the function assumes that the new dimension
-#'  columns created by the original variables will be used as predictors in a
-#'  model.
 #' @param inputs A vector of column names populated by `prep()`.
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -4,27 +4,12 @@
 #'  create and append additional binary columns to the dataset to indicate
 #'  which observations are missing.
 #'
-#' @param recipe A recipe object. The check will be added to the
-#'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new na indicator columns created from the original
-#'  variables will be used as predictors in a model.
-#' @param trained A logical for whether the selectors in `...`
-#' have been resolved by [prep()].
+#' @inheritParams step_pca
+#' @inheritParams step_center
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the terms argument.
 #' @param prefix A character string that will be the prefix to the
 #'  resulting new variables. Defaults to "na_ind".
-#' @param skip A logical. Should the check be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = TRUE` as it may affect
-#'  the computations for subsequent operations.
-#' @param id A character string that is unique to this step to identify it.
 #' @template step-return
 #' @details  When you [`tidy()`] this step, a tibble with
 #'  columns `terms` (the selectors or variables selected) and `model` (the

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -4,25 +4,14 @@
 #'   will remove observations (rows of data) if they contain `NA`
 #'   or `NaN` values.
 #'
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'   operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to remove observations containing `NA` or `NaN`
-#'   values. See [selections()] for more details.
+#' @template row-ops
+#' @inheritParams step_center
 #' @param role Unused, include for consistency with other steps.
 #' @param trained A logical to indicate if the quantities for preprocessing
 #'   have been estimated. Again included for consistency.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
-#' @param id A character string that is unique to this step to identify it.
-#' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = FALSE`.
 #'
-#' @template row-ops
-#' @rdname step_naomit
 #' @template step-return
 #' @export
 #'

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -3,31 +3,12 @@
 #' `check_new_values` creates a *specification* of a recipe
 #'  operation that will check if variables contain new values.
 #'
-#' @param recipe A recipe object. The check will be added to the
-#'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables are checked in the check. See [selections()]
-#'  for more details. For the `tidy` method, these are not
-#'  currently used.
-#' @param role Not used by this check since no new variables are
-#'  created.
-#' @param trained A logical for whether the selectors in `...`
-#' have been resolved by [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the terms argument.
+#' @inheritParams check_missing
 #' @param ignore_NA A logical that indicates if we should consider missing
 #'  values as value or not. Defaults to `TRUE`.
 #' @param values A named list with the allowed values.
 #'  This is `NULL` until computed by prep.recipe().
-#' @param id A character string that is unique to this step to identify it.
-#' @param skip A logical. Should the check be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = TRUE` as it may affect
-#'  the computations for subsequent operations.
-#' @return An updated version of `recipe` with the new check added to the
-#'  sequence of any existing operations.
+#' @template check-return
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain values it did not contain when `prep` was called

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -4,15 +4,8 @@
 #'  that will convert numeric data into one or more non-negative
 #'  components.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used to compute the components. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new component columns created by the
-#'  original variables will be used as predictors in a model.
 #' @param num_comp The number of components to retain as new
 #'  predictors. If `num_comp` is greater than the number of columns
 #'  or the number of possible components, a smaller value will be
@@ -30,8 +23,6 @@
 #'  resulting new variables. See notes below.
 #' @param seed An integer that will be used to set the seed in isolation
 #'  when computing the factorization.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -5,11 +5,6 @@
 #'  deviation of one and a mean of zero.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param means A named numeric vector of means. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @param sds A named numeric vector of standard deviations This

--- a/R/novel.R
+++ b/R/novel.R
@@ -5,13 +5,6 @@
 #'  new value.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will be affected by the step. These variables
-#'  should be character or factor types. See [selections()] for more
-#'  details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param new_level A single character value that will be assigned
 #'  to new factor levels.
 #' @param objects A list of objects that contain the information

--- a/R/ns.R
+++ b/R/ns.R
@@ -4,14 +4,8 @@
 #'  that will create new columns that are basis expansions of
 #'  variables using natural splines.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
 #' @param deg_free The degrees of freedom for the natural spline. As the
 #'  degrees of freedom for a natural spline increase, more flexible and
 #'  complex curves can be generated. When a single degree of freedom is used,

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -5,10 +5,6 @@
 #'  integers.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which variables will be
-#'  converted to factors. See [selections()] for more details.
-#' @param role Not used by this step since no new variables are created.
 #' @param transform A function taking a single argument `x` that can be used
 #'  to modify the numeric values prior to determining the levels (perhaps using
 #'  [base::as.integer()]). The output of a function should be an integer that

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -5,11 +5,6 @@
 #'  and unbalanced.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables that will be evaluated by the filtering. See
-#'  [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param freq_cut,unique_cut Numeric parameters for the filtering process. See
 #'  the Details section below.
 #' @param options A list of options for the filter (see Details

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -5,11 +5,6 @@
 #'  numeric scores.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variables that will be
 #'  converted. This is `NULL` until computed by
 #'  [prep.recipe()].

--- a/R/other.R
+++ b/R/other.R
@@ -5,17 +5,12 @@
 #'  into an "other" category.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will potentially be reduced. See
-#'  [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
-#' @param threshold A numeric value between 0 and 1 or an integer greater or
-#'  equal to one.  If it's less than one then factor levels whose rate of
-#'  occurrence in the training set are below `threshold` will be "othered". If
-#'  it's greater or equal to one then it's treated as a frequency and factor
-#'  levels that occur less then `threshold` times will be "othered".
+#' @param threshold A numeric value between 0 and 1, or an integer greater or
+#'  equal to one.  If less than one, then factor levels with a rate of
+#'  occurrence in the training set below `threshold` will be pooled to `other`.
+#'  If greater or equal to one, then this value is treated as a frequency
+#'  and factor levels that occur less than `threshold` times will be pooled
+#'  to `other`.
 #' @param other A single character value for the "other" category.
 #' @param objects A list of objects that contain the information
 #'  to pool infrequent levels that is determined by

--- a/R/pca.R
+++ b/R/pca.R
@@ -4,13 +4,9 @@
 #'  numeric data into one or more principal components.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which variables will be
-#'  used to compute the components. See [selections()] for more details.
 #' @param role For model terms created by this step, what analysis role should
-#'  they be assigned?. By default, the function assumes that the new principal
-#'  component columns created by the original variables will be used as
-#'  predictors in a model.
+#'  they be assigned?. By default, the new columns created by this step from
+#'  the original variables will be used as _predictors_ in a model.
 #' @param num_comp The number of PCA components to retain as new predictors.
 #'  If `num_comp` is greater than the number of columns or the number of
 #'  possible components, a smaller value will be used.
@@ -25,8 +21,8 @@
 #'  should not be passed here (or at all).
 #' @param res The [stats::prcomp.default()] object is stored here once this
 #'  preprocessing step has be trained by [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the resulting
-#'  new variables. See notes below.
+#' @param prefix A character string for the prefix of the resulting new
+#'  variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
 #' @template step-return

--- a/R/pca.R
+++ b/R/pca.R
@@ -5,7 +5,7 @@
 #'
 #' @inheritParams step_center
 #' @param role For model terms created by this step, what analysis role should
-#'  they be assigned?. By default, the new columns created by this step from
+#'  they be assigned? By default, the new columns created by this step from
 #'  the original variables will be used as _predictors_ in a model.
 #' @param num_comp The number of PCA components to retain as new predictors.
 #'  If `num_comp` is greater than the number of columns or the number of

--- a/R/pls.R
+++ b/R/pls.R
@@ -3,14 +3,8 @@
 #' `step_pls` creates a *specification* of a recipe step that will
 #'  convert numeric data into one or more new dimensions.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which variables will be
-#'  used to compute the dimensions. See [selections()] for more details.
-#' @param role For model terms created by this step, what analysis role should
-#'  they be assigned?. By default, the function assumes that the new dimension
-#'  columns created by the original variables will be used as predictors in a
-#'  model.
 #' @param num_comp The number of pls dimensions to retain as new predictors.
 #'  If `num_comp` is greater than the number of columns or the number of
 #'  possible dimensions, a smaller value will be used.
@@ -26,10 +20,6 @@
 #' arguments).
 #' @param res A list of results are stored here once this preprocessing step
 #'  has been trained by [prep.recipe()].
-#' @param prefix A character string that will be the prefix to the
-#'  resulting new variables. See notes below.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `FALSE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/poly.R
+++ b/R/poly.R
@@ -3,16 +3,9 @@
 #' `step_poly` creates a *specification* of a recipe
 #'  step that will create new columns that are basis expansions of
 #'  variables using orthogonal polynomials.
-
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
 #' @param objects A list of [stats::poly()] objects
 #'  created once the step has been trained.
 #' @param degree The polynomial degree (an integer).

--- a/R/profile.R
+++ b/R/profile.R
@@ -7,12 +7,6 @@
 #'  models.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be fixed to a single value. See [selections()] for
-#'  more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param profile A call to [dplyr::vars()]) to specify which
 #'  variable will be profiled (see [selections()]). If a column is
 #'  included in both lists to be fixed and to be profiled, an error

--- a/R/range.R
+++ b/R/range.R
@@ -5,11 +5,6 @@
 #'  range of values.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables will be scaled. See [selections()] for more
-#'  details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param min A single numeric value for the smallest value in the
 #'  range.
 #' @param max A single numeric value for the largest value in the

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -4,22 +4,7 @@
 #'  check that will check if the range of a numeric
 #'  variable changed in the new data.
 #'
-#' @param recipe A recipe object. The check will be added to the
-#'  sequence of operations for this recipe.
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the check. See [selections()]
-#'  for more details.
-#' @param role Not used by this check since no new variables are
-#'  created.
-#' @param id A character string that is unique to this step to identify it.
-#' @param skip A logical. Should the check be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = TRUE` as it may affect
-#'  the computations for subsequent operations.
-#' @param trained A logical to indicate if the quantities for
-#'  preprocessing have been estimated.
+#' @inheritParams check_missing
 #' @param slack_prop The allowed slack as a proportion of the range
 #'   of the variable in the train set.
 #' @param warn If `TRUE` the check will throw a warning instead
@@ -28,8 +13,7 @@
 #'   This is `NULL` until computed by [prep.recipe()].
 #' @param upper A named numeric vector of maximum values in the train set.
 #'   This is `NULL` until computed by [prep.recipe()].
-#' @return An updated version of `recipe` with the new check
-#'  added to the sequence of any existing operations.
+#' @template check-return
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -4,6 +4,7 @@
 #'  step that will create one or more ratios out of numeric
 #'  variables.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @inherit step_center return
 #' @param ... One or more selector functions to choose which
@@ -11,10 +12,6 @@
 #'  When used with `denom_vars`, the dots indicate which
 #'  variables are used in the *denominator*. See
 #'  [selections()] for more details.
-#' @param role For terms created by this step, what analysis role
-#'  should they be assigned?. By default, the function assumes that
-#'  the newly created ratios created by the original variables will
-#'  be used as predictors in a model.
 #' @param denom A call to `denom_vars` to specify which
 #'  variables are used in the denominator that can include specific
 #'  variable names separated by commas or different selectors (see

--- a/R/regex.R
+++ b/R/regex.R
@@ -3,16 +3,11 @@
 #' `step_regex` creates a *specification* of a recipe step that will
 #'   create a new dummy variable based on a regular expression.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... A single selector functions to choose which variable
-#'  will be searched for the pattern. The selector should resolve
-#'  into a single variable. See [selections()] for more
-#'  details.
-#' @param role For a variable created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new dummy variable column created by the original
-#'  variable will be used as a predictor in a model.
+#' @param ... A single selector function to choose which variable
+#'  will be searched for the regex pattern. The selector should resolve
+#'  to a single variable. See [selections()] for more details.
 #' @param pattern A character string containing a regular
 #'  expression (or character string for `fixed = TRUE`) to be
 #'  matched in the given character vector. Coerced by

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -7,14 +7,6 @@
 #'  reference.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#'
-#' @param ... One or more selector functions to choose which
-#'  variables that will be affected by the step. These variables
-#'  should be character or factor types. See [selections()] for more
-#'  details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param ref_level A single character value that will be used to
 #'  relevel the factor column(s) (if the level is present).
 #' @param objects A list of objects that contain the information

--- a/R/relu.R
+++ b/R/relu.R
@@ -4,21 +4,15 @@
 #'   will apply the rectified linear or softplus transformations to numeric
 #'   data. The transformed data is added as new columns to the data matrix.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'   operations for this recipe.
-#' @param ... One or more selector functions to choose which variables are
-#'   affected by the step. See [selections()] for more details.
-#' @param role Defaults to "predictor".
-#' @param trained A logical to indicate if the quantities for preprocessing
-#'   have been estimated.
 #' @param shift A numeric value dictating a translation to apply to the data.
 #' @param reverse A logical to indicate if the left hinge should be used as
 #'   opposed to the right hinge.
 #' @param smooth A logical indicating if the softplus function, a smooth
 #'   approximation to the rectified linear transformation, should be used.
-#' @param prefix A prefix for generated column names, default to "right_relu_"
-#'   when right hinge transformation and "left_relu_" for reversed/left hinge
+#' @param prefix A prefix for generated column names, defaults to "right_relu_"
+#'   for right hinge transformation and "left_relu_" for reversed/left hinge
 #'   transformations.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.

--- a/R/rename.R
+++ b/R/rename.R
@@ -3,13 +3,10 @@
 #' `step_rename` creates a *specification* of a recipe step that will add
 #'  variables using [dplyr::rename()].
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... One or more unquoted expressions separated by commas. See
 #'  [dplyr::rename()] where the convention is **`new_name = old_name`**.
-#' @param role For model terms created by this step, what analysis role should
-#'  they be assigned? By default, the function assumes that the new dimension
-#'  columns created by the original variables will be used as predictors in a
-#'  model.
 #' @param inputs Quosure(s) of `...`.
 #' @template step-return
 #' @details When an object in the user's global environment is referenced in

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -3,14 +3,11 @@
 #' `step_rename_at` creates a *specification* of a recipe step that will rename
 #' the selected variables using a common function via [dplyr::rename_at()].
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param fn A function `fun`, a quosure style lambda `~ fun(.)`` or a list of
 #' either form (but containing only a single function, see [dplyr::rename_at()]).
 #' **Note that this argument must be named**.
-#' @param role For model terms created by this step, what analysis role should
-#'  they be assigned? By default, the function assumes that the new dimension
-#'  columns created by the original variables will be used as predictors in a
-#'  model.
 #' @param inputs A vector of column names populated by `prep()`.
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with

--- a/R/rm.R
+++ b/R/rm.R
@@ -4,11 +4,6 @@
 #'  that will remove variables based on their name, type, or role.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables that will be evaluated by the filtering bake. See
-#'  [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.

--- a/R/sample.R
+++ b/R/sample.R
@@ -8,18 +8,11 @@
 #' @inheritParams step_center
 #' @param ... Argument ignored; included for consistency with other step
 #'  specification functions.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param size An integer or fraction. If the value is within (0, 1),
 #'  [dplyr::sample_frac()] is applied to the data. If an integer
 #'  value of 1 or greater is used, [dplyr::sample_n()] is applied.
 #'  The default of `NULL` uses [dplyr::sample_n()] with the size
 #'  of the training set (or smaller for smaller `new_data`).
-#' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = FALSE`.
 #' @param replace Sample with or without replacement?
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `size`,

--- a/R/scale.R
+++ b/R/scale.R
@@ -5,11 +5,6 @@
 #'  deviation of one.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param sds A named numeric vector of standard deviations. This
 #'  is `NULL` until computed by [prep.recipe()].
 #' @param factor A numeric value of either 1 or 2 that scales the

--- a/R/select.R
+++ b/R/select.R
@@ -4,9 +4,6 @@
 #'  that will select variables using [dplyr::select()].
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables will be selected when baking. See
-#'  [selections()] for more details.
 #' @param role For model terms selected by this step, what analysis
 #'  role should they be assigned?
 #' @template step-return

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -5,18 +5,12 @@
 #'  variables.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be permuted. See [selections()] for more
-#'  details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string that contains the names of
 #'  columns that should be shuffled. These values are not determined
 #'  until [prep.recipe()] is called.
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
-#' columns that will be affected) is returned.
+#' columns that will be permuted) is returned.
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept randomization

--- a/R/slice.R
+++ b/R/slice.R
@@ -7,14 +7,7 @@
 #' @inheritParams step_center
 #' @param ... Integer row values. See
 #'  [dplyr::slice()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param inputs Quosure of values given by `...`.
-#' @param skip A logical. Should the step be skipped when the
-#'  recipe is baked by [bake.recipe()]? While all operations are baked
-#'  when [prep.recipe()] is run, some operations may not be able to be
-#'  conducted on new data (e.g. processing the outcome variable(s)).
-#'  Care should be taken when using `skip = FALSE`.
 #' @template step-return
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -4,13 +4,8 @@
 #'  step that will convert numeric data into a projection on to a
 #'  unit sphere.
 #'
+#' @inheritParams step_pca
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be used for the normalization. See
-#'  [selections()] for more details.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?
 #' @param na_rm A logical: should missing data be removed from the
 #'  norm computation?
 #' @param columns A character string of variable names that will

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -4,12 +4,6 @@
 #'  step that will square root transform the data.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be transformed. See [selections()] for
-#'  more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -4,12 +4,6 @@
 #'  vectors to factors (ordered or unordered).
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables will be converted to factors. See
-#'  [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param levels An options specification of the levels to be used
 #'  for the new factor. If left `NULL`, the sorted unique
 #'  values present when `bake` is called will be used.

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -4,13 +4,6 @@
 #'  step that will assign a missing value in a factor level to"unknown".
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will be affected by the step. These variables
-#'  should be character or factor types. See [selections()] for more
-#'  details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param new_level A single character value that will be assigned
 #'  to new factor levels.
 #' @param objects A list of objects that contain the information

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -4,11 +4,6 @@
 #'  step that will transform the data.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -9,13 +9,6 @@
 #'  levels in a specific factor level equal.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variable is used to sample the data. See [selections()]
-#'  for more details. The selection should result in _single
-#'  factor variable_. For the `tidy` method, these are not
-#'  currently used.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param over_ratio A numeric value for the ratio of the

--- a/R/window.R
+++ b/R/window.R
@@ -5,9 +5,6 @@
 #'  functions that compute statistics across moving windows.
 #'
 #' @inheritParams step_center
-#' @param ... One or more selector functions to choose which
-#'  variables are affected by the step. See [selections()]
-#'  for more details.
 #' @param role For model terms created by this step, what analysis
 #'  role should they be assigned? If `names` is left to be
 #'  `NULL`, the rolling statistics replace the original columns

--- a/R/zv.R
+++ b/R/zv.R
@@ -4,12 +4,6 @@
 #'  that will remove variables that contain only a single value.
 #'
 #' @inheritParams step_center
-#' @inherit step_center return
-#' @param ... One or more selector functions to choose which
-#'  variables that will be evaluated by the filtering. See
-#'  [selections()] for more details.
-#' @param role Not used by this step since no new variables are
-#'  created.
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.

--- a/inst/boilerplate.R
+++ b/inst/boilerplate.R
@@ -3,6 +3,7 @@ library(glue)
 # set up the boilerplate for a new step or check
 # creates a prefilled script in /R
 # and an empty script in /tests
+# consider using @inheritParams where appropriate instead of full boilerplate
 make_new <- function(name,
                      which = c("step", "check")) {
   which <- match.arg(which)

--- a/man-roxygen/check-return.R
+++ b/man-roxygen/check-return.R
@@ -1,0 +1,2 @@
+#' @return An updated version of `recipe` with the new check added to the
+#'  sequence of any existing operations.

--- a/man-roxygen/row-ops.R
+++ b/man-roxygen/row-ops.R
@@ -1,3 +1,9 @@
+#' @param skip A logical. Should the step be skipped when the
+#'  recipe is baked by [bake.recipe()]? While all operations are baked
+#'  when [prep.recipe()] is run, some operations may not be able to be
+#'  conducted on new data (e.g. processing the outcome variable(s)).
+#'  Care should be taken when using `skip = FALSE`.
+#'
 #' @section Row Filtering:
 #'
 #' This step can entirely remove observations (rows of data), which can have

--- a/man/check_class.Rd
+++ b/man/check_class.Rd
@@ -20,15 +20,14 @@ check_class(
 \item{recipe}{A recipe object. The check will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the check. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this check. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this check since no new variables are
 created.}
 
-\item{trained}{A logical to indicate if the quantities for
-preprocessing have been estimated.}
+\item{trained}{A logical for whether the selectors in \code{...}
+have been resolved by \code{\link[=prep]{prep()}}.}
 
 \item{class_nm}{A character vector that will be used in \code{inherits} to
 check the class. If \code{NULL} the classes will be learned in \code{prep}.
@@ -47,11 +46,11 @@ the computations for subsequent operations.}
 \item{class_list}{A named list of column classes. This is
 \code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{id}{A character string that is unique to this step to identify it.}
+\item{id}{A character string that is unique to this check to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step added to the
-sequence of any existing steps.
+An updated version of \code{recipe} with the new check added to the
+sequence of any existing operations.
 }
 \description{
 \code{check_class} creates a \emph{specification} of a recipe

--- a/man/check_cols.Rd
+++ b/man/check_cols.Rd
@@ -17,9 +17,8 @@ check_cols(
 \item{recipe}{A recipe object. The check will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are checked in the check See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this check. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this check since no new variables are
 created.}
@@ -34,7 +33,11 @@ conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations.}
 
-\item{id}{A character string that is unique to this step to identify it.}
+\item{id}{A character string that is unique to this check to identify it.}
+}
+\value{
+An updated version of \code{recipe} with the new check added to the
+sequence of any existing operations.
 }
 \description{
 \code{check_cols} creates a \emph{specification} of a recipe

--- a/man/check_missing.Rd
+++ b/man/check_missing.Rd
@@ -18,9 +18,8 @@ check_missing(
 \item{recipe}{A recipe object. The check will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are checked in the check See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this check. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this check since no new variables are
 created.}
@@ -38,11 +37,11 @@ conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations.}
 
-\item{id}{A character string that is unique to this step to identify it.}
+\item{id}{A character string that is unique to this check to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new step added to the
-sequence of any existing steps.
+An updated version of \code{recipe} with the new check added to the
+sequence of any existing operations.
 }
 \description{
 \code{check_missing} creates a \emph{specification} of a recipe

--- a/man/check_new_values.Rd
+++ b/man/check_new_values.Rd
@@ -20,10 +20,8 @@ check_new_values(
 \item{recipe}{A recipe object. The check will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are checked in the check. See \code{\link[=selections]{selections()}}
-for more details. For the \code{tidy} method, these are not
-currently used.}
+\item{...}{One or more selector functions to choose variables
+for this check. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this check since no new variables are
 created.}
@@ -47,7 +45,7 @@ conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations.}
 
-\item{id}{A character string that is unique to this step to identify it.}
+\item{id}{A character string that is unique to this check to identify it.}
 }
 \value{
 An updated version of \code{recipe} with the new check added to the

--- a/man/check_range.Rd
+++ b/man/check_range.Rd
@@ -21,9 +21,8 @@ check_range(
 \item{recipe}{A recipe object. The check will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the check. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this check. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this check since no new variables are
 created.}
@@ -35,8 +34,8 @@ conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
 the computations for subsequent operations.}
 
-\item{trained}{A logical to indicate if the quantities for
-preprocessing have been estimated.}
+\item{trained}{A logical for whether the selectors in \code{...}
+have been resolved by \code{\link[=prep]{prep()}}.}
 
 \item{slack_prop}{The allowed slack as a proportion of the range
 of the variable in the train set.}
@@ -50,11 +49,11 @@ This is \code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.
 \item{upper}{A named numeric vector of maximum values in the train set.
 This is \code{NULL} until computed by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{id}{A character string that is unique to this step to identify it.}
+\item{id}{A character string that is unique to this check to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the new check
-added to the sequence of any existing operations.
+An updated version of \code{recipe} with the new check added to the
+sequence of any existing operations.
 }
 \description{
 \code{check_range} creates a \emph{specification} of a recipe

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -235,8 +235,8 @@ prepped or unprepped, to learn more about its components.\if{html}{\out{<div cla
 }\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 x 6
 ##   number operation type      trained skip  id             
 ##    <int> <chr>     <chr>     <lgl>   <lgl> <chr>          
-## 1      1 step      normalize TRUE    FALSE normalize_tNqMr
-## 2      2 step      pca       TRUE    FALSE pca_Ge1rB
+## 1      1 step      normalize TRUE    FALSE normalize_uFLiq
+## 2      2 step      pca       TRUE    FALSE pca_VMdtm
 }
 
 You can also \code{tidy()} recipe \emph{steps} with a \code{number} or \code{id} argument.

--- a/man/step_BoxCox.Rd
+++ b/man/step_BoxCox.Rd
@@ -20,9 +20,8 @@ step_BoxCox(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_YeoJohnson.Rd
+++ b/man/step_YeoJohnson.Rd
@@ -21,9 +21,8 @@ step_YeoJohnson(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -20,8 +20,8 @@ step_bin2factor(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{Selector functions that choose which variables will
-be converted. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -25,7 +25,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -21,14 +21,12 @@ step_bs(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_center.Rd
+++ b/man/step_center.Rd
@@ -19,9 +19,8 @@ step_center(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -24,16 +24,15 @@ step_classdist(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{class}{A single character string that specifies a single
 categorical variable to be used as the class.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that resulting distances will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -52,8 +51,8 @@ the natural log function?}
 \item{objects}{Statistics are stored here once this step has
 been trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{prefix}{A character string that defines the naming convention for
-new distance columns. Defaults to \code{"classdist_"}. See Details below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -31,7 +31,7 @@ for this step. See \code{\link[=selections]{selections()}} for more details.}
 categorical variable to be used as the class.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_corr.Rd
+++ b/man/step_corr.Rd
@@ -21,9 +21,8 @@ step_corr(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -22,15 +22,13 @@ step_count(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{A single selector functions to choose which variable
-will be searched for the pattern. The selector should resolve
-into a single variable. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{A single selector function to choose which variable
+will be searched for the regex pattern. The selector should
+resolve to a single variable. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For a variable created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new dummy variable column created by the original
-variable will be used as a predictor in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -27,7 +27,7 @@ will be searched for the regex pattern. The selector should
 resolve to a single variable. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_cut.Rd
+++ b/man/step_cut.Rd
@@ -16,16 +16,17 @@ step_cut(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{breaks}{A numeric vector with at least one cut point.}
 
@@ -33,10 +34,12 @@ have been estimated.}
 range in the train set should be included in the lowest or highest bucket.
 Defaults to \code{FALSE}, values outside the original range will be set to \code{NA}.}
 
-\item{skip}{A logical. Should the step be skipped when the recipe is baked
-by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked when \code{\link[=prep.recipe]{prep.recipe()}} is
-run, some operations may not be able to be conducted on new data (e.g.
-processing the outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it may affect the computations for subsequent operations}
+\item{skip}{A logical. Should the step be skipped when the
+recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
+when \code{\link[=prep.recipe]{prep.recipe()}} is run, some operations may not be able to be
+conducted on new data (e.g. processing the outcome variable(s)).
+Care should be taken when using \code{skip = TRUE} as it may affect
+the computations for subsequent operations}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -28,7 +28,7 @@ for this step. The selected variables should have class \code{Date} or
 \code{POSIXct}. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -23,15 +23,13 @@ step_date(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be used to create the new variables. The
-selected variables should have class \code{Date} or
+\item{...}{One or more selector functions to choose variables
+for this step. The selected variables should have class \code{Date} or
 \code{POSIXct}. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new variable columns created by the original variables
-will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -22,17 +22,15 @@ step_depth(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be used to create the new features. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{class}{A single character string that specifies a single
 categorical variable to be used as the class.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that resulting depth estimates will be used as predictors in a
-model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -54,8 +52,8 @@ depth functions. See \code{\link[ddalpha:depth.halfspace]{ddalpha::depth.halfspa
 \item{data}{The training data are stored here once after
 \code{\link[=prep.recipe]{prep.recipe()}} is executed.}
 
-\item{prefix}{A character string that defines the naming convention for
-new depth columns. Defaults to \code{"depth_"}. See Details below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -29,7 +29,7 @@ for this step. See \code{\link[=selections]{selections()}} for more details.}
 categorical variable to be used as the class.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_discretize.Rd
+++ b/man/step_discretize.Rd
@@ -21,10 +21,8 @@ step_discretize(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{For \code{step_discretize}, the dots specify
-one or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -25,11 +25,8 @@ step_downsample(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variable is used to sample the data. See \code{\link[=selections]{selections()}}
-for more details. The selection should result in \emph{single
-factor variable}. For the \code{tidy} method, these are not
-currently used.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{under_ratio}{A numeric value for the ratio of the
 minority-to-majority frequencies. The default value (1) means

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -27,7 +27,7 @@ for this step. See \code{\link[=selections]{selections()}} for more details. The
 variables \emph{must} be factors.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -22,15 +22,13 @@ step_dummy(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-\emph{factor} variables will be used to create the dummy variables. See
-\code{\link[=selections]{selections()}} for more details. The selected
-variables must be factors.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details. The selected
+variables \emph{must} be factors.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the binary dummy variable columns created by the original
-variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -18,9 +18,8 @@ step_factor2string(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be converted to strings. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -28,7 +28,7 @@ sequence of operations for this recipe.}
 used by the step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -27,9 +27,9 @@ sequence of operations for this recipe.}
 \item{lon, lat}{Selector functions to choose which variables are
 used by the step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{or model term created by this step, what analysis
-role should be assigned?. By default, the function assumes
-that resulting distance will be used as a predictor in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -25,7 +25,7 @@ for this step. The selected variables should have class \code{Date} or
 \code{POSIXct}. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -20,15 +20,13 @@ step_holiday(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to create the new variables. The selected
-variables should have class \code{Date} or \code{POSIXct}. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. The selected variables should have class \code{Date} or
+\code{POSIXct}. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new variable columns created by the original variables
-will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_hyperbolic.Rd
+++ b/man/step_hyperbolic.Rd
@@ -20,9 +20,8 @@ step_hyperbolic(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -26,7 +26,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -22,14 +22,12 @@ step_ica(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the components. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new independent component columns created by the
-original variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -48,8 +46,8 @@ not be passed here.}
 here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_impute_bag.Rd
+++ b/man/step_impute_bag.Rd
@@ -40,12 +40,13 @@ imp_vars(...)
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables. For
-\code{step_impute_bag}, this indicates the variables to be imputed. When used
-with \code{imp_vars}, the dots indicate which variables are used to predict the
-missing data in each variable. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables to be imputed.
+When used with \code{imp_vars}, these dots indicate which variables are used to
+predict the missing data in each variable. See \code{\link[=selections]{selections()}} for more
+details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_impute_knn.Rd
+++ b/man/step_impute_knn.Rd
@@ -37,12 +37,13 @@ step_knnimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables. For
-\code{step_impute_knn}, this indicates the variables to be imputed. When used
-with \code{imp_vars}, the dots indicate which variables are used to predict the
-missing data in each variable. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables to be imputed.
+When used with \code{imp_vars}, these dots indicate which variables are used to
+predict the missing data in each variable. See \code{\link[=selections]{selections()}} for more
+details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_impute_linear.Rd
+++ b/man/step_impute_linear.Rd
@@ -21,7 +21,7 @@ sequence of operations for this recipe.}
 
 \item{...}{One or more selector functions to choose variables to be imputed;
 these variables \strong{must} be of type \code{numeric}. When used with \code{imp_vars},
-these dots indicates which variables are used to predict the missing data
+these dots indicate which variables are used to predict the missing data
 in each variable. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are

--- a/man/step_impute_linear.Rd
+++ b/man/step_impute_linear.Rd
@@ -19,13 +19,13 @@ step_impute_linear(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose variables. For
-\code{step_impute_linear}, this indicates the variables to be imputed; these variables
-\strong{must} be of type \code{numeric}. When used with \code{imp_vars}, the dots indicates
-which variables are used to predict the missing data in each variable. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables to be imputed;
+these variables \strong{must} be of type \code{numeric}. When used with \code{imp_vars},
+these dots indicates which variables are used to predict the missing data
+in each variable. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_impute_lower.Rd
+++ b/man/step_impute_lower.Rd
@@ -29,9 +29,8 @@ step_lowerimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_impute_mean.Rd
+++ b/man/step_impute_mean.Rd
@@ -31,10 +31,11 @@ step_meanimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_impute_median.Rd
+++ b/man/step_impute_median.Rd
@@ -29,10 +29,11 @@ step_medianimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_impute_mode.Rd
+++ b/man/step_impute_mode.Rd
@@ -31,9 +31,8 @@ step_modeimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_impute_roll.Rd
+++ b/man/step_impute_roll.Rd
@@ -33,10 +33,9 @@ step_rollimpute(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}} for more
-details. These columns should be non-integer numerics (i.e.,
-double precision).}
+\item{...}{One or more selector functions to choose variables to be imputed;
+these columns must be non-integer numerics (i.e., double precision).
+See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -23,7 +23,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -16,19 +16,18 @@ step_indicate_na(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The check will be added to the
+\item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new na indicator columns created from the original
-variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical for whether the selectors in \code{...}
-have been resolved by \code{\link[=prep]{prep()}}.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{columns}{A character string of variable names that will
 be populated (eventually) by the terms argument.}
@@ -36,12 +35,12 @@ be populated (eventually) by the terms argument.}
 \item{prefix}{A character string that will be the prefix to the
 resulting new variables. Defaults to "na_ind".}
 
-\item{skip}{A logical. Should the check be skipped when the
+\item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked
 when \code{\link[=prep.recipe]{prep.recipe()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
-the computations for subsequent operations.}
+the computations for subsequent operations}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -24,7 +24,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -20,14 +20,12 @@ step_integer(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to create the integer variables. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created by the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -25,7 +25,7 @@ for more details, and consider using \code{\link[tidyselect:starts_with]{tidysel
 dummy variables have been created.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -24,10 +24,9 @@ terms. This can include \code{.} and selectors. See \code{\link[=selections]{sel
 for more details, and consider using \code{\link[tidyselect:starts_with]{tidyselect::starts_with()}} when
 dummy variables have been created.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -16,19 +16,18 @@ step_intercept(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
 \item{...}{Argument ignored; included for consistency with other step
 specification functions.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated. Again included for consistency.}
+have been estimated. Again included only for consistency.}
 
 \item{name}{Character name for newly added column}
 

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -23,7 +23,7 @@ sequence of operations for this recipe.}
 specification functions.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for preprocessing

--- a/man/step_inverse.Rd
+++ b/man/step_inverse.Rd
@@ -19,9 +19,8 @@ step_inverse(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_invlogit.Rd
+++ b/man/step_invlogit.Rd
@@ -18,9 +18,8 @@ step_invlogit(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -23,14 +23,12 @@ step_isomap(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the dimensions. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new dimension columns created by the original variables
-will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -48,8 +46,8 @@ used.}
 here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -27,7 +27,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -25,7 +25,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -21,14 +21,12 @@ step_kpca(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the components. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned? By default, the function assumes
-that the new principal component columns created by the original
-variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -48,8 +46,8 @@ here once this preprocessing step has be trained by
 \strong{Note} that the arguments \code{x} and \code{features}
 should not be passed here (or at all).}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -24,14 +24,12 @@ step_kpca_poly(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the components. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned? By default, the function assumes
-that the new principal component columns created by the original
-variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -47,8 +45,8 @@ here once this preprocessing step has be trained by
 
 \item{degree, scale_factor, offset}{Numeric values for the polynomial kernel function.}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -28,7 +28,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -22,14 +22,12 @@ step_kpca_rbf(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the components. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned? By default, the function assumes
-that the new principal component columns created by the original
-variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -45,8 +43,8 @@ here once this preprocessing step has be trained by
 
 \item{sigma}{A numeric value for the radial basis function parameter.}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -26,7 +26,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -18,16 +18,18 @@ step_lag(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Defaults to "predictor"}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{lag}{A vector of positive integers. Each specified column will be
 lagged for each value in the vector.}

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -25,7 +25,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_lincomb.Rd
+++ b/man/step_lincomb.Rd
@@ -19,9 +19,8 @@ step_lincomb(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}
@@ -29,7 +28,7 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{max_steps}{A value.}
+\item{max_steps}{The number of times to apply the algorithm.}
 
 \item{removals}{A character string that contains the names of
 columns that should be removed. These values are not determined

--- a/man/step_log.Rd
+++ b/man/step_log.Rd
@@ -21,9 +21,8 @@ step_log(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_logit.Rd
+++ b/man/step_logit.Rd
@@ -18,9 +18,8 @@ step_logit(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -23,7 +23,7 @@ If the argument is not named, the expression is converted to
 a column name.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -22,10 +22,9 @@ sequence of operations for this recipe.}
 If the argument is not named, the expression is converted to
 a column name.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned? By default, the function assumes
-that the new dimension columns created by the original variables
-will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -27,7 +27,7 @@ either form. (see \code{\link[dplyr:mutate_all]{dplyr::mutate_at()}}). \strong{N
 named}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -19,18 +19,16 @@ step_mutate_at(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{fn}{A function fun, a quosure style lambda `~ fun(.)`` or a list of
 either form. (see \code{\link[dplyr:mutate_all]{dplyr::mutate_at()}}). \strong{Note that this argument must be
 named}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned? By default, the function assumes that the new dimension
-columns created by the original variables will be used as predictors in a
-model.}
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_naomit.Rd
+++ b/man/step_naomit.Rd
@@ -15,12 +15,11 @@ step_naomit(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to remove observations containing \code{NA} or \code{NaN}
-values. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Unused, include for consistency with other steps.}
 

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -28,7 +28,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -24,14 +24,12 @@ step_nnmf(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used to compute the components. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new component columns created by the
-original variables will be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_normalize.Rd
+++ b/man/step_normalize.Rd
@@ -20,9 +20,8 @@ step_normalize(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -19,10 +19,8 @@ step_novel(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be affected by the step. These variables
-should be character or factor types. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -24,7 +24,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -20,14 +20,12 @@ step_ns(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -20,10 +20,11 @@ step_num2factor(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables will be
-converted to factors. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Not used by this step since no new variables are created.}
+\item{role}{Not used by this step since no new variables are
+created.}
 
 \item{transform}{A function taking a single argument \code{x} that can be used
 to modify the numeric values prior to determining the levels (perhaps using

--- a/man/step_nzv.Rd
+++ b/man/step_nzv.Rd
@@ -21,9 +21,8 @@ step_nzv(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be evaluated by the filtering. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -19,9 +19,8 @@ step_ordinalscore(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -20,9 +20,8 @@ step_other(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will potentially be reduced. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}
@@ -30,11 +29,12 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{threshold}{A numeric value between 0 and 1 or an integer greater or
-equal to one.  If it's less than one then factor levels whose rate of
-occurrence in the training set are below \code{threshold} will be "othered". If
-it's greater or equal to one then it's treated as a frequency and factor
-levels that occur less then \code{threshold} times will be "othered".}
+\item{threshold}{A numeric value between 0 and 1, or an integer greater or
+equal to one.  If less than one, then factor levels with a rate of
+occurrence in the training set below \code{threshold} will be pooled to \code{other}.
+If greater or equal to one, then this value is treated as a frequency
+and factor levels that occur less than \code{threshold} times will be pooled
+to \code{other}.}
 
 \item{other}{A single character value for the "other" category.}
 

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -23,13 +23,12 @@ step_pca(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables will be
-used to compute the components. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the function assumes that the new principal
-component columns created by the original variables will be used as
-predictors in a model.}
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -51,8 +50,8 @@ should not be passed here (or at all).}
 \item{res}{The \code{\link[stats:prcomp]{stats::prcomp.default()}} object is stored here once this
 preprocessing step has be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{prefix}{A character string that will be the prefix to the resulting
-new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -27,7 +27,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -25,13 +25,12 @@ step_pls(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables will be
-used to compute the dimensions. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the function assumes that the new dimension
-columns created by the original variables will be used as predictors in a
-model.}
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
@@ -57,8 +56,8 @@ original predictor data should be retained along with the new features.}
 \item{res}{A list of results are stored here once this preprocessing step
 has been trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{prefix}{A character string that will be the prefix to the
-resulting new variables. See notes below.}
+\item{prefix}{A character string for the prefix of the resulting new
+variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -29,7 +29,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_poly.Rd
+++ b/man/step_poly.Rd
@@ -24,7 +24,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_poly.Rd
+++ b/man/step_poly.Rd
@@ -20,14 +20,12 @@ step_poly(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_profile.Rd
+++ b/man/step_profile.Rd
@@ -22,9 +22,8 @@ step_profile(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be fixed to a single value. See \code{\link[=selections]{selections()}} for
-more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{profile}{A call to \code{\link[dplyr:vars]{dplyr::vars()}}) to specify which
 variable will be profiled (see \code{\link[=selections]{selections()}}). If a column is

--- a/man/step_range.Rd
+++ b/man/step_range.Rd
@@ -20,9 +20,8 @@ step_range(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be scaled. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -31,7 +31,7 @@ variables are used in the \emph{denominator}. See
 \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -30,10 +30,9 @@ When used with \code{denom_vars}, the dots indicate which
 variables are used in the \emph{denominator}. See
 \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For terms created by this step, what analysis role
-should they be assigned?. By default, the function assumes that
-the newly created ratios created by the original variables will
-be used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -26,7 +26,7 @@ will be searched for the regex pattern. The selector should resolve
 to a single variable. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -21,15 +21,13 @@ step_regex(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{A single selector functions to choose which variable
-will be searched for the pattern. The selector should resolve
-into a single variable. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{A single selector function to choose which variable
+will be searched for the regex pattern. The selector should resolve
+to a single variable. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For a variable created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new dummy variable column created by the original
-variable will be used as a predictor in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_relevel.Rd
+++ b/man/step_relevel.Rd
@@ -19,10 +19,8 @@ step_relevel(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be affected by the step. These variables
-should be character or factor types. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_relu.Rd
+++ b/man/step_relu.Rd
@@ -19,16 +19,18 @@ step_relu(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{Defaults to "predictor".}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{shift}{A numeric value dictating a translation to apply to the data.}
 
@@ -38,8 +40,8 @@ opposed to the right hinge.}
 \item{smooth}{A logical indicating if the softplus function, a smooth
 approximation to the rectified linear transformation, should be used.}
 
-\item{prefix}{A prefix for generated column names, default to "right_relu_"
-when right hinge transformation and "left_relu_" for reversed/left hinge
+\item{prefix}{A prefix for generated column names, defaults to "right_relu_"
+for right hinge transformation and "left_relu_" for reversed/left hinge
 transformations.}
 
 \item{columns}{A character string of variable names that will

--- a/man/step_relu.Rd
+++ b/man/step_relu.Rd
@@ -26,7 +26,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_rename.Rd
+++ b/man/step_rename.Rd
@@ -22,7 +22,7 @@ sequence of operations for this recipe.}
 \code{\link[dplyr:rename]{dplyr::rename()}} where the convention is \strong{\code{new_name = old_name}}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_rename.Rd
+++ b/man/step_rename.Rd
@@ -22,9 +22,8 @@ sequence of operations for this recipe.}
 \code{\link[dplyr:rename]{dplyr::rename()}} where the convention is \strong{\code{new_name = old_name}}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned? By default, the function assumes that the new dimension
-columns created by the original variables will be used as predictors in a
-model.}
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -27,7 +27,7 @@ either form (but containing only a single function, see \code{\link[dplyr:select
 \strong{Note that this argument must be named}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -19,18 +19,16 @@ step_rename_at(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{fn}{A function \code{fun}, a quosure style lambda `~ fun(.)`` or a list of
 either form (but containing only a single function, see \code{\link[dplyr:select_all]{dplyr::rename_at()}}).
 \strong{Note that this argument must be named}.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned? By default, the function assumes that the new dimension
-columns created by the original variables will be used as predictors in a
-model.}
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}

--- a/man/step_rm.Rd
+++ b/man/step_rm.Rd
@@ -18,9 +18,8 @@ step_rm(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be evaluated by the filtering bake. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_scale.Rd
+++ b/man/step_scale.Rd
@@ -20,9 +20,8 @@ step_scale(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_select.Rd
+++ b/man/step_select.Rd
@@ -17,9 +17,8 @@ step_select(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be selected when baking. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms selected by this step, what analysis
 role should they be assigned?}

--- a/man/step_shuffle.Rd
+++ b/man/step_shuffle.Rd
@@ -18,9 +18,8 @@ step_shuffle(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be permuted. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}
@@ -52,7 +51,7 @@ variables.
 }
 \details{
 When you \code{\link[=tidy]{tidy()}} this step, a tibble with column \code{terms} (the
-columns that will be affected) is returned.
+columns that will be permuted) is returned.
 }
 \examples{
 integers <- data.frame(A = 1:12, B = 13:24, C = 25:36)

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -19,12 +19,12 @@ step_spatialsign(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be used for the normalization. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned?. By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
 \item{na_rm}{A logical: should missing data be removed from the
 norm computation?}

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -23,7 +23,7 @@ sequence of operations for this recipe.}
 for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
-they be assigned?. By default, the new columns created by this step from
+they be assigned? By default, the new columns created by this step from
 the original variables will be used as \emph{predictors} in a model.}
 
 \item{na_rm}{A logical: should missing data be removed from the

--- a/man/step_sqrt.Rd
+++ b/man/step_sqrt.Rd
@@ -18,9 +18,8 @@ step_sqrt(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be transformed. See \code{\link[=selections]{selections()}} for
-more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_string2factor.Rd
+++ b/man/step_string2factor.Rd
@@ -19,9 +19,8 @@ step_string2factor(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables will be converted to factors. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_unknown.Rd
+++ b/man/step_unknown.Rd
@@ -19,10 +19,8 @@ step_unknown(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be affected by the step. These variables
-should be character or factor types. See \code{\link[=selections]{selections()}} for more
-details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -18,9 +18,8 @@ step_unorder(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_upsample.Rd
+++ b/man/step_upsample.Rd
@@ -25,11 +25,8 @@ step_upsample(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variable is used to sample the data. See \code{\link[=selections]{selections()}}
-for more details. The selection should result in \emph{single
-factor variable}. For the \code{tidy} method, these are not
-currently used.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{over_ratio}{A numeric value for the ratio of the
 majority-to-minority frequencies. The default value (1) means

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -22,9 +22,8 @@ step_window(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables are affected by the step. See \code{\link[=selections]{selections()}}
-for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis
 role should they be assigned? If \code{names} is left to be

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -18,9 +18,8 @@ step_zv(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which
-variables that will be evaluated by the filtering. See
-\code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{Not used by this step since no new variables are
 created.}


### PR DESCRIPTION
This PR mostly focuses on using the documentation in `step_center()` and `step_pca()` for the other steps via `@inheritParams`, rather than repeating ourself a lot. It is not exhaustive (we still have more work to do in this area) but it focuses mostly on the `...` and `role`, with a few other lesser used params thrown in.