### PR TITLE
Fix `step_mutate()` auto naming

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -84,7 +84,7 @@ step_mutate <- function(
   id = rand_id("mutate")
 ) {
 
-  inputs <- enquos(..., .named = TRUE)
+  inputs <- enquos(...)
 
   add_step(
     recipe,
@@ -131,10 +131,8 @@ bake.step_mutate <- function(object, new_data, ...) {
 
 
 print.step_mutate <-
-  function(x, width = max(20, options()$width - 35), ...) {
-    cat("Variable mutation for ",
-        paste0(names(x$inputs), collapse = ", "),
-        sep = "")
+  function(x, ...) {
+    cat("Variable mutation")
     if (x$trained) {
       cat(" [trained]\n")
     } else {
@@ -147,11 +145,14 @@ print.step_mutate <-
 #' @param x A `step_mutate` object
 #' @export
 tidy.step_mutate <- function(x, ...) {
-  var_expr <- map(x$inputs, quo_get_expr)
-  var_expr <- map_chr(var_expr, quo_text, width = options()$width, nlines = 1)
-    tibble(
-      terms = names(x$inputs),
-      value = var_expr,
-      id = rep(x$id, length(x$inputs))
-    )
+  inputs <- x$inputs
+
+  terms <- names(quos_auto_name(inputs))
+  value <- map_chr(unname(inputs), as_label)
+
+  tibble(
+    terms = terms,
+    value = value,
+    id = rep(x$id, length(x$inputs))
+  )
 }

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -89,7 +89,6 @@ step_mutate <- function(
   add_step(
     recipe,
     step_mutate_new(
-      terms = terms,
       trained = trained,
       role = role,
       inputs = inputs,
@@ -100,10 +99,9 @@ step_mutate <- function(
 }
 
 step_mutate_new <-
-  function(terms, role, trained, inputs, skip, id) {
+  function(role, trained, inputs, skip, id) {
     step(
       subclass = "mutate",
-      terms = terms,
       role = role,
       trained = trained,
       inputs = inputs,
@@ -115,7 +113,6 @@ step_mutate_new <-
 #' @export
 prep.step_mutate <- function(x, training, info = NULL, ...) {
   step_mutate_new(
-    terms = x$terms,
     trained = TRUE,
     role = x$role,
     inputs = x$inputs,

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -1,13 +1,11 @@
 #' Add new variables using dplyr
 #'
-#' `step_mutate` creates a *specification* of a recipe step
+#' `step_mutate()` creates a *specification* of a recipe step
 #'  that will add variables using [dplyr::mutate()].
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... Name-value pairs of expressions. See [dplyr::mutate()].
-#' If the argument is not named, the expression is converted to
-#' a column name.
 #' @param inputs Quosure(s) of `...`.
 #' @template step-return
 #' @details When an object in the user's global environment is
@@ -17,7 +15,7 @@
 #'  between sessions). See the examples.
 #'
 #'  When you [`tidy()`] this step, a tibble with column `values`, which
-#'  contains the `mutate` expressions as character strings
+#'  contains the `mutate()` expressions as character strings
 #'  (and are not reparsable), is returned.
 #'
 #' @keywords datagen

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -18,9 +18,7 @@ step_mutate(
 \item{recipe}{A recipe object. The step will be added to the
 sequence of operations for this recipe.}
 
-\item{...}{Name-value pairs of expressions. See \code{\link[dplyr:mutate]{dplyr::mutate()}}.
-If the argument is not named, the expression is converted to
-a column name.}
+\item{...}{Name-value pairs of expressions. See \code{\link[dplyr:mutate]{dplyr::mutate()}}.}
 
 \item{role}{For model terms created by this step, what analysis role should
 they be assigned? By default, the new columns created by this step from
@@ -45,7 +43,7 @@ An updated version of \code{recipe} with the new step added to the
 sequence of any existing operations.
 }
 \description{
-\code{step_mutate} creates a \emph{specification} of a recipe step
+\code{step_mutate()} creates a \emph{specification} of a recipe step
 that will add variables using \code{\link[dplyr:mutate]{dplyr::mutate()}}.
 }
 \details{
@@ -56,7 +54,7 @@ the value of the object in the expression (to be portable
 between sessions). See the examples.
 
 When you \code{\link[=tidy]{tidy()}} this step, a tibble with column \code{values}, which
-contains the \code{mutate} expressions as character strings
+contains the \code{mutate()} expressions as character strings
 (and are not reparsable), is returned.
 }
 \examples{

--- a/tests/testthat/test_mutate.R
+++ b/tests/testthat/test_mutate.R
@@ -79,6 +79,26 @@ test_that('quasiquotation', {
   expect_equal(dplyr_train, rec_2_train)
 })
 
+test_that("can use unnamed expressions like `across()` (#759)", {
+  skip_if_not_installed("dplyr", "1.0.0")
+
+  df <- tibble(
+    x = c(TRUE, FALSE),
+    y = c(1, 2),
+    z = c(TRUE, FALSE)
+  )
+
+  rec <- recipe(~., df) %>%
+    step_mutate(across(where(is.logical), as.integer))
+
+  rec <- prep(rec, df)
+
+  expect_identical(
+    bake(rec, new_data = NULL),
+    mutate(df, across(where(is.logical), as.integer))
+  )
+})
+
 test_that('no input', {
   no_inputs <-
     iris_rec %>%
@@ -92,6 +112,22 @@ test_that('printing', {
   rec <- iris_rec %>% step_mutate(x = 5)
   expect_output(print(rec))
   expect_output(prep(rec, training = iris, verbose = TRUE))
+})
+
+test_that("tidying allows for named and unnamed expressions", {
+  rec <- step_mutate(iris_rec, x = mean(y), id = "named")
+  tidied <- tidy(rec, id = "named")
+
+  # Named expressions use the name
+  expect_identical(tidied$terms, "x")
+  expect_identical(tidied$value, "mean(y)")
+
+  rec <- step_mutate(iris_rec, across(c(x, y), mean), id = "unnamed")
+  tidied <- tidy(rec, id = "unnamed")
+
+  # Unnamed expressions use the expression
+  expect_identical(tidied$terms, "across(c(x, y), mean)")
+  expect_identical(tidied$value, "across(c(x, y), mean)")
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #759 

So now we can use `across()` in `step_mutate()`

The only other dplyr step that auto-named was `step_rename()`, but it makes sense there (because you need to specify the LHS and RHS of the `=` sign to specify the old and new names)