### PR TITLE
use @family to streamline cross-references in documentation

### DIFF
--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details The Box-Cox transformation, which requires a strictly
 #'  positive variable, can be used to rescale a variable to be more
@@ -55,9 +56,6 @@
 #'
 #' tidy(bc_trans, number = 1)
 #' tidy(bc_estimates, number = 1)
-#'
-#' @seealso [step_YeoJohnson()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
 step_BoxCox <-
   function(recipe,
            ...,

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details The Yeo-Johnson transformation is very similar to the
 #'  Box-Cox but does not require the input variables to be strictly
@@ -61,8 +62,6 @@
 #'
 #' tidy(yj_transform, number = 1)
 #' tidy(yj_estimates, number = 1)
-#' @seealso [step_BoxCox()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
 step_YeoJohnson <-
   function(recipe, ..., role = NA, trained = FALSE,
            lambdas = NULL, limits = c(-5, 5), num_unique = 5,

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -21,6 +21,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {row operations}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -21,7 +21,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
-#' @family {row operations}
+#' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -21,6 +21,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' rec <- recipe( ~ ., data = iris) %>%

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -27,7 +27,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -27,6 +27,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept factors
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/bs.R
+++ b/R/bs.R
@@ -47,9 +47,6 @@
 #'
 #' expanded <- bake(with_splines, biomass_te)
 #' expanded
-#' @seealso [step_poly()] [recipe()] [step_ns()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_bs <-
   function(recipe,
            ...,

--- a/R/bs.R
+++ b/R/bs.R
@@ -19,6 +19,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion
+#' @family {individual transformation steps}
 #' @export
 #' @details `step_bs` can create new features from a single variable
 #'  that enable fitting routines to model this variable in a

--- a/R/center.R
+++ b/R/center.R
@@ -27,6 +27,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods
+#' @family {normalization steps}
 #' @export
 #' @details Centering data means that the average of a variable is
 #'  subtracted from the data. `step_center` estimates the
@@ -59,8 +60,6 @@
 #'
 #' tidy(center_trans, number = 1)
 #' tidy(center_obj, number = 1)
-#' @seealso [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 step_center <-
   function(recipe,
            ...,

--- a/R/class.R
+++ b/R/class.R
@@ -15,6 +15,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing normalization_methods
+#' @family {checks}
 #' @export
 #' @details
 #' This function can check the classes of the variables
@@ -71,8 +72,6 @@
 #'   prep(x_df) %>%
 #'   bake(x_df)
 #'
-#' @seealso [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 check_class <-
   function(recipe,
            ...,

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -22,6 +22,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept dimension_reduction
+#' @family {multivariate transformation steps}
 #' @export
 #' @details `step_classdist` will create a new column for every
 #'  unique value of the `class` variable.

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -6,6 +6,7 @@
 #'
 #' @inheritParams check_missing
 #' @template check-return
+#' @family {checks}
 #' @export
 #' @details This check will break the `bake` function if any of the specified
 #' columns is not present in the data. If the check passes, nothing is changed

--- a/R/corr.R
+++ b/R/corr.R
@@ -24,6 +24,7 @@
 #'  function.
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @export
 #'
 #' @details This step attempts to remove variables to keep the
@@ -63,9 +64,6 @@
 #'
 #' tidy(corr_filter, number = 1)
 #' tidy(filter_obj, number = 1)
-#' @seealso [step_nzv()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_corr <- function(recipe,
                       ...,
                       role = NA,

--- a/R/count.R
+++ b/R/count.R
@@ -30,7 +30,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept regular_expressions
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/count.R
+++ b/R/count.R
@@ -30,6 +30,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept regular_expressions
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/cut.R
+++ b/R/cut.R
@@ -11,6 +11,7 @@
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {discretization steps}
 #' @export
 #' @details Unlike the `base::cut()` function there is no need to specify the
 #'  min and the max values in the breaks. All values before the lowest break

--- a/R/date.R
+++ b/R/date.R
@@ -39,7 +39,6 @@
 #' @concept variable_encodings
 #' @concept dates
 #' @family {dummy variable and encoding steps}
-#' @seealso [step_rm()]
 #' @export
 #' @details Unlike some other steps, `step_date` does *not*
 #'  remove the original date variables by default. Set `keep_original_cols`

--- a/R/date.R
+++ b/R/date.R
@@ -38,6 +38,8 @@
 #' @concept model_specification
 #' @concept variable_encodings
 #' @concept dates
+#' @family {dummy variables and encodings steps}
+#' @seealso [step_rm()]
 #' @export
 #' @details Unlike some other steps, `step_date` does *not*
 #'  remove the original date variables by default. Set `keep_original_cols`
@@ -64,9 +66,6 @@
 #'
 #' tidy(date_rec, number = 1)
 #'
-#' @seealso [step_holiday()] [step_rm()]
-#'   [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 step_date <-
   function(recipe,
            ...,

--- a/R/date.R
+++ b/R/date.R
@@ -38,7 +38,7 @@
 #' @concept model_specification
 #' @concept variable_encodings
 #' @concept dates
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [step_rm()]
 #' @export
 #' @details Unlike some other steps, `step_date` does *not*

--- a/R/depth.R
+++ b/R/depth.R
@@ -27,6 +27,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept dimension_reduction
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Data depth metrics attempt to measure how close data a
 #'  data point is to the center of its distribution. There are a

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -232,6 +232,7 @@ print.discretize <-
 #' @details  When you [`tidy()`] this step, a tibble
 #'  with columns `terms` (the selectors or variables selected)
 #'  and `value` (the breaks) is returned.
+#' @family {discretization steps}
 #' @export
 
 step_discretize <- function(recipe,

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -27,6 +27,8 @@
 #' @concept model_specification
 #' @concept dummy_variables
 #' @concept variable_encodings
+#' @family {dummy variables and encodings steps}
+#' @seealso [dummy_names()]
 #' @export
 #' @details `step_dummy()` will create a set of binary dummy
 #'  variables from a factor variable. For example, if an unordered
@@ -80,10 +82,6 @@
 #'  selectors or original variables selected) and `columns` (the
 #'  list of corresponding binary columns) is returned.
 #'
-#' @seealso [step_factor2string()], [step_string2factor()],
-#'  [dummy_names()], [step_regex()], [step_count()],
-#'  [step_ordinalscore()], [step_unorder()], [step_other()]
-#'  [step_novel()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -27,7 +27,7 @@
 #' @concept model_specification
 #' @concept dummy_variables
 #' @concept variable_encodings
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export
 #' @details `step_dummy()` will create a set of binary dummy

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -12,6 +12,7 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details `prep` has an option `strings_as_factors` that
 #'  defaults to `TRUE`. If this step is used with the default
@@ -21,7 +22,6 @@
 #' When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  columns that will be affected) is returned.
 #'
-#' @seealso [step_string2factor()] [step_dummy()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -12,7 +12,7 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details `prep` has an option `strings_as_factors` that
 #'  defaults to `TRUE`. If this step is used with the default

--- a/R/filter.R
+++ b/R/filter.R
@@ -24,7 +24,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept row_filters
-#' @family {row operations}
+#' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/filter.R
+++ b/R/filter.R
@@ -24,6 +24,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept row_filters
+#' @family {row operations}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/filter.R
+++ b/R/filter.R
@@ -60,8 +60,6 @@
 #'   step_filter(Sepal.Length > 4.5, Species  %in% !!values)
 #'
 #' tidy(qq_rec, number = 1)
-#' @seealso [step_naomit()] [step_sample()] [step_slice()]
-
 step_filter <- function(
   recipe, ...,
   role = NA,

--- a/R/filter.R
+++ b/R/filter.R
@@ -24,6 +24,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept row_filters
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' rec <- recipe( ~ ., data = iris) %>%

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -27,6 +27,7 @@
 #'  is returned.
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {multivariate transformation steps}
 #' @references https://en.wikipedia.org/wiki/Haversine_formula
 #' @export
 #' @details `step_geodist` uses the Pythagorean theorem to calculate Euclidean

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -3,19 +3,13 @@
 #' `step_harmonic` creates a *specification* of a recipe step that
 #'   will add sin and cos terms for harmonic analysis.
 #'
+#' @inheritParams step_date
+#' @inheritParams step_pca
 #' @inheritParams step_center
 #'
-#' @param recipe A recipe object. The step will be added to the sequence of
-#'   operations for this recipe.
-#' @param ... One or more selector functions to choose which variables are
-#'  affected by the step. See [selections()] for more details.  This will
+#' @param ... One or more selector functions to choose variables
+#'  for this step. See [selections()] for more details. This will
 #'  typically be a single variable.
-#' @param role For model terms created by this step, what analysis
-#'  role should they be assigned?. By default, the function assumes
-#'  that the new columns created from the original variables will be
-#'  used as predictors in a model.
-#' @param trained A logical to indicate if the quantities for preprocessing
-#'   have been estimated. Again included for consistency.
 #' @param frequency A numeric vector with at least one value.
 #'   The value(s) must be greater than zero and finite.
 #' @param cycle_size A numeric vector with at least one value that indicates
@@ -27,10 +21,7 @@
 #'   using `as.numeric`. This parameter may be specified to increase control
 #'   over the signal phase.  If `starting_val` is not specified the default
 #'   is 0.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `TRUE`.
-#' @return An updated version of `recipe` with the
-#'   new step added to the sequence of existing steps (if any).
+#' @template step-return
 #' @export
 #' @details This step seeks to describe periodic components of observational
 #'  data using a combination of sin and cos waves. To do this, each wave of a
@@ -136,8 +127,6 @@
 #'  bind_rows(carbon_dioxide, preds) %>%
 #'    ggplot(aes(x = date_time, y = co2, color = type)) +
 #'    geom_line()
-#'
-#' @seealso [recipe()] [prep.recipe()] [bake.recipe()]
 step_harmonic <-
   function(recipe,
            ...,

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -22,6 +22,7 @@
 #'   over the signal phase.  If `starting_val` is not specified the default
 #'   is 0.
 #' @template step-return
+#' @family {individual transformation steps}
 #' @export
 #' @details This step seeks to describe periodic components of observational
 #'  data using a combination of sin and cos waves. To do this, each wave of a

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -21,6 +21,8 @@
 #' @concept model_specification
 #' @concept variable_encodings
 #' @concept dates
+#' @family {dummy variables and encodings steps}
+#' @seealso [step_rm()], [timeDate::listHolidays()]
 #' @export
 #' @details Unlike some other steps, `step_holiday` does *not*
 #'  remove the original date variables by default. Set `keep_original_cols`
@@ -39,9 +41,6 @@
 #' holiday_rec <- prep(holiday_rec, training = examples)
 #' holiday_values <- bake(holiday_rec, new_data = examples)
 #' holiday_values
-#' @seealso [step_date()] [step_rm()]
-#'   [recipe()] [prep.recipe()]
-#'   [bake.recipe()] [timeDate::listHolidays()]
 #' @import timeDate
 step_holiday <-
   function(

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -19,7 +19,7 @@
 #' @concept model_specification
 #' @concept variable_encodings
 #' @concept dates
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [step_rm()], [timeDate::listHolidays()]
 #' @export
 #' @details Unlike some other steps, `step_holiday` does *not*

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -20,7 +20,7 @@
 #' @concept variable_encodings
 #' @concept dates
 #' @family {dummy variable and encoding steps}
-#' @seealso [step_rm()], [timeDate::listHolidays()]
+#' @seealso [timeDate::listHolidays()]
 #' @export
 #' @details Unlike some other steps, `step_holiday` does *not*
 #'  remove the original date variables by default. Set `keep_original_cols`

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -13,8 +13,6 @@
 #' @param columns A character string of variables that will be
 #'  used as inputs. This field is a placeholder and will be
 #'  populated once [prep.recipe()] is used.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `TRUE`.
 #' @template step-return
 #' @keywords datagen
 #' @concept preprocessing

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -14,6 +14,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  columns that will be affected), `inverse`, and `func` is returned.
@@ -35,10 +36,6 @@
 #'
 #' tidy(cos_trans, number = 1)
 #' tidy(cos_obj, number = 1)
-#' @seealso [step_logit()] [step_invlogit()]
-#'   [step_log()]  [step_sqrt()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_hyperbolic <-
   function(recipe,
            ...,

--- a/R/ica.R
+++ b/R/ica.R
@@ -22,6 +22,7 @@
 #' @concept preprocessing
 #' @concept ica
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Independent component analysis (ICA) is a
 #'  transformation of a group of variables that produces a new set
@@ -82,9 +83,6 @@
 #'   tidy(ica_trans, number = 3)
 #'   tidy(ica_estimates, number = 3)
 #' }
-#' @seealso [step_pca()] [step_kpca()]
-#'   [step_isomap()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 step_ica <-
   function(recipe,
            ...,

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -25,7 +25,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details For each variable requiring imputation, a bagged tree is created
 #'  where the outcome is the variable of interest and the predictors are any

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -25,6 +25,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details For each variable requiring imputation, a bagged tree is created
 #'  where the outcome is the variable of interest and the predictors are any

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -17,6 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details The step uses the training set to impute any other data sets. The
 #'  only distance function available is Gower's distance which can be used for

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -17,7 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details The step uses the training set to impute any other data sets. The
 #'  only distance function available is Gower's distance which can be used for

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -15,7 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details For each variable requiring imputation, a linear model is fit
 #'  where the outcome is the variable of interest and the predictors are any

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details For each variable requiring imputation, a linear model is fit
 #'  where the outcome is the variable of interest and the predictors are any

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -13,6 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details `step_impute_lower` estimates the variable minimums
 #'  from the data used in the `training` argument of `prep.recipe`.

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -13,7 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details `step_impute_lower` estimates the variable minimums
 #'  from the data used in the `training` argument of `prep.recipe`.

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -15,7 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details `step_impute_mean` estimates the variable means from the data used
 #'  in the `training` argument of `prep.recipe`. `bake.recipe` then applies the

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details `step_impute_mean` estimates the variable means from the data used
 #'  in the `training` argument of `prep.recipe`. `bake.recipe` then applies the

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -12,7 +12,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details `step_impute_median` estimates the variable medians from the data
 #'  used in the `training` argument of `prep.recipe`. `bake.recipe` then applies

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -12,6 +12,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details `step_impute_median` estimates the variable medians from the data
 #'  used in the `training` argument of `prep.recipe`. `bake.recipe` then applies

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -13,7 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
+#' @family {imputation steps}
 #' @export
 #' @details `step_impute_mode` estimates the variable modes
 #'  from the data used in the `training` argument of

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -13,6 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
 #' @export
 #' @details `step_impute_mode` estimates the variable modes
 #'  from the data used in the `training` argument of

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -20,6 +20,8 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {imputations}
+#' @family {row operations}
 #' @export
 #' @details On the tails, the window is shifted towards the ends.
 #'  For example, for a 5-point window, the windows for the first

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -20,8 +20,8 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {imputations}
-#' @family {row operations}
+#' @family {imputation steps}
+#' @family {row operation steps}
 #' @export
 #' @details On the tails, the window is shifted towards the ends.
 #'  For example, for a 5-point window, the windows for the first

--- a/R/integer.R
+++ b/R/integer.R
@@ -18,6 +18,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_encodings
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details `step_integer` will determine the unique values of
 #'  each variable from the training set (excluding missing values),
@@ -36,10 +37,6 @@
 #'  variables selected) and `value` (a _list column_ with the
 #'  conversion key) is returned.
 #'
-#' @seealso [step_factor2string()], [step_string2factor()],
-#'  [step_regex()], [step_count()],
-#'  [step_ordinalscore()], [step_unorder()], [step_other()]
-#'  [step_novel()], [step_dummy()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/integer.R
+++ b/R/integer.R
@@ -18,7 +18,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_encodings
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details `step_integer` will determine the unique values of
 #'  each variable from the training set (excluding missing values),

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -36,7 +36,6 @@
 #' with_intercept <- bake(rec_obj, biomass_te)
 #' with_intercept
 #'
-#' @seealso [recipe()] [prep.recipe()] [bake.recipe()]
 step_intercept <- function(recipe, ..., role = "predictor",
                            trained = FALSE, name = "intercept",
                            value = 1,

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -12,6 +12,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms`
 #' (the columns that will be affected) is returned.
@@ -32,10 +33,6 @@
 #'
 #' tidy(inverse_trans, number = 1)
 #' tidy(inverse_obj, number = 1)
-#' @seealso [step_log()]
-#' [step_sqrt()]  [step_hyperbolic()] [recipe()]
-#' [prep.recipe()] [bake.recipe()]
-
 step_inverse <-
   function(recipe,
            ...,

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -11,6 +11,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details The inverse logit transformation takes values on the
 #'  real line and translates them to be between zero and one using
@@ -37,11 +38,6 @@
 #'
 #' transformed_te <- bake(ilogit_obj, biomass_te)
 #' plot(biomass_te$carbon, transformed_te$carbon)
-#' @seealso [step_logit()] [step_log()]
-#'   [step_sqrt()]  [step_hyperbolic()]
-#'   [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
-
 step_invlogit <-
   function(recipe, ...,  role = NA, trained = FALSE, columns = NULL,
            skip = FALSE, id = rand_id("invlogit")) {

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -20,6 +20,7 @@
 #' @concept preprocessing
 #' @concept isomap
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Isomap is a form of multidimensional scaling (MDS).
 #'  MDS methods try to find a reduced set of dimensions such that
@@ -86,10 +87,6 @@
 #'   tidy(im_estimates, number = 3)
 #' }
 #' }
-#' @seealso [step_pca()] [step_kpca()]
-#'   [step_ica()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
-
 step_isomap <-
   function(recipe,
            ...,

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -21,6 +21,7 @@
 #' @concept projection_methods
 #' @concept kernel_methods
 #' @concept basis_expansion
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an
 #'  extension of a PCA analysis that conducts the calculations in a
@@ -86,9 +87,6 @@
 #'   tidy(kpca_trans, number = 3)
 #'   tidy(kpca_estimates, number = 3)
 #' }
-#' @seealso [step_pca()] [step_ica()]
-#'   [step_isomap()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 #'
 step_kpca_poly <-
   function(recipe,

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -21,6 +21,7 @@
 #' @concept projection_methods
 #' @concept kernel_methods
 #' @concept basis_expansion
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an
 #'  extension of a PCA analysis that conducts the calculations in a
@@ -86,9 +87,6 @@
 #'   tidy(kpca_trans, number = 3)
 #'   tidy(kpca_estimates, number = 3)
 #' }
-#' @seealso [step_pca()] [step_ica()]
-#'   [step_isomap()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 #'
 step_kpca_rbf <-
   function(recipe,

--- a/R/lag.R
+++ b/R/lag.R
@@ -19,7 +19,7 @@
 #' @template step-return
 #' @details The step assumes that the data are already _in the proper sequential
 #'  order_ for lagging.
-#' @family {row operations}
+#' @family {row operation steps}
 #' @export
 #' @rdname step_lag
 #'

--- a/R/lag.R
+++ b/R/lag.R
@@ -36,8 +36,6 @@
 #'   step_lag(index, day, lag = 2:3) %>%
 #'   prep(df) %>%
 #'   bake(df)
-#'
-#' @seealso [recipe()] [prep.recipe()] [bake.recipe()] [step_naomit()]
 step_lag <-
   function(recipe,
            ...,

--- a/R/lag.R
+++ b/R/lag.R
@@ -19,6 +19,7 @@
 #' @template step-return
 #' @details The step assumes that the data are already _in the proper sequential
 #'  order_ for lagging.
+#' @family {row operations}
 #' @export
 #' @rdname step_lag
 #'

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -13,6 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @author Max Kuhn, Kirk Mettler, and Jed Wing
 #' @export
 #'
@@ -48,10 +49,6 @@
 #'
 #' tidy(lincomb_filter, number = 1)
 #' tidy(lincomb_filter_trained, number = 1)
-#' @seealso [step_nzv()][step_corr()]
-#'   [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
-
 step_lincomb <-
   function(recipe,
            ...,

--- a/R/log.R
+++ b/R/log.R
@@ -16,6 +16,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  columns that will be affected) and `base`.
@@ -52,11 +53,6 @@
 #'   prep(training = examples2) %>%
 #'   bake(examples2)
 #'
-#' @seealso [step_logit()] [step_invlogit()]
-#'   [step_hyperbolic()]  [step_sqrt()]
-#'   [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
-
 step_log <-
   function(recipe,
            ...,

--- a/R/logit.R
+++ b/R/logit.R
@@ -10,6 +10,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @export
 #' @details The logit transformation takes values between
 #'  zero and one and translates them to be on the real line using
@@ -34,10 +35,6 @@
 #'
 #' tidy(logit_trans, number = 1)
 #' tidy(logit_obj, number = 1)
-#' @seealso [step_invlogit()] [step_log()]
-#' [step_sqrt()]  [step_hyperbolic()] [recipe()]
-#' [prep.recipe()] [bake.recipe()]
-
 step_logit <-
   function(recipe,
            ...,

--- a/R/missing.r
+++ b/R/missing.r
@@ -21,6 +21,7 @@
 #'  Care should be taken when using `skip = TRUE` as it may affect
 #'  the computations for subsequent operations.
 #' @template check-return
+#' @family {checks}
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain `NA` values. If the check passes, nothing is changed

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -23,6 +23,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -23,6 +23,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' rec <-

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {multivariate transformation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' library(dplyr)

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -17,6 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -17,7 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept imputation
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -13,6 +13,7 @@
 #'  be populated (eventually) by the `terms` argument.
 #'
 #' @template step-return
+#' @family {row operations}
 #' @export
 #'
 #' @examples

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -23,7 +23,6 @@
 #'   prep(airquality, verbose = FALSE) %>%
 #'   bake(new_data = NULL)
 #'
-#' @seealso [step_filter()] [step_sample()] [step_slice()]
 step_naomit <- function(recipe, ..., role = NA, trained = FALSE,
                         columns = NULL, skip = FALSE,
                         id = rand_id("naomit")) {

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -13,7 +13,7 @@
 #'  be populated (eventually) by the `terms` argument.
 #'
 #' @template step-return
-#' @family {row operations}
+#' @family {row operation steps}
 #' @export
 #'
 #' @examples

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -9,6 +9,7 @@
 #' @param values A named list with the allowed values.
 #'  This is `NULL` until computed by prep.recipe().
 #' @template check-return
+#' @family {checks}
 #' @export
 #' @details This check will break the `bake` function if any of the checked
 #'  columns does contain values it did not contain when `prep` was called

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -28,6 +28,7 @@
 #' @concept preprocessing
 #' @concept nnmf
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Non-negative matrix factorization computes latent components that
 #'  have non-negative values and take into account that the original data
@@ -61,10 +62,6 @@
 #' # library(ggplot2)
 #' # bake(rec, new_data = NULL) %>%
 #' #  ggplot(aes(x = NNMF2, y = NNMF1, col = HHV)) + geom_point()
-#'
-#' @seealso [step_pca()], [step_ica()], [step_kpca()],
-#'   [step_isomap()], [recipe()], [prep.recipe()],
-#'   [bake.recipe()]
 step_nnmf <-
   function(recipe,
            ...,

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods
+#' @family {normalization steps}
 #' @export
 #' @details Centering data means that the average of a variable is subtracted
 #'  from the data. Scaling data means that the standard deviation of a variable

--- a/R/novel.R
+++ b/R/novel.R
@@ -13,7 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export
 #' @details The selected variables are adjusted to have a new

--- a/R/novel.R
+++ b/R/novel.R
@@ -13,6 +13,8 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
+#' @family {dummy variables and encodings steps}
+#' @seealso [dummy_names()]
 #' @export
 #' @details The selected variables are adjusted to have a new
 #'  level (given by `new_level`) that is placed in the last
@@ -37,9 +39,6 @@
 #'  columns that will be affected) and `value` (the factor
 #'  levels that is used for the new value) is returned.
 #'
-#' @seealso [step_factor2string()], [step_string2factor()],
-#'  [dummy_names()], [step_regex()], [step_count()],
-#'  [step_ordinalscore()], [step_unorder()], [step_other()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/ns.R
+++ b/R/ns.R
@@ -18,6 +18,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion
+#' @family {individual transformation steps}
 #' @export
 #' @details `step_ns` can create new features from a single variable
 #'  that enable fitting routines to model this variable in a
@@ -46,9 +47,6 @@
 #'
 #' expanded <- bake(with_splines, biomass_te)
 #' expanded
-#' @seealso [step_poly()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_ns <-
   function(recipe,
            ...,

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -21,8 +21,8 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
+#' @family {dummy variables and encodings steps}
 #' @export
-#' @seealso [step_factor2string()], [step_string2factor()], [step_dummy()]
 #' @examples
 #' library(dplyr)
 #' library(modeldata)

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -21,7 +21,7 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @examples
 #' library(dplyr)

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -16,6 +16,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @export
 #'
 #' @details This step diagnoses predictors that have one unique
@@ -68,9 +69,6 @@
 #'
 #' tidy(nzv_filter, number = 1)
 #' tidy(filter_obj, number = 1)
-#' @seealso [step_corr()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_nzv <-
   function(recipe,
            ...,

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -14,7 +14,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details Dummy variables from ordered factors with `C`
 #'  levels will create polynomial basis functions with `C-1`

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -14,6 +14,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details Dummy variables from ordered factors with `C`
 #'  levels will create polynomial basis functions with `C-1`

--- a/R/other.R
+++ b/R/other.R
@@ -19,7 +19,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export
 #' @details The overall proportion (or total counts) of the categories are

--- a/R/other.R
+++ b/R/other.R
@@ -19,6 +19,8 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
+#' @family {dummy variables and encodings steps}
+#' @seealso [dummy_names()]
 #' @export
 #' @details The overall proportion (or total counts) of the categories are
 #'  computed. The "other" category is used in place of any categorical levels
@@ -47,9 +49,6 @@
 #'  columns that will be affected) and `retained` (the factor
 #'  levels that were not pulled into "other") is returned.
 #'
-#' @seealso [step_factor2string()], [step_string2factor()],
-#'  [dummy_names()], [step_regex()], [step_count()],
-#'  [step_ordinalscore()], [step_unorder()], [step_novel()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/pca.R
+++ b/R/pca.R
@@ -30,6 +30,7 @@
 #' @concept preprocessing
 #' @concept pca
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details
 #' Principal component analysis (PCA) is a transformation of a
@@ -86,9 +87,6 @@
 #'
 #' tidy(pca_trans, number = 2)
 #' tidy(pca_estimates, number = 2)
-#' @seealso [step_ica()] [step_kpca()]
-#'   [step_isomap()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 step_pca <- function(recipe,
                      ...,
                      role = "predictor",

--- a/R/pls.R
+++ b/R/pls.R
@@ -25,6 +25,7 @@
 #' @concept preprocessing
 #' @concept pls
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details PLS is a supervised version of principal component
 #'  analysis that requires the outcome data to compute
@@ -107,9 +108,6 @@
 #'   recipe(class ~ ., data = cell_tr) %>%
 #'   step_pls(all_numeric_predictors(), outcome = "class", num_comp = 5, predictor_prop = 1/4)
 #'
-#' @seealso [step_pca()], [step_kpca()], [step_ica()], [recipe()],
-#'  [prep.recipe()], [bake.recipe()]
-
 step_pls <-
   function(recipe,
            ...,

--- a/R/poly.R
+++ b/R/poly.R
@@ -17,6 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept basis_expansion
+#' @family {individual transformation steps}
 #' @export
 #' @details `step_poly` can create new features from a single
 #'  variable that enable fitting routines to model this variable in
@@ -47,10 +48,6 @@
 #' expanded
 #'
 #' tidy(quadratic, number = 1)
-#' @seealso [step_ns()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
-
 step_poly <-
   function(recipe,
            ...,

--- a/R/range.R
+++ b/R/range.R
@@ -17,6 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods
+#' @family {normalization steps}
 #' @export
 #' @details When a new data point is outside of the ranges seen in
 #'  the training set, the new values are truncated at `min` or

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -17,6 +17,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods
+#' @family {checks}
 #' @export
 #' @details
 #'   The amount of slack that is allowed is determined by the
@@ -56,8 +57,6 @@
 #'     prep() %>%
 #'     bake(slack_new_data)
 #' }
-#' @seealso [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 check_range <-
   function(recipe,
            ...,

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -4,6 +4,7 @@
 #'  step that will create one or more ratios out of numeric
 #'  variables.
 #'
+#' @inheritParams step_date
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... One or more selector functions to choose which
@@ -22,8 +23,6 @@
 #' @param columns The column names used in the ratios. This
 #'  argument is not populated until [prep.recipe()] is
 #'  executed.
-#' @param keep_original_cols A logical to keep the original variables in the
-#'  output. Defaults to `TRUE`.
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `denom` is returned.

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -29,6 +29,7 @@
 #'  selectors or variables selected) and `denom` is returned.
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {multivariate transformation steps}
 #' @export
 #' @examples
 #' library(recipes)

--- a/R/regex.R
+++ b/R/regex.R
@@ -27,6 +27,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept regular_expressions
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/regex.R
+++ b/R/regex.R
@@ -27,7 +27,7 @@
 #' @concept preprocessing
 #' @concept dummy_variables
 #' @concept regular_expressions
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -16,6 +16,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details The selected variables are releveled to a level
 #' (given by `ref_level`). Placing the `ref_level` in the first

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -16,7 +16,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details The selected variables are releveled to a level
 #' (given by `ref_level`). Placing the `ref_level` in the first

--- a/R/relu.R
+++ b/R/relu.R
@@ -17,6 +17,7 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
+#' @family {individual transformation steps}
 #' @export
 #' @rdname step_relu
 #'
@@ -55,9 +56,6 @@
 #'   bake(biomass_te)
 #'
 #' transformed_te
-#'
-#' @seealso [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
 step_relu <-
   function(recipe,
            ...,

--- a/R/rename.R
+++ b/R/rename.R
@@ -21,6 +21,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' recipe( ~ ., data = iris) %>%

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -15,6 +15,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' library(dplyr)

--- a/R/rm.R
+++ b/R/rm.R
@@ -13,6 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/sample.R
+++ b/R/sample.R
@@ -19,6 +19,7 @@
 #' `replace`, and `id` is returned.
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #'

--- a/R/sample.R
+++ b/R/sample.R
@@ -46,8 +46,6 @@
 #'
 #' bake(smaller_cars, new_data = NULL) %>% nrow()
 #' bake(smaller_cars, new_data = mtcars %>% slice(21:32)) %>% nrow()
-#' @seealso [step_filter()] [step_naomit()] [step_slice()]
-
 step_sample <- function(
   recipe, ...,
   role = NA,

--- a/R/sample.R
+++ b/R/sample.R
@@ -19,7 +19,7 @@
 #' `replace`, and `id` is returned.
 #' @keywords datagen
 #' @concept preprocessing
-#' @family {row operations}
+#' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/sample.R
+++ b/R/sample.R
@@ -19,6 +19,7 @@
 #' `replace`, and `id` is returned.
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {row operations}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/scale.R
+++ b/R/scale.R
@@ -18,6 +18,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept normalization_methods
+#' @family {normalization steps}
 #' @export
 #' @details Scaling data means that the standard deviation of a
 #'  variable is divided out of the data. `step_scale` estimates

--- a/R/select.R
+++ b/R/select.R
@@ -20,6 +20,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' library(dplyr)

--- a/R/select.R
+++ b/R/select.R
@@ -20,6 +20,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -15,7 +15,7 @@
 #' @concept preprocessing
 #' @concept randomization
 #' @concept permutation
-#' @family {row operations}
+#' @family {row operation steps}
 #' @export
 #' @examples
 #' integers <- data.frame(A = 1:12, B = 13:24, C = 25:36)

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -15,6 +15,7 @@
 #' @concept preprocessing
 #' @concept randomization
 #' @concept permutation
+#' @family {row operations}
 #' @export
 #' @examples
 #' integers <- data.frame(A = 1:12, B = 13:24, C = 25:36)

--- a/R/slice.R
+++ b/R/slice.R
@@ -20,6 +20,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {row operations}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/slice.R
+++ b/R/slice.R
@@ -20,6 +20,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
+#' @family {dplyr steps}
 #' @export
 #' @examples
 #' rec <- recipe( ~ ., data = iris) %>%

--- a/R/slice.R
+++ b/R/slice.R
@@ -20,7 +20,7 @@
 #'
 #' @keywords datagen
 #' @concept preprocessing
-#' @family {row operations}
+#' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/slice.R
+++ b/R/slice.R
@@ -61,8 +61,6 @@
 #'   prep(training = iris)
 #'
 #' tidy(qq_rec, number = 1)
-#' @seealso [step_filter()] [step_naomit()] [step_sample()]
-
 step_slice <- function(
   recipe, ...,
   role = NA,

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -14,6 +14,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept projection_methods
+#' @family {multivariate transformation steps}
 #' @export
 #' @details The spatial sign transformation projects the variables
 #'  onto a unit sphere and is related to global contrast

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -10,6 +10,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept transformation_methods
+#' @family {individual transformation steps}
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #' columns that will be affected) is returned.
 #' @export
@@ -30,10 +31,6 @@
 #'
 #' tidy(sqrt_trans, number = 1)
 #' tidy(sqrt_obj, number = 1)
-#' @seealso [step_logit()] [step_invlogit()]
-#'   [step_log()]  [step_hyperbolic()] [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_sqrt <- function(recipe, ..., role = NA,
                       trained = FALSE, columns = NULL,
                       skip = FALSE,

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -14,6 +14,7 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details If `levels` is given, `step_string2factor` will
 #'  convert all variables affected by this step to have the same
@@ -27,8 +28,6 @@
 #'  When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `ordered` is returned.
 #'
-#' @seealso [step_factor2string()] [step_dummy()] [step_other()]
-#'  [step_novel()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -14,7 +14,7 @@
 #' @concept preprocessing
 #' @concept variable_encodings
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details If `levels` is given, `step_string2factor` will
 #'  convert all variables affected by this step to have the same

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -12,6 +12,8 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
+#' @family {dummy variables and encodings steps}
+#' @seealso [dummy_names()]
 #' @export
 #' @details The selected variables are adjusted to have a new
 #'  level (given by `new_level`) that is placed in the last
@@ -27,9 +29,6 @@
 #'  columns that will be affected) and `value` (the factor
 #'  levels that is used for the new value) is returned.
 #'
-#' @seealso [step_factor2string()], [step_string2factor()],
-#'  [dummy_names()], [step_regex()], [step_count()],
-#'  [step_ordinalscore()], [step_unorder()], [step_other()], [step_novel()]
 #' @examples
 #' library(modeldata)
 #' data(okc)

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -12,7 +12,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept factors
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export
 #' @details The selected variables are adjusted to have a new

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -10,7 +10,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data
-#' @family {dummy variables and encodings steps}
+#' @family {dummy variable and encoding steps}
 #' @export
 #' @details The factors level order is preserved during the transformation.
 #'

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -10,6 +10,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept ordinal_data
+#' @family {dummy variables and encodings steps}
 #' @export
 #' @details The factors level order is preserved during the transformation.
 #'
@@ -35,9 +36,6 @@
 #'
 #' tidy(factor_trans, number = 1)
 #' tidy(factor_obj, number = 1)
-#' @seealso [step_ordinalscore()] [recipe()]
-#' [prep.recipe()] [bake.recipe()]
-
 step_unorder <-
   function(recipe,
            ...,

--- a/R/zv.R
+++ b/R/zv.R
@@ -13,6 +13,7 @@
 #' @keywords datagen
 #' @concept preprocessing
 #' @concept variable_filters
+#' @family {variable filter steps}
 #' @export
 #'
 #' @examples
@@ -38,10 +39,6 @@
 #'
 #' tidy(zv_filter, number = 1)
 #' tidy(filter_obj, number = 1)
-#' @seealso [step_nzv()] [step_corr()]
-#'   [recipe()]
-#'   [prep.recipe()] [bake.recipe()]
-
 step_zv <-
   function(recipe,
            ...,

--- a/man/check_class.Rd
+++ b/man/check_class.Rd
@@ -113,8 +113,12 @@ recipe(x_df) \%>\%
 
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {checks}: 
+\code{\link{check_cols}()},
+\code{\link{check_missing}()},
+\code{\link{check_new_values}()},
+\code{\link{check_range}()}
 }
 \concept{preprocessing normalization_methods}
+\concept{{checks}}
 \keyword{datagen}

--- a/man/check_cols.Rd
+++ b/man/check_cols.Rd
@@ -66,3 +66,11 @@ biomass_rec <- recipe(HHV ~ ., data = biomass) \%>\%
 bake(biomass_rec, biomass[, c("carbon", "HHV")])
 }
 }
+\seealso{
+Other {checks}: 
+\code{\link{check_class}()},
+\code{\link{check_missing}()},
+\code{\link{check_new_values}()},
+\code{\link{check_range}()}
+}
+\concept{{checks}}

--- a/man/check_missing.Rd
+++ b/man/check_missing.Rd
@@ -88,3 +88,11 @@ bake(rp, train_data)
 bake(rp, test_data)
 }
 }
+\seealso{
+Other {checks}: 
+\code{\link{check_class}()},
+\code{\link{check_cols}()},
+\code{\link{check_new_values}()},
+\code{\link{check_range}()}
+}
+\concept{{checks}}

--- a/man/check_new_values.Rd
+++ b/man/check_new_values.Rd
@@ -97,3 +97,11 @@ recipe(credit_data \%>\% dplyr::filter(!is.na(Home))) \%>\%
   bake(credit_data)
 }
 }
+\seealso{
+Other {checks}: 
+\code{\link{check_class}()},
+\code{\link{check_cols}()},
+\code{\link{check_missing}()},
+\code{\link{check_range}()}
+}
+\concept{{checks}}

--- a/man/check_range.Rd
+++ b/man/check_range.Rd
@@ -100,9 +100,13 @@ selectors or variables selected) and \code{value} (the means) is returned.
 }
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {checks}: 
+\code{\link{check_class}()},
+\code{\link{check_cols}()},
+\code{\link{check_missing}()},
+\code{\link{check_new_values}()}
 }
 \concept{normalization_methods}
 \concept{preprocessing}
+\concept{{checks}}
 \keyword{datagen}

--- a/man/step_BoxCox.Rd
+++ b/man/step_BoxCox.Rd
@@ -94,16 +94,28 @@ plot(density(bc_data$Illiteracy), main = "after")
 
 tidy(bc_trans, number = 1)
 tidy(bc_estimates, number = 1)
-
 }
 \references{
 Sakia, R. M. (1992). The Box-Cox transformation technique:
 A review. \emph{The Statistician}, 169-178..
 }
 \seealso{
-\code{\link[=step_YeoJohnson]{step_YeoJohnson()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_YeoJohnson.Rd
+++ b/man/step_YeoJohnson.Rd
@@ -110,9 +110,22 @@ Yeo, I. K., and Johnson, R. A. (2000). A new family of power
 transformations to improve normality or symmetry. \emph{Biometrika}.
 }
 \seealso{
-\code{\link[=step_BoxCox]{step_BoxCox()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_arrange.Rd
+++ b/man/step_arrange.Rd
@@ -98,5 +98,17 @@ qq_rec <-
 
 tidy(qq_rec, number = 1)
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_arrange.Rd
+++ b/man/step_arrange.Rd
@@ -99,6 +99,15 @@ qq_rec <-
 tidy(qq_rec, number = 1)
 }
 \seealso{
+Other {row operation steps}: 
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
+
 Other {dplyr steps}: 
 \code{\link{step_filter}()},
 \code{\link{step_mutate_at}()},
@@ -111,4 +120,5 @@ Other {dplyr steps}:
 }
 \concept{preprocessing}
 \concept{{dplyr steps}}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -88,7 +88,7 @@ table(results$rocks, results$more_rocks)
 tidy(rec, number = 3)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_count}()},
 \code{\link{step_date}()},
 \code{\link{step_dummy}()},
@@ -109,5 +109,5 @@ Other {dummy variables and encodings steps}:
 \concept{dummy_variables}
 \concept{factors}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -87,7 +87,27 @@ table(results$rocks, results$more_rocks)
 
 tidy(rec, number = 3)
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{dummy_variables}
 \concept{factors}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -92,9 +92,22 @@ expanded <- bake(with_splines, biomass_te)
 expanded
 }
 \seealso{
-\code{\link[=step_poly]{step_poly()}} \code{\link[=recipe]{recipe()}} \code{\link[=step_ns]{step_ns()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{basis_expansion}
 \concept{preprocessing}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_center.Rd
+++ b/man/step_center.Rd
@@ -85,9 +85,12 @@ tidy(center_trans, number = 1)
 tidy(center_obj, number = 1)
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {normalization steps}: 
+\code{\link{step_normalize}()},
+\code{\link{step_range}()},
+\code{\link{step_scale}()}
 }
 \concept{normalization_methods}
 \concept{preprocessing}
+\concept{{normalization steps}}
 \keyword{datagen}

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -115,6 +115,22 @@ dists_to_species[, c("Species", dist_cols)]
 tidy(rec, number = 1)
 tidy(rec_dists, number = 1)
 }
+\seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
+}
 \concept{dimension_reduction}
 \concept{preprocessing}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_corr.Rd
+++ b/man/step_corr.Rd
@@ -103,8 +103,12 @@ tidy(corr_filter, number = 1)
 tidy(filter_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_nzv]{step_nzv()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {variable filter steps}: 
+\code{\link{step_lincomb}()},
+\code{\link{step_nzv}()},
+\code{\link{step_rm}()},
+\code{\link{step_select}()},
+\code{\link{step_zv}()}
 }
 \author{
 Original R code for filtering algorithm by Dong Li,
@@ -114,4 +118,5 @@ function.
 }
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{variable filter steps}}
 \keyword{datagen}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -92,7 +92,7 @@ tidy(rec, number = 1)
 tidy(rec2, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_date}()},
 \code{\link{step_dummy}()},
@@ -113,5 +113,5 @@ Other {dummy variables and encodings steps}:
 \concept{dummy_variables}
 \concept{preprocessing}
 \concept{regular_expressions}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -91,7 +91,27 @@ count_values
 tidy(rec, number = 1)
 tidy(rec2, number = 1)
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{dummy_variables}
 \concept{preprocessing}
 \concept{regular_expressions}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_cut.Rd
+++ b/man/step_cut.Rd
@@ -99,5 +99,10 @@ rec \%>\%
   prep() \%>\%
   bake(new_df)
 }
+\seealso{
+Other {discretization steps}: 
+\code{\link{step_discretize}()}
+}
 \concept{preprocessing}
+\concept{{discretization steps}}
 \keyword{datagen}

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -108,8 +108,6 @@ tidy(date_rec, number = 1)
 
 }
 \seealso{
-\code{\link[=step_rm]{step_rm()}}
-
 Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -108,12 +108,29 @@ tidy(date_rec, number = 1)
 
 }
 \seealso{
-\code{\link[=step_holiday]{step_holiday()}} \code{\link[=step_rm]{step_rm()}}
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+\code{\link[=step_rm]{step_rm()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{dates}
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -110,7 +110,7 @@ tidy(date_rec, number = 1)
 \seealso{
 \code{\link[=step_rm]{step_rm()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_dummy}()},
@@ -132,5 +132,5 @@ Other {dummy variables and encodings steps}:
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -124,6 +124,22 @@ dists_to_species
 tidy(rec, number = 1)
 tidy(rec_dists, number = 1)
 }
+\seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
+}
 \concept{dimension_reduction}
 \concept{preprocessing}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_discretize.Rd
+++ b/man/step_discretize.Rd
@@ -72,3 +72,8 @@ When you \code{\link[=tidy]{tidy()}} this step, a tibble
 with columns \code{terms} (the selectors or variables selected)
 and \code{value} (the breaks) is returned.
 }
+\seealso{
+Other {discretization steps}: 
+\code{\link{step_cut}()}
+}
+\concept{{discretization steps}}

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -160,13 +160,29 @@ tidy(dummies, number = 1)
 tidy(dummies_one_hot, number = 1)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},
-\code{\link[=dummy_names]{dummy_names()}}, \code{\link[=step_regex]{step_regex()}}, \code{\link[=step_count]{step_count()}},
-\code{\link[=step_ordinalscore]{step_ordinalscore()}}, \code{\link[=step_unorder]{step_unorder()}}, \code{\link[=step_other]{step_other()}}
-\code{\link[=step_novel]{step_novel()}}
+\code{\link[=dummy_names]{dummy_names()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{dummy_variables}
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -162,7 +162,7 @@ tidy(dummies_one_hot, number = 1)
 \seealso{
 \code{\link[=dummy_names]{dummy_names()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -184,5 +184,5 @@ Other {dummy variables and encodings steps}:
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -86,7 +86,7 @@ class(string_test$diet)
 tidy(rec, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -107,5 +107,5 @@ Other {dummy variables and encodings steps}:
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -86,9 +86,26 @@ class(string_test$diet)
 tidy(rec, number = 1)
 }
 \seealso{
-\code{\link[=step_string2factor]{step_string2factor()}} \code{\link[=step_dummy]{step_dummy()}}
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_filter.Rd
+++ b/man/step_filter.Rd
@@ -106,7 +106,18 @@ tidy(qq_rec, number = 1)
 }
 \seealso{
 \code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_sample]{step_sample()}} \code{\link[=step_slice]{step_slice()}}
+
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
 }
 \concept{preprocessing}
 \concept{row_filters}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_filter.Rd
+++ b/man/step_filter.Rd
@@ -105,7 +105,14 @@ qq_rec <-
 tidy(qq_rec, number = 1)
 }
 \seealso{
-\code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_sample]{step_sample()}} \code{\link[=step_slice]{step_slice()}}
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
 
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
@@ -120,4 +127,5 @@ Other {dplyr steps}:
 \concept{preprocessing}
 \concept{row_filters}
 \concept{{dplyr steps}}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -100,5 +100,21 @@ tidy(near_station, number = 1)
 \references{
 https://en.wikipedia.org/wiki/Haversine_formula
 }
+\seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
+}
 \concept{preprocessing}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_harmonic.Rd
+++ b/man/step_harmonic.Rd
@@ -18,20 +18,19 @@ step_harmonic(
 )
 }
 \arguments{
-\item{recipe}{A recipe object. The step will be added to the sequence of
-operations for this recipe.}
+\item{recipe}{A recipe object. The step will be added to the
+sequence of operations for this recipe.}
 
-\item{...}{One or more selector functions to choose which variables are
-affected by the step. See \code{\link[=selections]{selections()}} for more details.  This will
+\item{...}{One or more selector functions to choose variables
+for this step. See \code{\link[=selections]{selections()}} for more details. This will
 typically be a single variable.}
 
-\item{role}{For model terms created by this step, what analysis
-role should they be assigned?. By default, the function assumes
-that the new columns created from the original variables will be
-used as predictors in a model.}
+\item{role}{For model terms created by this step, what analysis role should
+they be assigned? By default, the new columns created by this step from
+the original variables will be used as \emph{predictors} in a model.}
 
-\item{trained}{A logical to indicate if the quantities for preprocessing
-have been estimated. Again included for consistency.}
+\item{trained}{A logical to indicate if the quantities for
+preprocessing have been estimated.}
 
 \item{frequency}{A numeric vector with at least one value.
 The value(s) must be greater than zero and finite.}
@@ -60,8 +59,8 @@ the computations for subsequent operations.}
 \item{id}{A character string that is unique to this step to identify it.}
 }
 \value{
-An updated version of \code{recipe} with the
-new step added to the sequence of existing steps (if any).
+An updated version of \code{recipe} with the new step added to the
+sequence of any existing operations.
 }
 \description{
 \code{step_harmonic} creates a \emph{specification} of a recipe step that
@@ -163,7 +162,6 @@ dat <-
  bind_rows(carbon_dioxide, preds) \%>\%
    ggplot(aes(x = date_time, y = co2, color = type)) +
    geom_line()
-
 }
 \references{
 Doran, H. E., & Quilkey, J. J. (1972).
@@ -175,5 +173,19 @@ The harmonic analysis of tidal model time series.
 Advances in water resources, 12(3), 109-120.
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
+\concept{{individual transformation steps}}

--- a/man/step_harmonic.Rd
+++ b/man/step_harmonic.Rd
@@ -55,7 +55,7 @@ recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operatio
 when \code{\link[=prep.recipe]{prep.recipe()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
-the computations for subsequent operations}
+the computations for subsequent operations.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -80,7 +80,7 @@ holiday_values <- bake(holiday_rec, new_data = examples)
 holiday_values
 }
 \seealso{
-\code{\link[=step_rm]{step_rm()}}, \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
+\code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
 
 Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -80,12 +80,29 @@ holiday_values <- bake(holiday_rec, new_data = examples)
 holiday_values
 }
 \seealso{
-\code{\link[=step_date]{step_date()}} \code{\link[=step_rm]{step_rm()}}
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}} \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
+\code{\link[=step_rm]{step_rm()}}, \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{dates}
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -82,7 +82,7 @@ holiday_values
 \seealso{
 \code{\link[=step_rm]{step_rm()}}, \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -104,5 +104,5 @@ Other {dummy variables and encodings steps}:
 \concept{model_specification}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_hyperbolic.Rd
+++ b/man/step_hyperbolic.Rd
@@ -79,10 +79,22 @@ tidy(cos_trans, number = 1)
 tidy(cos_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_logit]{step_logit()}} \code{\link[=step_invlogit]{step_invlogit()}}
-\code{\link[=step_log]{step_log()}}  \code{\link[=step_sqrt]{step_sqrt()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -133,11 +133,22 @@ component analysis: algorithms and applications. \emph{Neural
 Networks}, 13(4-5), 411-430.
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}} \code{\link[=step_kpca]{step_kpca()}}
-\code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{ica}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_impute_bag.Rd
+++ b/man/step_impute_bag.Rd
@@ -159,6 +159,17 @@ tidy(imp_models, number = 1)
 Kuhn, M. and Johnson, K. (2013). \emph{Applied Predictive Modeling}.
 Springer Verlag.
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_knn.Rd
+++ b/man/step_impute_knn.Rd
@@ -146,6 +146,17 @@ tidy(ratio_recipe2, number = 1)
 Gower, C. (1971) "A general coefficient of similarity and some
 of its properties," Biometrics, 857-871.
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_linear.Rd
+++ b/man/step_impute_linear.Rd
@@ -106,6 +106,17 @@ Kuhn, M. and Johnson, K. (2013).
 \emph{Feature Engineering and Selection}
 \url{https://bookdown.org/max/FES/handling-missing-data.html}
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_lower.Rd
+++ b/man/step_impute_lower.Rd
@@ -105,6 +105,17 @@ transformed_te <- bake(impute_rec, biomass_te)
 plot(transformed_te$carbon, biomass_te$carbon,
      ylab = "pre-imputation", xlab = "imputed")
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_mean.Rd
+++ b/man/step_impute_mean.Rd
@@ -107,6 +107,17 @@ imputed_te[missing_examples, names(credit_te)]
 tidy(impute_rec, number = 1)
 tidy(imp_models, number = 1)
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_median.Rd
+++ b/man/step_impute_median.Rd
@@ -101,6 +101,17 @@ imputed_te[missing_examples, names(credit_te)]
 tidy(impute_rec, number = 1)
 tidy(imp_models, number = 1)
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_mode}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_mode.Rd
+++ b/man/step_impute_mode.Rd
@@ -106,6 +106,17 @@ table(credit_te$Home, imputed_te$Home, useNA = "always")
 tidy(impute_rec, number = 1)
 tidy(imp_models, number = 1)
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_roll}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
 \keyword{datagen}

--- a/man/step_impute_roll.Rd
+++ b/man/step_impute_roll.Rd
@@ -117,6 +117,27 @@ seven_pt <- recipe(~ . , data = example_data) \%>\%
 # The training set:
 bake(seven_pt, new_data = NULL)
 }
+\seealso{
+Other {imputation steps}: 
+\code{\link{step_impute_bag}()},
+\code{\link{step_impute_knn}()},
+\code{\link{step_impute_linear}()},
+\code{\link{step_impute_lower}()},
+\code{\link{step_impute_mean}()},
+\code{\link{step_impute_median}()},
+\code{\link{step_impute_mode}()}
+
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{imputation steps}}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -80,6 +80,26 @@ imp_models <- prep(impute_rec, training = credit_tr)
 
 imputed_te <- bake(imp_models, new_data = credit_te, everything())
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{imputation}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -81,7 +81,7 @@ imp_models <- prep(impute_rec, training = credit_tr)
 imputed_te <- bake(imp_models, new_data = credit_te, everything())
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -101,5 +101,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{imputation}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -99,7 +99,7 @@ bake(rec, okc_te, all_predictors())
 tidy(rec, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -119,5 +119,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -99,11 +99,25 @@ bake(rec, okc_te, all_predictors())
 tidy(rec, number = 1)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},
-\code{\link[=step_regex]{step_regex()}}, \code{\link[=step_count]{step_count()}},
-\code{\link[=step_ordinalscore]{step_ordinalscore()}}, \code{\link[=step_unorder]{step_unorder()}}, \code{\link[=step_other]{step_other()}}
-\code{\link[=step_novel]{step_novel()}}, \code{\link[=step_dummy]{step_dummy()}}
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -73,6 +73,3 @@ with_intercept <- bake(rec_obj, biomass_te)
 with_intercept
 
 }
-\seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
-}

--- a/man/step_inverse.Rd
+++ b/man/step_inverse.Rd
@@ -74,10 +74,22 @@ tidy(inverse_trans, number = 1)
 tidy(inverse_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_log]{step_log()}}
-\code{\link[=step_sqrt]{step_sqrt()}}  \code{\link[=step_hyperbolic]{step_hyperbolic()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_invlogit.Rd
+++ b/man/step_invlogit.Rd
@@ -77,11 +77,22 @@ transformed_te <- bake(ilogit_obj, biomass_te)
 plot(biomass_te$carbon, transformed_te$carbon)
 }
 \seealso{
-\code{\link[=step_logit]{step_logit()}} \code{\link[=step_log]{step_log()}}
-\code{\link[=step_sqrt]{step_sqrt()}}  \code{\link[=step_hyperbolic]{step_hyperbolic()}}
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -138,11 +138,22 @@ versus local methods in nonlinear dimensionality reduction.
 https://github.com/gdkrmr
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}} \code{\link[=step_kpca]{step_kpca()}}
-\code{\link[=step_ica]{step_ica()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{isomap}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -126,6 +126,7 @@ if (require(dimRed) & require(kernlab)) {
   tidy(kpca_trans, number = 3)
   tidy(kpca_estimates, number = 3)
 }
+
 }
 \references{
 Scholkopf, B., Smola, A., and Muller, K. (1997).
@@ -137,13 +138,24 @@ kernlab - An S4 package for kernel methods in R. \emph{Journal
 of Statistical Software}, 11(1), 1-20.
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}} \code{\link[=step_ica]{step_ica()}}
-\code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{basis_expansion}
 \concept{kernel_methods}
 \concept{pca}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -124,6 +124,7 @@ if (require(dimRed) & require(kernlab)) {
   tidy(kpca_trans, number = 3)
   tidy(kpca_estimates, number = 3)
 }
+
 }
 \references{
 Scholkopf, B., Smola, A., and Muller, K. (1997).
@@ -135,13 +136,24 @@ kernlab - An S4 package for kernel methods in R. \emph{Journal
 of Statistical Software}, 11(1), 1-20.
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}} \code{\link[=step_ica]{step_ica()}}
-\code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{basis_expansion}
 \concept{kernel_methods}
 \concept{pca}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -80,8 +80,15 @@ recipe(~ ., data = df) \%>\%
   step_lag(index, day, lag = 2:3) \%>\%
   prep(df) \%>\%
   bake(df)
-
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}} \code{\link[=step_naomit]{step_naomit()}}
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
 }
+\concept{{row operation steps}}

--- a/man/step_lincomb.Rd
+++ b/man/step_lincomb.Rd
@@ -87,13 +87,17 @@ tidy(lincomb_filter, number = 1)
 tidy(lincomb_filter_trained, number = 1)
 }
 \seealso{
-\link[=step_corr]{step_nzv()}
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {variable filter steps}: 
+\code{\link{step_corr}()},
+\code{\link{step_nzv}()},
+\code{\link{step_rm}()},
+\code{\link{step_select}()},
+\code{\link{step_zv}()}
 }
 \author{
 Max Kuhn, Kirk Mettler, and Jed Wing
 }
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{variable filter steps}}
 \keyword{datagen}

--- a/man/step_log.Rd
+++ b/man/step_log.Rd
@@ -98,11 +98,22 @@ recipe(~ V1 + V2, data = examples2) \%>\%
 
 }
 \seealso{
-\code{\link[=step_logit]{step_logit()}} \code{\link[=step_invlogit]{step_invlogit()}}
-\code{\link[=step_hyperbolic]{step_hyperbolic()}}  \code{\link[=step_sqrt]{step_sqrt()}}
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_logit.Rd
+++ b/man/step_logit.Rd
@@ -74,10 +74,22 @@ tidy(logit_trans, number = 1)
 tidy(logit_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_invlogit]{step_invlogit()}} \code{\link[=step_log]{step_log()}}
-\code{\link[=step_sqrt]{step_sqrt()}}  \code{\link[=step_hyperbolic]{step_hyperbolic()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -111,6 +111,21 @@ bake(qq_rec, new_data = NULL, contains("appro")) \%>\% slice(1:4)
 tidy(qq_rec, number = 1)
 }
 \seealso{
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
+
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
 \code{\link{step_filter}()},
@@ -124,4 +139,5 @@ Other {dplyr steps}:
 \concept{preprocessing}
 \concept{transformation_methods}
 \concept{{dplyr steps}}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -110,6 +110,18 @@ bake(qq_rec, new_data = NULL, contains("appro")) \%>\% slice(1:4)
 # The difference:
 tidy(qq_rec, number = 1)
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -71,6 +71,18 @@ recipe(~ ., data = iris) \%>\%
   bake(new_data = NULL) \%>\%
   slice(1:10)
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -72,6 +72,20 @@ recipe(~ ., data = iris) \%>\%
   slice(1:10)
 }
 \seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
+
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
 \code{\link{step_filter}()},
@@ -85,4 +99,5 @@ Other {dplyr steps}:
 \concept{preprocessing}
 \concept{transformation_methods}
 \concept{{dplyr steps}}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_naomit.Rd
+++ b/man/step_naomit.Rd
@@ -67,5 +67,13 @@ recipe(Ozone ~ ., data = airquality) \%>\%
 
 }
 \seealso{
-\code{\link[=step_filter]{step_filter()}} \code{\link[=step_sample]{step_sample()}} \code{\link[=step_slice]{step_slice()}}
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
 }
+\concept{{row operation steps}}

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -111,14 +111,24 @@ data(biomass)
 # library(ggplot2)
 # bake(rec, new_data = NULL) \%>\%
 #  ggplot(aes(x = NNMF2, y = NNMF1, col = HHV)) + geom_point()
-
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}}, \code{\link[=step_ica]{step_ica()}}, \code{\link[=step_kpca]{step_kpca()}},
-\code{\link[=step_isomap]{step_isomap()}}, \code{\link[=recipe]{recipe()}}, \code{\link[=prep.recipe]{prep.recipe()}},
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{nnmf}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_normalize.Rd
+++ b/man/step_normalize.Rd
@@ -100,6 +100,13 @@ keep_orig_te <- bake(keep_orig_obj, biomass_te)
 keep_orig_te
 
 }
+\seealso{
+Other {normalization steps}: 
+\code{\link{step_center}()},
+\code{\link{step_range}()},
+\code{\link{step_scale}()}
+}
 \concept{normalization_methods}
 \concept{preprocessing}
+\concept{{normalization steps}}
 \keyword{datagen}

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -97,10 +97,27 @@ tibble(old = okc_te$diet, new = processed$diet)
 tidy(rec, number = 1)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},
-\code{\link[=dummy_names]{dummy_names()}}, \code{\link[=step_regex]{step_regex()}}, \code{\link[=step_count]{step_count()}},
-\code{\link[=step_ordinalscore]{step_ordinalscore()}}, \code{\link[=step_unorder]{step_unorder()}}, \code{\link[=step_other]{step_other()}}
+\code{\link[=dummy_names]{dummy_names()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -99,7 +99,7 @@ tidy(rec, number = 1)
 \seealso{
 \code{\link[=dummy_names]{dummy_names()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -119,5 +119,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{factors}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -89,9 +89,22 @@ expanded <- bake(with_splines, biomass_te)
 expanded
 }
 \seealso{
-\code{\link[=step_poly]{step_poly()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{basis_expansion}
 \concept{preprocessing}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -117,9 +117,26 @@ ceo <- attrition \%>\% slice(1) \%>\% mutate(MonthlyIncome = 10^10)
 bake(rec, ceo)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}}, \code{\link[=step_dummy]{step_dummy()}}
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -117,7 +117,7 @@ ceo <- attrition \%>\% slice(1) \%>\% mutate(MonthlyIncome = 10^10)
 bake(rec, ceo)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -138,5 +138,5 @@ Other {dummy variables and encodings steps}:
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_nzv.Rd
+++ b/man/step_nzv.Rd
@@ -111,9 +111,14 @@ tidy(nzv_filter, number = 1)
 tidy(filter_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_corr]{step_corr()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {variable filter steps}: 
+\code{\link{step_corr}()},
+\code{\link{step_lincomb}()},
+\code{\link{step_rm}()},
+\code{\link{step_select}()},
+\code{\link{step_zv}()}
 }
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{variable filter steps}}
 \keyword{datagen}

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -102,7 +102,7 @@ bake(nonlin_scores, new_data = NULL, everything())
 tidy(nonlin_scores, number = 2)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -122,5 +122,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{ordinal_data}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -101,6 +101,26 @@ bake(nonlin_scores, new_data = NULL, everything())
 
 tidy(nonlin_scores, number = 2)
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{ordinal_data}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -128,10 +128,27 @@ tidy(rec, number = 1)
 # okc_tr \%>\% count(location, sort = TRUE) \%>\% top_n(3)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},
-\code{\link[=dummy_names]{dummy_names()}}, \code{\link[=step_regex]{step_regex()}}, \code{\link[=step_count]{step_count()}},
-\code{\link[=step_ordinalscore]{step_ordinalscore()}}, \code{\link[=step_unorder]{step_unorder()}}, \code{\link[=step_novel]{step_novel()}}
+\code{\link[=dummy_names]{dummy_names()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -130,7 +130,7 @@ tidy(rec, number = 1)
 \seealso{
 \code{\link[=dummy_names]{dummy_names()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -150,5 +150,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{factors}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -131,11 +131,22 @@ Jolliffe, I. T. (2010). \emph{Principal Component
 Analysis}. Springer.
 }
 \seealso{
-\code{\link[=step_ica]{step_ica()}} \code{\link[=step_kpca]{step_kpca()}}
-\code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{pca}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -163,10 +163,22 @@ Rohart F, Gautier B, Singh A, Lê Cao K-A (2017) \emph{mixOmics: An R package fo
 13(11): e1005752. \doi{10.1371/journal.pcbi.1005752}
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}}, \code{\link[=step_kpca]{step_kpca()}}, \code{\link[=step_ica]{step_ica()}}, \code{\link[=recipe]{recipe()}},
-\code{\link[=prep.recipe]{prep.recipe()}}, \code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
 \concept{pls}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_poly.Rd
+++ b/man/step_poly.Rd
@@ -90,9 +90,22 @@ expanded
 tidy(quadratic, number = 1)
 }
 \seealso{
-\code{\link[=step_ns]{step_ns()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_relu}()},
+\code{\link{step_sqrt}()}
 }
 \concept{basis_expansion}
 \concept{preprocessing}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_range.Rd
+++ b/man/step_range.Rd
@@ -89,6 +89,13 @@ transformed_te
 tidy(ranged_trans, number = 1)
 tidy(ranged_obj, number = 1)
 }
+\seealso{
+Other {normalization steps}: 
+\code{\link{step_center}()},
+\code{\link{step_normalize}()},
+\code{\link{step_scale}()}
+}
 \concept{normalization_methods}
 \concept{preprocessing}
+\concept{{normalization steps}}
 \keyword{datagen}

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -100,5 +100,21 @@ ratio_recipe <- prep(ratio_recipe, training = biomass_tr)
 ratio_data <- bake(ratio_recipe, biomass_te)
 ratio_data
 }
+\seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_spatialsign}()}
+}
 \concept{preprocessing}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -85,7 +85,27 @@ with_dummies
 tidy(rec, number = 1)
 tidy(rec2, number = 1)
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{dummy_variables}
 \concept{preprocessing}
 \concept{regular_expressions}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -86,7 +86,7 @@ tidy(rec, number = 1)
 tidy(rec2, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -107,5 +107,5 @@ Other {dummy variables and encodings steps}:
 \concept{dummy_variables}
 \concept{preprocessing}
 \concept{regular_expressions}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_relevel.Rd
+++ b/man/step_relevel.Rd
@@ -75,7 +75,7 @@ data <- bake(rec, okc)
 levels(data$diet)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -95,5 +95,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{factors}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_relevel.Rd
+++ b/man/step_relevel.Rd
@@ -74,6 +74,26 @@ rec <- recipe(~ diet + location, data = okc) \%>\%
 data <- bake(rec, okc)
 levels(data$diet)
 }
+\seealso{
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
+}
 \concept{factors}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_relu.Rd
+++ b/man/step_relu.Rd
@@ -103,9 +103,21 @@ transformed_te <- rec \%>\%
   bake(biomass_te)
 
 transformed_te
-
 }
 \seealso{
-\code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_sqrt}()}
 }
+\concept{{individual transformation steps}}

--- a/man/step_rename.Rd
+++ b/man/step_rename.Rd
@@ -76,6 +76,18 @@ car_rec \%>\%
 car_rec \%>\%
   tidy(number = 1)
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -64,6 +64,18 @@ recipe(~ ., data = iris) \%>\%
   bake(new_data = NULL) \%>\%
   slice(1:10)
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_rm.Rd
+++ b/man/step_rm.Rd
@@ -74,6 +74,15 @@ filtered_te
 
 tidy(smaller_set, number = 1)
 }
+\seealso{
+Other {variable filter steps}: 
+\code{\link{step_corr}()},
+\code{\link{step_lincomb}()},
+\code{\link{step_nzv}()},
+\code{\link{step_select}()},
+\code{\link{step_zv}()}
+}
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{variable filter steps}}
 \keyword{datagen}

--- a/man/step_sample.Rd
+++ b/man/step_sample.Rd
@@ -96,6 +96,17 @@ bake(smaller_cars, new_data = mtcars \%>\% slice(21:32)) \%>\% nrow()
 }
 \seealso{
 \code{\link[=step_filter]{step_filter()}} \code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_slice]{step_slice()}}
+
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_select}()},
+\code{\link{step_slice}()}
 }
 \concept{preprocessing}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_sample.Rd
+++ b/man/step_sample.Rd
@@ -95,7 +95,14 @@ bake(smaller_cars, new_data = NULL) \%>\% nrow()
 bake(smaller_cars, new_data = mtcars \%>\% slice(21:32)) \%>\% nrow()
 }
 \seealso{
-\code{\link[=step_filter]{step_filter()}} \code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_slice]{step_slice()}}
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_shuffle}()},
+\code{\link{step_slice}()}
 
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
@@ -109,4 +116,5 @@ Other {dplyr steps}:
 }
 \concept{preprocessing}
 \concept{{dplyr steps}}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_scale.Rd
+++ b/man/step_scale.Rd
@@ -99,6 +99,13 @@ Gelman, A. (2007) "Scaling regression inputs by
 dividing by two standard deviations." Unpublished. Source:
 \url{http://www.stat.columbia.edu/~gelman/research/unpublished/standardizing.pdf}.
 }
+\seealso{
+Other {normalization steps}: 
+\code{\link{step_center}()},
+\code{\link{step_normalize}()},
+\code{\link{step_range}()}
+}
 \concept{normalization_methods}
 \concept{preprocessing}
+\concept{{normalization steps}}
 \keyword{datagen}

--- a/man/step_select.Rd
+++ b/man/step_select.Rd
@@ -87,6 +87,18 @@ qq_rec <-
 # Note that `sepal_vars` is inlined in the second approach
 qq_rec
 }
+\seealso{
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_slice}()}
+}
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_select.Rd
+++ b/man/step_select.Rd
@@ -88,6 +88,13 @@ qq_rec <-
 qq_rec
 }
 \seealso{
+Other {variable filter steps}: 
+\code{\link{step_corr}()},
+\code{\link{step_lincomb}()},
+\code{\link{step_nzv}()},
+\code{\link{step_rm}()},
+\code{\link{step_zv}()}
+
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
 \code{\link{step_filter}()},
@@ -101,4 +108,5 @@ Other {dplyr steps}:
 \concept{preprocessing}
 \concept{variable_filters}
 \concept{{dplyr steps}}
+\concept{{variable filter steps}}
 \keyword{datagen}

--- a/man/step_shuffle.Rd
+++ b/man/step_shuffle.Rd
@@ -68,7 +68,18 @@ bake(rand_set, integers)
 tidy(rec, number = 1)
 tidy(rand_set, number = 1)
 }
+\seealso{
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_slice}()}
+}
 \concept{permutation}
 \concept{preprocessing}
 \concept{randomization}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_slice.Rd
+++ b/man/step_slice.Rd
@@ -108,6 +108,17 @@ tidy(qq_rec, number = 1)
 }
 \seealso{
 \code{\link[=step_filter]{step_filter()}} \code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_sample]{step_sample()}}
+
+Other {dplyr steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_mutate}()},
+\code{\link{step_rename_at}()},
+\code{\link{step_rename}()},
+\code{\link{step_sample}()},
+\code{\link{step_select}()}
 }
 \concept{preprocessing}
+\concept{{dplyr steps}}
 \keyword{datagen}

--- a/man/step_slice.Rd
+++ b/man/step_slice.Rd
@@ -107,7 +107,14 @@ qq_rec <-
 tidy(qq_rec, number = 1)
 }
 \seealso{
-\code{\link[=step_filter]{step_filter()}} \code{\link[=step_naomit]{step_naomit()}} \code{\link[=step_sample]{step_sample()}}
+Other {row operation steps}: 
+\code{\link{step_arrange}()},
+\code{\link{step_filter}()},
+\code{\link{step_impute_roll}()},
+\code{\link{step_lag}()},
+\code{\link{step_naomit}()},
+\code{\link{step_sample}()},
+\code{\link{step_shuffle}()}
 
 Other {dplyr steps}: 
 \code{\link{step_arrange}()},
@@ -121,4 +128,5 @@ Other {dplyr steps}:
 }
 \concept{preprocessing}
 \concept{{dplyr steps}}
+\concept{{row operation steps}}
 \keyword{datagen}

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -97,6 +97,22 @@ Serneels, S., De Nolf, E., and Van Espen, P.
 moderate robustness to multivariate estimators. \emph{Journal of
 Chemical Information and Modeling}, 46(3), 1402-1409.
 }
+\seealso{
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()}
+}
 \concept{preprocessing}
 \concept{projection_methods}
+\concept{{multivariate transformation steps}}
 \keyword{datagen}

--- a/man/step_sqrt.Rd
+++ b/man/step_sqrt.Rd
@@ -70,10 +70,22 @@ tidy(sqrt_trans, number = 1)
 tidy(sqrt_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_logit]{step_logit()}} \code{\link[=step_invlogit]{step_invlogit()}}
-\code{\link[=step_log]{step_log()}}  \code{\link[=step_hyperbolic]{step_hyperbolic()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {individual transformation steps}: 
+\code{\link{step_BoxCox}()},
+\code{\link{step_YeoJohnson}()},
+\code{\link{step_bs}()},
+\code{\link{step_harmonic}()},
+\code{\link{step_hyperbolic}()},
+\code{\link{step_inverse}()},
+\code{\link{step_invlogit}()},
+\code{\link{step_logit}()},
+\code{\link{step_log}()},
+\code{\link{step_mutate}()},
+\code{\link{step_ns}()},
+\code{\link{step_poly}()},
+\code{\link{step_relu}()}
 }
 \concept{preprocessing}
 \concept{transformation_methods}
+\concept{{individual transformation steps}}
 \keyword{datagen}

--- a/man/step_string2factor.Rd
+++ b/man/step_string2factor.Rd
@@ -83,7 +83,7 @@ okc \%>\% head
 tidy(make_factor, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -104,5 +104,5 @@ Other {dummy variables and encodings steps}:
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_string2factor.Rd
+++ b/man/step_string2factor.Rd
@@ -83,10 +83,26 @@ okc \%>\% head
 tidy(make_factor, number = 1)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}} \code{\link[=step_dummy]{step_dummy()}} \code{\link[=step_other]{step_other()}}
-\code{\link[=step_novel]{step_novel()}}
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_unknown}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
 \concept{variable_encodings}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_unknown.Rd
+++ b/man/step_unknown.Rd
@@ -85,10 +85,27 @@ table(bake(rec, new_data = NULL) \%>\% pull(diet),
 tidy(rec, number = 1)
 }
 \seealso{
-\code{\link[=step_factor2string]{step_factor2string()}}, \code{\link[=step_string2factor]{step_string2factor()}},
-\code{\link[=dummy_names]{dummy_names()}}, \code{\link[=step_regex]{step_regex()}}, \code{\link[=step_count]{step_count()}},
-\code{\link[=step_ordinalscore]{step_ordinalscore()}}, \code{\link[=step_unorder]{step_unorder()}}, \code{\link[=step_other]{step_other()}}, \code{\link[=step_novel]{step_novel()}}
+\code{\link[=dummy_names]{dummy_names()}}
+
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unorder}()}
 }
 \concept{factors}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_unknown.Rd
+++ b/man/step_unknown.Rd
@@ -87,7 +87,7 @@ tidy(rec, number = 1)
 \seealso{
 \code{\link[=dummy_names]{dummy_names()}}
 
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -107,5 +107,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{factors}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -74,9 +74,25 @@ tidy(factor_trans, number = 1)
 tidy(factor_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_ordinalscore]{step_ordinalscore()}} \code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {dummy variables and encodings steps}: 
+\code{\link{step_bin2factor}()},
+\code{\link{step_count}()},
+\code{\link{step_date}()},
+\code{\link{step_dummy}()},
+\code{\link{step_factor2string}()},
+\code{\link{step_holiday}()},
+\code{\link{step_indicate_na}()},
+\code{\link{step_integer}()},
+\code{\link{step_novel}()},
+\code{\link{step_num2factor}()},
+\code{\link{step_ordinalscore}()},
+\code{\link{step_other}()},
+\code{\link{step_regex}()},
+\code{\link{step_relevel}()},
+\code{\link{step_string2factor}()},
+\code{\link{step_unknown}()}
 }
 \concept{ordinal_data}
 \concept{preprocessing}
+\concept{{dummy variables and encodings steps}}
 \keyword{datagen}

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -74,7 +74,7 @@ tidy(factor_trans, number = 1)
 tidy(factor_obj, number = 1)
 }
 \seealso{
-Other {dummy variables and encodings steps}: 
+Other {dummy variable and encoding steps}: 
 \code{\link{step_bin2factor}()},
 \code{\link{step_count}()},
 \code{\link{step_date}()},
@@ -94,5 +94,5 @@ Other {dummy variables and encodings steps}:
 }
 \concept{ordinal_data}
 \concept{preprocessing}
-\concept{{dummy variables and encodings steps}}
+\concept{{dummy variable and encoding steps}}
 \keyword{datagen}

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -77,10 +77,14 @@ tidy(zv_filter, number = 1)
 tidy(filter_obj, number = 1)
 }
 \seealso{
-\code{\link[=step_nzv]{step_nzv()}} \code{\link[=step_corr]{step_corr()}}
-\code{\link[=recipe]{recipe()}}
-\code{\link[=prep.recipe]{prep.recipe()}} \code{\link[=bake.recipe]{bake.recipe()}}
+Other {variable filter steps}: 
+\code{\link{step_corr}()},
+\code{\link{step_lincomb}()},
+\code{\link{step_nzv}()},
+\code{\link{step_rm}()},
+\code{\link{step_select}()}
 }
 \concept{preprocessing}
 \concept{variable_filters}
+\concept{{variable filter steps}}
 \keyword{datagen}


### PR DESCRIPTION
Addresses #709

This PR makes use of the `@family` tag: all functions in a family get references to the other functions in the family in the `See Also` section of the documentation. 

The families largely correspond to the grouping on the [pkgdown reference site](https://recipes.tidymodels.org/reference/index.html), however a function can belong to more than one family, e.g. `step_impute_roll()` is listed with row-wise operations but also belongs to the family of imputation steps.

Closes #708, closes  #678.