### PR TITLE
Remove usage of `@keywords` and `@concept`, except for internal

### DIFF
--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -12,9 +12,6 @@
 #' @param num_unique An integer to specify minimum required unique
 #'  values to evaluate for a transformation.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details The Box-Cox transformation, which requires a strictly

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -12,9 +12,6 @@
 #' @param num_unique An integer where data that have less possible
 #'  values will not be evaluated for a transformation.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details The Yeo-Johnson transformation is very similar to the

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -19,8 +19,6 @@
 #'  contains the sorting variable(s) or expression(s) is returned. The
 #'  expressions are text representations and are not parsable.
 #'
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -23,10 +23,6 @@
 #'  When you [`tidy()`] this step, a tibble with column `terms` (the
 #'  columns that will be affected) is returned.
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dummy_variables
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @examples

--- a/R/bs.R
+++ b/R/bs.R
@@ -16,9 +16,6 @@
 #' @param options A list of options for [splines::bs()]
 #'  which should not include `x`, `degree`, or `df`.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept basis_expansion
 #' @family {individual transformation steps}
 #' @export
 #' @details `step_bs` can create new features from a single variable

--- a/R/center.R
+++ b/R/center.R
@@ -24,9 +24,6 @@
 #' @param id A character string that is unique to this step to identify it.
 #' @template step-return
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept normalization_methods
 #' @family {normalization steps}
 #' @export
 #' @details Centering data means that the average of a variable is

--- a/R/class.R
+++ b/R/class.R
@@ -13,8 +13,6 @@
 #'  `NULL` until computed by [prep.recipe()].
 #' @template check-return
 #'
-#' @keywords datagen
-#' @concept preprocessing normalization_methods
 #' @family {checks}
 #' @export
 #' @details

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -19,9 +19,6 @@
 #' @param objects Statistics are stored here once this step has
 #'  been trained by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dimension_reduction
 #' @family {multivariate transformation steps}
 #' @export
 #' @details `step_classdist` will create a new column for every

--- a/R/corr.R
+++ b/R/corr.R
@@ -17,13 +17,10 @@
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
 #' @template step-return
-#' @keywords datagen
 #' @author Original R code for filtering algorithm by Dong Li,
 #'  modified by Max Kuhn. Contributions by Reynald Lescarbeau (for
 #'  original in `caret` package). Max Kuhn for the `step`
 #'  function.
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @export
 #'

--- a/R/count.R
+++ b/R/count.R
@@ -26,10 +26,6 @@
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `result` (the
 #'  new column name) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dummy_variables
-#' @concept regular_expressions
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @examples

--- a/R/cut.R
+++ b/R/cut.R
@@ -9,8 +9,6 @@
 #'  range in the train set should be included in the lowest or highest bucket.
 #'  Defaults to `FALSE`, values outside the original range will be set to `NA`.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {discretization steps}
 #' @export
 #' @details Unlike the `base::cut()` function there is no need to specify the

--- a/R/date.R
+++ b/R/date.R
@@ -33,11 +33,6 @@
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
-#' @concept variable_encodings
-#' @concept dates
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details Unlike some other steps, `step_date` does *not*

--- a/R/depth.R
+++ b/R/depth.R
@@ -24,9 +24,6 @@
 #' @param data The training data are stored here once after
 #'  [prep.recipe()] is executed.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dimension_reduction
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Data depth metrics attempt to measure how close data a

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -37,10 +37,6 @@ discretize.default <- function(x, ...)
 #' @return `discretize` returns an object of class
 #'  `discretize` and `predict.discretize` returns a factor
 #'  vector.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept discretization
-#' @concept factors
 #' @export
 #' @details `discretize` estimates the cut points from
 #'  `x` using percentiles. For example, if `cuts = 3`, the

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -50,8 +50,6 @@
 #'  conducted outside of the training set.
 #'
 #' @keywords internal
-#' @concept preprocessing
-#' @concept subsampling
 #' @export
 
 step_downsample <-

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -21,12 +21,6 @@
 #'  `terms`. This is `NULL` until the step is trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dummy_variables
-#' @concept model_specification
-#' @concept dummy_variables
-#' @concept variable_encodings
 #' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -8,10 +8,6 @@
 #'  converted. This is `NULL` until computed by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_encodings
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details `prep` has an option `strings_as_factors` that

--- a/R/filter.R
+++ b/R/filter.R
@@ -21,9 +21,6 @@
 #'  contains the conditional statements is returned. These
 #'  expressions are text representations and are not parsable.
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept row_filters
 #' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -25,8 +25,6 @@
 #' @details When you [`tidy()`] this step, a tibble with columns echoing the
 #'  values of `lat`, `lon`, `ref_lat`, `ref_lon`, `is_lat_lon`, `name`, and `id`
 #'  is returned.
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {multivariate transformation steps}
 #' @references https://en.wikipedia.org/wiki/Haversine_formula
 #' @export

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -14,11 +14,6 @@
 #'  used as inputs. This field is a placeholder and will be
 #'  populated once [prep.recipe()] is used.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
-#' @concept variable_encodings
-#' @concept dates
 #' @family {dummy variable and encoding steps}
 #' @seealso [timeDate::listHolidays()]
 #' @export

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -11,9 +11,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the

--- a/R/ica.R
+++ b/R/ica.R
@@ -18,10 +18,6 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept ica
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Independent component analysis (ICA) is a

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -22,9 +22,6 @@
 #' @param models The [ipred::ipredbagg()] objects are stored here once this
 #'  bagged trees have be trained by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details For each variable requiring imputation, a bagged tree is created

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -14,9 +14,6 @@
 #' @param columns The column names that will be imputed and used for
 #'  imputation. This is `NULL` until the step is trained by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details The step uses the training set to impute any other data sets. The

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -12,9 +12,6 @@
 #' @param models The [lm()] objects are stored here once the linear models
 #'  have been trained by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details For each variable requiring imputation, a linear model is fit

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -10,9 +10,6 @@
 #' @param threshold A named numeric vector of lower bounds. This is
 #'  `NULL` until computed by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details `step_impute_lower` estimates the variable minimums

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -12,9 +12,6 @@
 #'  end of the variables before the mean is computed. Values of trim outside
 #'  that range are taken as the nearest endpoint.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details `step_impute_mean` estimates the variable means from the data used

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -9,9 +9,6 @@
 #'  computed by [prep.recipe()]. Note that, if the original data are integers,
 #'  the median will be converted to an integer to maintain the same data type.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details `step_impute_median` estimates the variable medians from the data

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -10,9 +10,6 @@
 #' @param ptype A data frame prototype to cast new data sets to. This is
 #'  commonly a 0-row slice of the training set.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @export
 #' @details `step_impute_mode` estimates the variable modes

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -17,9 +17,6 @@
 #'  the imputed value. Only complete values will be passed to the function and
 #'  it should return a double precision value.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {imputation steps}
 #' @family {row operation steps}
 #' @export

--- a/R/integer.R
+++ b/R/integer.R
@@ -15,9 +15,6 @@
 #' @param zero_based A logical for whether the integers should start at zero and
 #'  new values be appended as the largest integer.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_encodings
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details `step_integer` will determine the unique values of

--- a/R/interactions.R
+++ b/R/interactions.R
@@ -16,9 +16,6 @@
 #'  interaction (e.g. `var1_x_var2` instead of the more
 #'  traditional `var1:var2`).
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
 #' @export
 #' @details `step_interact` can create interactions between
 #'  variables. It is primarily intended for **numeric data**;

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -9,9 +9,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms`

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -8,9 +8,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details The inverse logit transformation takes values on the

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -16,10 +16,6 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept isomap
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Isomap is a form of multidimensional scaling (MDS).

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -19,12 +19,6 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen internal
-#' @concept preprocessing
-#' @concept pca
-#' @concept projection_methods
-#' @concept kernel_methods
-#' @concept basis_expansion
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an
 #'  extension of a PCA analysis that conducts the calculations in a

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -19,6 +19,7 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
+#' @keywords internal
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an
 #'  extension of a PCA analysis that conducts the calculations in a

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -15,12 +15,6 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept pca
-#' @concept projection_methods
-#' @concept kernel_methods
-#' @concept basis_expansion
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -15,12 +15,6 @@
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept pca
-#' @concept projection_methods
-#' @concept kernel_methods
-#' @concept basis_expansion
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -10,9 +10,6 @@
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @author Max Kuhn, Kirk Mettler, and Jed Wing
 #' @export

--- a/R/log.R
+++ b/R/log.R
@@ -13,9 +13,6 @@
 #'  This is sign(x) * abs(log(x)) when abs(x) => 1 or 0 if abs(x) < 1.
 #'  If `TRUE` the `offset` argument will be ignored.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the

--- a/R/logit.R
+++ b/R/logit.R
@@ -7,9 +7,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @export
 #' @details The logit transformation takes values between

--- a/R/misc.R
+++ b/R/misc.R
@@ -126,9 +126,6 @@ mod_call_args <- function(cl, args, removals = NULL) {
 #' @return `names0` returns a character string of length `num` and
 #'  `dummy_names` generates a character vector the same length as
 #'  `lvl`.
-#' @keywords datagen
-#' @concept string_functions
-#' @concept naming_functions
 #' @examples
 #' names0(9, "x")
 #' names0(10, "x")

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -18,9 +18,6 @@
 #'  contains the `mutate()` expressions as character strings
 #'  (and are not reparsable), is returned.
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -12,9 +12,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with
 #'  column `terms` which contains the columns being transformed is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {multivariate transformation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -14,9 +14,6 @@
 #' @details  When you [`tidy()`] this step, a tibble with
 #'  columns `terms` (the selectors or variables selected) and `model` (the
 #'  median value) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept imputation
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @examples

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -24,10 +24,6 @@
 #' @param seed An integer that will be used to set the seed in isolation
 #'  when computing the factorization.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept nnmf
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details Non-negative matrix factorization computes latent components that

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -12,9 +12,6 @@
 #' @param na_rm A logical value indicating whether `NA`
 #'  values should be removed when computing the standard deviation and mean.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept normalization_methods
 #' @family {normalization steps}
 #' @export
 #' @details Centering data means that the average of a variable is subtracted

--- a/R/novel.R
+++ b/R/novel.R
@@ -10,9 +10,6 @@
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export

--- a/R/ns.R
+++ b/R/ns.R
@@ -15,9 +15,6 @@
 #' @param options A list of options for [splines::ns()]
 #'  which should not include `x` or `df`.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept basis_expansion
 #' @family {individual transformation steps}
 #' @export
 #' @details `step_ns` can create new features from a single variable

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -17,10 +17,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `ordered` is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_encodings
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @examples

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -13,9 +13,6 @@
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @export
 #'

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -11,9 +11,6 @@
 #' @param convert A function that takes an ordinal factor vector
 #'  as an input and outputs a single numeric variable.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept ordinal_data
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details Dummy variables from ordered factors with `C`

--- a/R/other.R
+++ b/R/other.R
@@ -16,9 +16,6 @@
 #'  to pool infrequent levels that is determined by
 #'  [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export

--- a/R/pca.R
+++ b/R/pca.R
@@ -26,10 +26,6 @@
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `FALSE`.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept pca
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details

--- a/R/pls.R
+++ b/R/pls.R
@@ -21,10 +21,6 @@
 #' @param res A list of results are stored here once this preprocessing step
 #'  has been trained by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept pls
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details PLS is a supervised version of principal component

--- a/R/poly.R
+++ b/R/poly.R
@@ -14,9 +14,6 @@
 #'  the option `raw = TRUE` will produce the regular polynomial
 #'  values (not orthogonalized).
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept basis_expansion
 #' @family {individual transformation steps}
 #' @export
 #' @details `step_poly` can create new features from a single

--- a/R/profile.R
+++ b/R/profile.R
@@ -44,8 +44,6 @@
 #'  profiled) is returned.
 #'
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
 #' @export
 #' @examples
 #' library(modeldata)

--- a/R/range.R
+++ b/R/range.R
@@ -14,9 +14,6 @@
 #'  determined by [prep.recipe()]. Setting this value will
 #'  be ineffective.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept normalization_methods
 #' @family {normalization steps}
 #' @export
 #' @details When a new data point is outside of the ranges seen in

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -14,9 +14,6 @@
 #' @param upper A named numeric vector of maximum values in the train set.
 #'   This is `NULL` until computed by [prep.recipe()].
 #' @template check-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept normalization_methods
 #' @family {checks}
 #' @export
 #' @details

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -26,8 +26,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `denom` is returned.
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {multivariate transformation steps}
 #' @export
 #' @examples

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -5,9 +5,6 @@
 #'
 #' @aliases recipe recipe.default recipe.formula
 #' @author Max Kuhn
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
 #' @export
 recipe <- function(x, ...)
   UseMethod("recipe")
@@ -240,9 +237,6 @@ inline_check <- function(x) {
 #' @param ... further arguments passed to or from other methods (not currently
 #'   used).
 #' @author Max Kuhn
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
 #' @export
 prep <- function(x, ...)
   UseMethod("prep")
@@ -459,9 +453,6 @@ prep.recipe <-
 #' @rdname bake
 #' @aliases bake bake.recipe
 #' @author Max Kuhn
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
 #' @export
 bake <- function(object, ...)
   UseMethod("bake")

--- a/R/regex.R
+++ b/R/regex.R
@@ -23,10 +23,6 @@
 #' @details When you [`tidy()`] this step, a tibble with columns `terms` (the
 #'  selectors or variables selected) and `result` (the
 #'  new column name) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept dummy_variables
-#' @concept regular_expressions
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @examples

--- a/R/relevel.R
+++ b/R/relevel.R
@@ -12,10 +12,6 @@
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
 #' @template step-return
-#'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details The selected variables are releveled to a level

--- a/R/rename.R
+++ b/R/rename.R
@@ -18,9 +18,6 @@
 #'  columns `values` which contains the `rename` expressions as character
 #'  strings (and are not reparsable) is returned.
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -12,9 +12,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with
 #'  columns `terms` which contains the columns being transformed is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {dplyr steps}
 #' @export
 #' @examples

--- a/R/rm.R
+++ b/R/rm.R
@@ -10,9 +10,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #'  columns that will be removed) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @export
 #' @examples

--- a/R/roles.R
+++ b/R/roles.R
@@ -46,9 +46,6 @@
 #' on all of the variables that have a custom role with the selector
 #' [has_role()].
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept model_specification
 #' @examples
 #' library(recipes)
 #' library(modeldata)

--- a/R/sample.R
+++ b/R/sample.R
@@ -17,8 +17,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with columns `size`,
 #' `replace`, and `id` is returned.
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/scale.R
+++ b/R/scale.R
@@ -15,9 +15,6 @@
 #' @param na_rm A logical value indicating whether `NA`
 #'  values should be removed when computing the standard deviation.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept normalization_methods
 #' @family {normalization steps}
 #' @export
 #' @details Scaling data means that the standard deviation of a

--- a/R/select.R
+++ b/R/select.R
@@ -17,9 +17,6 @@
 #'  contains the `select` expressions as character strings
 #'  (and are not reparsable) is returned.
 #'
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/selections.R
+++ b/R/selections.R
@@ -227,7 +227,6 @@ recipes_eval_select <- function(quos, data, info, ..., allow_rename = FALSE) {
 #'
 #' `current_info()` returns an environment with objects `vars` and `data`.
 #'
-#' @keywords datagen
 #' @examples
 #' library(modeldata)
 #' data(biomass)

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -11,10 +11,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #' columns that will be permuted) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept randomization
-#' @concept permutation
 #' @family {row operation steps}
 #' @export
 #' @examples

--- a/R/slice.R
+++ b/R/slice.R
@@ -18,8 +18,6 @@
 #'  When you [`tidy()`] this step, a tibble with column `terms` which
 #'  contains the filtering indices is returned.
 #'
-#' @keywords datagen
-#' @concept preprocessing
 #' @family {row operation steps}
 #' @family {dplyr steps}
 #' @export

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -11,9 +11,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept projection_methods
 #' @family {multivariate transformation steps}
 #' @export
 #' @details The spatial sign transformation projects the variables

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -7,9 +7,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept transformation_methods
 #' @family {individual transformation steps}
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #' columns that will be affected) is returned.

--- a/R/steps_and_checks.R
+++ b/R/steps_and_checks.R
@@ -8,7 +8,6 @@
 #' @param ... All arguments to the operator that should be returned.
 #' @param .prefix Prefix to the subclass created.
 #' @keywords internal
-#' @concept preprocessing
 #' @return An updated step or check with the new class.
 #' @export
 step <- function(subclass, ..., .prefix = "step_") {
@@ -30,8 +29,6 @@ check <- function(subclass, ..., .prefix = "check_") {
 #'
 #' @param rec A [recipe()].
 #' @param object A step or check object.
-#' @keywords datagen
-#' @concept preprocessing
 #' @return A updated [recipe()] with the new operation in the last slot.
 #' @export
 add_step <- function(rec, object) {

--- a/R/string2factor.R
+++ b/R/string2factor.R
@@ -10,10 +10,6 @@
 #' @param ordered A single logical value; should the factor(s) be
 #'  ordered?
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_encodings
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details If `levels` is given, `step_string2factor` will

--- a/R/terms-select.R
+++ b/R/terms-select.R
@@ -16,8 +16,6 @@
 #'  quoted expressions. See [rlang::quos()] for examples.
 #' @param empty_fun A function to execute when no terms are selected by the
 #'  step. The default function throws an error with a message.
-#' @keywords datagen
-#' @concept preprocessing
 #' @return A character string of column names or an error of there
 #'  are no selectors or if no variables are selected.
 #' @seealso [recipe()] [summary.recipe()]

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -9,9 +9,6 @@
 #' @param objects A list of objects that contain the information
 #'  on factor levels that will be determined by [prep.recipe()].
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept factors
 #' @family {dummy variable and encoding steps}
 #' @seealso [dummy_names()]
 #' @export

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -7,9 +7,6 @@
 #' @param columns A character string of variable names that will
 #'  be populated (eventually) by the `terms` argument.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept ordinal_data
 #' @family {dummy variable and encoding steps}
 #' @export
 #' @details The factors level order is preserved during the transformation.

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -45,8 +45,6 @@
 #'  conducted outside of the training set.
 #'
 #' @keywords internal
-#' @concept preprocessing
-#' @concept subsampling
 #' @export
 
 step_upsample <-

--- a/R/window.R
+++ b/R/window.R
@@ -28,9 +28,6 @@
 #'  `summary` function (see the example below). These will be
 #'  the names of the new columns created by the step.
 #' @template step-return
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept moving_windows
 #' @export
 #' @details The calculations use a somewhat atypical method for
 #'  handling the beginning and end parts of the rolling statistics.

--- a/R/zv.R
+++ b/R/zv.R
@@ -10,9 +10,6 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the
 #'  columns that will be removed) is returned.
-#' @keywords datagen
-#' @concept preprocessing
-#' @concept variable_filters
 #' @family {variable filter steps}
 #' @export
 #'

--- a/inst/boilerplate.R
+++ b/inst/boilerplate.R
@@ -63,8 +63,6 @@ create_documentation <- function(name,
 #' @param id A character string that is unique to this step to identify it.
 #' @return <describe return>
 #'
-#' @keywords datagen
-#' @concept preprocessing
 #' @export
 #' @details <describe details>
 #'

--- a/man/add_step.Rd
+++ b/man/add_step.Rd
@@ -21,5 +21,3 @@ A updated \code{\link[=recipe]{recipe()}} with the new operation in the last slo
 \code{add_step} adds a step to the last location in the recipe.
 \code{add_check} does the same for checks.
 }
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -78,6 +78,3 @@ ames_new <- bake(ames_rec, new_data = head(ames))
 \author{
 Max Kuhn
 }
-\concept{model_specification}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/check_class.Rd
+++ b/man/check_class.Rd
@@ -119,6 +119,4 @@ Other {checks}:
 \code{\link{check_new_values}()},
 \code{\link{check_range}()}
 }
-\concept{preprocessing normalization_methods}
 \concept{{checks}}
-\keyword{datagen}

--- a/man/check_range.Rd
+++ b/man/check_range.Rd
@@ -106,7 +106,4 @@ Other {checks}:
 \code{\link{check_missing}()},
 \code{\link{check_new_values}()}
 }
-\concept{normalization_methods}
-\concept{preprocessing}
 \concept{{checks}}
-\keyword{datagen}

--- a/man/discretize.Rd
+++ b/man/discretize.Rd
@@ -110,7 +110,3 @@ rec <- prep(rec, biomass_tr)
 binned_te <- bake(rec, biomass_te)
 table(binned_te$carbon)
 }
-\concept{discretization}
-\concept{factors}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/has_role.Rd
+++ b/man/has_role.Rd
@@ -81,4 +81,3 @@ rec \%>\%
   bake(new_data = NULL)
 
 }
-\keyword{datagen}

--- a/man/names0.Rd
+++ b/man/names0.Rd
@@ -53,6 +53,3 @@ levels(example$y)
 
 dummy_names("y", substring(after_mm, 2), ordinal = TRUE)
 }
-\concept{naming_functions}
-\concept{string_functions}
-\keyword{datagen}

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -103,6 +103,3 @@ prep(ames_rec, log_changes = TRUE)
 \author{
 Max Kuhn
 }
-\concept{model_specification}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -114,7 +114,7 @@ used.
 The best way to use use a recipe for modeling is via the \code{workflows}
 package. This bundles a model and preprocessor (e.g. a recipe) together
 and gives the user a fluent way to train the model/recipe and make
-predictions.\if{html}{\out{<div class="r">}}\preformatted{library(dplyr)
+predictions.\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(dplyr)
 library(workflows)
 library(recipes)
 library(parsnip)
@@ -150,7 +150,7 @@ sp_signed
 }
 
 We can create a \code{parsnip} model, and then build a workflow with the
-model and recipe:\if{html}{\out{<div class="r">}}\preformatted{linear_mod <- linear_reg()
+model and recipe:\if{html}{\out{<div class="sourceCode r">}}\preformatted{linear_mod <- linear_reg()
 
 linear_sp_sign_wflow <- 
   workflow() \%>\% 
@@ -158,30 +158,30 @@ linear_sp_sign_wflow <-
   add_recipe(sp_signed)
 
 linear_sp_sign_wflow
-}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ══════════════════════════════════════════════════════════
+}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 ## Preprocessor: Recipe
 ## Model: linear_reg()
 ## 
-## ── Preprocessor ──────────────────────────────────────────────────────
+## ── Preprocessor ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ## 2 Recipe Steps
 ## 
 ## • step_normalize()
 ## • step_spatialsign()
 ## 
-## ── Model ─────────────────────────────────────────────────────────────
+## ── Model ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ## Linear Regression Model Specification (regression)
 ## 
 ## Computational engine: lm
 }
 
 To estimate the preprocessing steps and then fit the linear model, a
-single call to \code{fit()} is used:\if{html}{\out{<div class="r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
+single call to \code{fit()} is used:\if{html}{\out{<div class="sourceCode r">}}\preformatted{linear_sp_sign_fit <- fit(linear_sp_sign_wflow, data = biomass_tr)
 }\if{html}{\out{</div>}}
 
 When predicting, there is no need to do anything other than call
 \code{predict()}. This preprocesses the new data in the same manner as the
-training set, then gives the data to the linear model prediction code:\if{html}{\out{<div class="r">}}\preformatted{predict(linear_sp_sign_fit, new_data = head(biomass_te))
-}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 x 1
+training set, then gives the data to the linear model prediction code:\if{html}{\out{<div class="sourceCode r">}}\preformatted{predict(linear_sp_sign_fit, new_data = head(biomass_te))
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 × 1
 ##   .pred
 ##   <dbl>
 ## 1  18.1
@@ -203,14 +203,14 @@ Once a recipe has been defined, the \code{\link[=prep]{prep()}} function can be
 used to estimate quantities required for the operations using a data set
 (a.k.a. the training data). \code{\link[=prep]{prep()}} returns a recipe.
 
-As an example of using PCA (perhaps to produce a plot):\if{html}{\out{<div class="r">}}\preformatted{# Define the recipe
+As an example of using PCA (perhaps to produce a plot):\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Define the recipe
 pca_rec <- 
   rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_pca(all_numeric_predictors())
 }\if{html}{\out{</div>}}
 
-Now to estimate the normalization statistics and the PCA loadings:\if{html}{\out{<div class="r">}}\preformatted{pca_rec <- prep(pca_rec, training = biomass_tr)
+Now to estimate the normalization statistics and the PCA loadings:\if{html}{\out{<div class="sourceCode r">}}\preformatted{pca_rec <- prep(pca_rec, training = biomass_tr)
 pca_rec
 }\if{html}{\out{</div>}}\preformatted{## Data Recipe
 ## 
@@ -232,20 +232,20 @@ Note that the estimated recipe shows the actual column names captured by
 the selectors.
 
 You can \code{\link[=tidy.recipe]{tidy.recipe()}} a recipe, either when it is
-prepped or unprepped, to learn more about its components.\if{html}{\out{<div class="r">}}\preformatted{tidy(pca_rec)
-}\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 x 6
+prepped or unprepped, to learn more about its components.\if{html}{\out{<div class="sourceCode r">}}\preformatted{tidy(pca_rec)
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 × 6
 ##   number operation type      trained skip  id             
 ##    <int> <chr>     <chr>     <lgl>   <lgl> <chr>          
-## 1      1 step      normalize TRUE    FALSE normalize_mnfYN
-## 2      2 step      pca       TRUE    FALSE pca_DiY2m
+## 1      1 step      normalize TRUE    FALSE normalize_8WF2w
+## 2      2 step      pca       TRUE    FALSE pca_8BSFb
 }
 
 You can also \code{tidy()} recipe \emph{steps} with a \code{number} or \code{id} argument.
 
 To apply the prepped recipe to a data set, the \code{\link[=bake]{bake()}}
 function is used in the same manner that \code{predict()} would be for
-models. This applies the estimated steps to any data set.\if{html}{\out{<div class="r">}}\preformatted{bake(pca_rec, head(biomass_te))
-}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 x 6
+models. This applies the estimated steps to any data set.\if{html}{\out{<div class="sourceCode r">}}\preformatted{bake(pca_rec, head(biomass_te))
+}\if{html}{\out{</div>}}\preformatted{## # A tibble: 6 × 6
 ##     HHV    PC1    PC2     PC3     PC4     PC5
 ##   <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>
 ## 1  18.3 0.730   0.412  0.495   0.333   0.253 
@@ -307,6 +307,3 @@ rec
 \author{
 Max Kuhn
 }
-\concept{model_specification}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/roles.Rd
+++ b/man/roles.Rd
@@ -128,6 +128,3 @@ recipe(biomass) \%>\%
   summary()
 
 }
-\concept{model_specification}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/step.Rd
+++ b/man/step.Rd
@@ -24,5 +24,4 @@ An updated step or check with the new class.
 \description{
 \code{step} sets the class of the \code{step} and \code{check} is for checks.
 }
-\concept{preprocessing}
 \keyword{internal}

--- a/man/step_BoxCox.Rd
+++ b/man/step_BoxCox.Rd
@@ -115,7 +115,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_YeoJohnson.Rd
+++ b/man/step_YeoJohnson.Rd
@@ -125,7 +125,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_arrange.Rd
+++ b/man/step_arrange.Rd
@@ -118,7 +118,5 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
 \concept{{dplyr steps}}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -106,8 +106,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dummy_variables}
-\concept{factors}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_bs.Rd
+++ b/man/step_bs.Rd
@@ -107,7 +107,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{basis_expansion}
-\concept{preprocessing}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_center.Rd
+++ b/man/step_center.Rd
@@ -90,7 +90,4 @@ Other {normalization steps}:
 \code{\link{step_range}()},
 \code{\link{step_scale}()}
 }
-\concept{normalization_methods}
-\concept{preprocessing}
 \concept{{normalization steps}}
-\keyword{datagen}

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -130,7 +130,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{dimension_reduction}
-\concept{preprocessing}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_corr.Rd
+++ b/man/step_corr.Rd
@@ -116,7 +116,4 @@ modified by Max Kuhn. Contributions by Reynald Lescarbeau (for
 original in \code{caret} package). Max Kuhn for the \code{step}
 function.
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -110,8 +110,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dummy_variables}
-\concept{preprocessing}
-\concept{regular_expressions}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_cut.Rd
+++ b/man/step_cut.Rd
@@ -103,6 +103,4 @@ rec \%>\%
 Other {discretization steps}: 
 \code{\link{step_discretize}()}
 }
-\concept{preprocessing}
 \concept{{discretization steps}}
-\keyword{datagen}

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -126,9 +126,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dates}
-\concept{model_specification}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -139,7 +139,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{dimension_reduction}
-\concept{preprocessing}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -101,6 +101,4 @@ When used in modeling, users should strongly consider using the
 option \code{skip = TRUE} so that the extra sampling is \emph{not}
 conducted outside of the training set.
 }
-\concept{preprocessing}
-\concept{subsampling}
 \keyword{internal}

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -180,9 +180,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dummy_variables}
-\concept{model_specification}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -104,8 +104,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_filter.Rd
+++ b/man/step_filter.Rd
@@ -124,8 +124,5 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{row_filters}
 \concept{{dplyr steps}}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -115,6 +115,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{preprocessing}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -100,9 +100,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dates}
-\concept{model_specification}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_hyperbolic.Rd
+++ b/man/step_hyperbolic.Rd
@@ -94,7 +94,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -147,8 +147,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{ica}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_impute_bag.Rd
+++ b/man/step_impute_bag.Rd
@@ -169,7 +169,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_knn.Rd
+++ b/man/step_impute_knn.Rd
@@ -156,7 +156,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_linear.Rd
+++ b/man/step_impute_linear.Rd
@@ -116,7 +116,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_lower.Rd
+++ b/man/step_impute_lower.Rd
@@ -115,7 +115,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_mean.Rd
+++ b/man/step_impute_mean.Rd
@@ -117,7 +117,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_median.Rd
+++ b/man/step_impute_median.Rd
@@ -111,7 +111,4 @@ Other {imputation steps}:
 \code{\link{step_impute_mode}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_mode.Rd
+++ b/man/step_impute_mode.Rd
@@ -116,7 +116,4 @@ Other {imputation steps}:
 \code{\link{step_impute_median}()},
 \code{\link{step_impute_roll}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
-\keyword{datagen}

--- a/man/step_impute_roll.Rd
+++ b/man/step_impute_roll.Rd
@@ -136,8 +136,5 @@ Other {row operation steps}:
 \code{\link{step_shuffle}()},
 \code{\link{step_slice}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{imputation steps}}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -99,7 +99,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{imputation}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -117,7 +117,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -119,6 +119,3 @@ names(dat_2)
 tidy(int_mod_1, number = 1)
 tidy(int_mod_2, number = 2)
 }
-\concept{model_specification}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/step_inverse.Rd
+++ b/man/step_inverse.Rd
@@ -89,7 +89,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_invlogit.Rd
+++ b/man/step_invlogit.Rd
@@ -92,7 +92,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -152,8 +152,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{isomap}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -146,3 +146,4 @@ of Statistical Software}, 11(1), 1-20.
 \code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
 \code{\link[=bake.recipe]{bake.recipe()}}
 }
+\keyword{internal}

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -146,10 +146,3 @@ of Statistical Software}, 11(1), 1-20.
 \code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
 \code{\link[=bake.recipe]{bake.recipe()}}
 }
-\concept{basis_expansion}
-\concept{kernel_methods}
-\concept{pca}
-\concept{preprocessing}
-\concept{projection_methods}
-\keyword{datagen}
-\keyword{internal}

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -152,10 +152,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{basis_expansion}
-\concept{kernel_methods}
-\concept{pca}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -150,10 +150,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{basis_expansion}
-\concept{kernel_methods}
-\concept{pca}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_lincomb.Rd
+++ b/man/step_lincomb.Rd
@@ -97,7 +97,4 @@ Other {variable filter steps}:
 \author{
 Max Kuhn, Kirk Mettler, and Jed Wing
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/step_log.Rd
+++ b/man/step_log.Rd
@@ -113,7 +113,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_logit.Rd
+++ b/man/step_logit.Rd
@@ -89,7 +89,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -134,8 +134,5 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{dplyr steps}}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -96,8 +96,5 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{dplyr steps}}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -127,8 +127,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{nnmf}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_normalize.Rd
+++ b/man/step_normalize.Rd
@@ -106,7 +106,4 @@ Other {normalization steps}:
 \code{\link{step_range}()},
 \code{\link{step_scale}()}
 }
-\concept{normalization_methods}
-\concept{preprocessing}
 \concept{{normalization steps}}
-\keyword{datagen}

--- a/man/step_novel.Rd
+++ b/man/step_novel.Rd
@@ -117,7 +117,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -104,7 +104,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{basis_expansion}
-\concept{preprocessing}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_num2factor.Rd
+++ b/man/step_num2factor.Rd
@@ -135,8 +135,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_nzv.Rd
+++ b/man/step_nzv.Rd
@@ -118,7 +118,4 @@ Other {variable filter steps}:
 \code{\link{step_select}()},
 \code{\link{step_zv}()}
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -120,7 +120,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{ordinal_data}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_other.Rd
+++ b/man/step_other.Rd
@@ -148,7 +148,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -145,8 +145,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{pca}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -177,8 +177,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_ratio}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{pls}
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_poly.Rd
+++ b/man/step_poly.Rd
@@ -105,7 +105,4 @@ Other {individual transformation steps}:
 \code{\link{step_relu}()},
 \code{\link{step_sqrt}()}
 }
-\concept{basis_expansion}
-\concept{preprocessing}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_profile.Rd
+++ b/man/step_profile.Rd
@@ -143,5 +143,3 @@ ggplot(plot_data, aes(x = disp, y = pred)) +
   geom_point(alpha = .5, cex = 1) +
   facet_wrap(~ method)
 }
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/step_range.Rd
+++ b/man/step_range.Rd
@@ -95,7 +95,4 @@ Other {normalization steps}:
 \code{\link{step_normalize}()},
 \code{\link{step_scale}()}
 }
-\concept{normalization_methods}
-\concept{preprocessing}
 \concept{{normalization steps}}
-\keyword{datagen}

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -115,6 +115,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_pls}()},
 \code{\link{step_spatialsign}()}
 }
-\concept{preprocessing}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -104,8 +104,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{dummy_variables}
-\concept{preprocessing}
-\concept{regular_expressions}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_relevel.Rd
+++ b/man/step_relevel.Rd
@@ -93,7 +93,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_rename.Rd
+++ b/man/step_rename.Rd
@@ -87,7 +87,4 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{dplyr steps}}
-\keyword{datagen}

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -75,7 +75,4 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{dplyr steps}}
-\keyword{datagen}

--- a/man/step_rm.Rd
+++ b/man/step_rm.Rd
@@ -82,7 +82,4 @@ Other {variable filter steps}:
 \code{\link{step_select}()},
 \code{\link{step_zv}()}
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/step_sample.Rd
+++ b/man/step_sample.Rd
@@ -114,7 +114,5 @@ Other {dplyr steps}:
 \code{\link{step_select}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
 \concept{{dplyr steps}}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_scale.Rd
+++ b/man/step_scale.Rd
@@ -105,7 +105,4 @@ Other {normalization steps}:
 \code{\link{step_normalize}()},
 \code{\link{step_range}()}
 }
-\concept{normalization_methods}
-\concept{preprocessing}
 \concept{{normalization steps}}
-\keyword{datagen}

--- a/man/step_select.Rd
+++ b/man/step_select.Rd
@@ -105,8 +105,5 @@ Other {dplyr steps}:
 \code{\link{step_sample}()},
 \code{\link{step_slice}()}
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{dplyr steps}}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/step_shuffle.Rd
+++ b/man/step_shuffle.Rd
@@ -78,8 +78,4 @@ Other {row operation steps}:
 \code{\link{step_sample}()},
 \code{\link{step_slice}()}
 }
-\concept{permutation}
-\concept{preprocessing}
-\concept{randomization}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_slice.Rd
+++ b/man/step_slice.Rd
@@ -126,7 +126,5 @@ Other {dplyr steps}:
 \code{\link{step_sample}()},
 \code{\link{step_select}()}
 }
-\concept{preprocessing}
 \concept{{dplyr steps}}
 \concept{{row operation steps}}
-\keyword{datagen}

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -112,7 +112,4 @@ Other {multivariate transformation steps}:
 \code{\link{step_pls}()},
 \code{\link{step_ratio}()}
 }
-\concept{preprocessing}
-\concept{projection_methods}
 \concept{{multivariate transformation steps}}
-\keyword{datagen}

--- a/man/step_sqrt.Rd
+++ b/man/step_sqrt.Rd
@@ -85,7 +85,4 @@ Other {individual transformation steps}:
 \code{\link{step_poly}()},
 \code{\link{step_relu}()}
 }
-\concept{preprocessing}
-\concept{transformation_methods}
 \concept{{individual transformation steps}}
-\keyword{datagen}

--- a/man/step_string2factor.Rd
+++ b/man/step_string2factor.Rd
@@ -101,8 +101,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_unknown}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
-\concept{variable_encodings}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_unknown.Rd
+++ b/man/step_unknown.Rd
@@ -105,7 +105,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_string2factor}()},
 \code{\link{step_unorder}()}
 }
-\concept{factors}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -92,7 +92,4 @@ Other {dummy variable and encoding steps}:
 \code{\link{step_string2factor}()},
 \code{\link{step_unknown}()}
 }
-\concept{ordinal_data}
-\concept{preprocessing}
 \concept{{dummy variable and encoding steps}}
-\keyword{datagen}

--- a/man/step_upsample.Rd
+++ b/man/step_upsample.Rd
@@ -96,6 +96,4 @@ When used in modeling, users should strongly consider using the
 option \code{skip = TRUE} so that the extra sampling is \emph{not}
 conducted outside of the training set.
 }
-\concept{preprocessing}
-\concept{subsampling}
 \keyword{internal}

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -136,6 +136,3 @@ ggplot(smoothed_dat, aes(x = original, y = y1)) +
   geom_point() +
   theme_bw()
 }
-\concept{moving_windows}
-\concept{preprocessing}
-\keyword{datagen}

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -84,7 +84,4 @@ Other {variable filter steps}:
 \code{\link{step_rm}()},
 \code{\link{step_select}()}
 }
-\concept{preprocessing}
-\concept{variable_filters}
 \concept{{variable filter steps}}
-\keyword{datagen}

--- a/man/terms_select.Rd
+++ b/man/terms_select.Rd
@@ -42,6 +42,4 @@ terms_select(info = info, quos(all_predictors()))
 \code{\link[=recipe]{recipe()}} \code{\link[=summary.recipe]{summary.recipe()}}
 \code{\link[=prep.recipe]{prep.recipe()}}
 }
-\concept{preprocessing}
-\keyword{datagen}
 \keyword{internal}


### PR DESCRIPTION
Goodbye, somewhat random and uneven use of `@keywords` and `@concept`! :sassy_woman: We will still, of course, continue to use `@keywords internal` but we will now use `@family` instead of these other methods of organizing/linking documentation.

Related to #763 as a followup and continuation of that work.

I believe closes #709 but I would appreciate someone else confirming this.