### PR TITLE
fix name of dials function

### DIFF
--- a/R/window.R
+++ b/R/window.R
@@ -289,7 +289,7 @@ tunable.step_window <- function(x, ...) {
     name = c("statistic", "window"),
     call_info = list(
       list(pkg = "dials", fun = "summary_stat"),
-      list(pkg = "dials", fun = "window")
+      list(pkg = "dials", fun = "window_size")
     ),
     source = "recipe",
     component = "step_window",


### PR DESCRIPTION
This is related to https://github.com/tidymodels/dials/issues/180

the tunable method for `step_window()` was looking for a dials function `dials::window()` however only `dials::window_size()` exists