### PR TITLE
Update doc titles to "preprocessing recipe"

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -628,7 +628,7 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
 #' @author Max Kuhn
 #' @export
 print.recipe <- function(x, form_width = 30, ...) {
-  cat("Data Recipe\n\n")
+  cat("Recipe\n\n")
   cat("Inputs:\n\n")
   no_role <- is.na(x$var_info$role)
   if (any(!no_role)) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -1,4 +1,4 @@
-#' Create a Recipe for Preprocessing Data
+#' Create a recipe for preprocessing data
 #'
 #' A recipe is a description of the steps to be applied to a data set in
 #'   order to prepare it for data analysis.
@@ -241,7 +241,7 @@ inline_check <- function(x) {
 prep <- function(x, ...)
   UseMethod("prep")
 
-#' Estimate a Data Recipe
+#' Estimate a preprocessing recipe
 #'
 #' For a recipe with at least one preprocessing operation, estimate the required
 #'   parameters from a training set that can be later applied to other data
@@ -457,7 +457,7 @@ prep.recipe <-
 bake <- function(object, ...)
   UseMethod("bake")
 
-#' Apply a Trained Data Recipe
+#' Apply a trained preprocessing recipe
 #'
 #' For a recipe with at least one preprocessing operation that has been trained by
 #'   [prep.recipe()], apply the computations to new data.
@@ -663,7 +663,7 @@ print.recipe <- function(x, form_width = 30, ...) {
   invisible(x)
 }
 
-#' Summarize a Recipe
+#' Summarize a recipe
 #'
 #' This function prints the current set of variables/features and some of their
 #' characteristics.
@@ -700,7 +700,7 @@ summary.recipe <- function(object, original = FALSE, ...) {
 }
 
 
-#' Extract Finalized Training Set
+#' Extract transformed training set
 #'
 #' As of `recipes` version 0.1.14, **`juice()` is superseded** in favor of
 #' `bake(object, new_data = NULL)`.

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -3,7 +3,7 @@
 \name{bake}
 \alias{bake}
 \alias{bake.recipe}
-\title{Apply a Trained Data Recipe}
+\title{Apply a trained preprocessing recipe}
 \usage{
 bake(object, ...)
 

--- a/man/juice.Rd
+++ b/man/juice.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/recipe.R
 \name{juice}
 \alias{juice}
-\title{Extract Finalized Training Set}
+\title{Extract transformed training set}
 \usage{
 juice(object, ..., composition = "tibble")
 }

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -3,7 +3,7 @@
 \name{prep}
 \alias{prep}
 \alias{prep.recipe}
-\title{Estimate a Data Recipe}
+\title{Estimate a preprocessing recipe}
 \usage{
 prep(x, ...)
 

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -6,7 +6,7 @@
 \alias{recipe.formula}
 \alias{recipe.data.frame}
 \alias{recipe.matrix}
-\title{Create a Recipe for Preprocessing Data}
+\title{Create a recipe for preprocessing data}
 \usage{
 recipe(x, ...)
 
@@ -158,17 +158,17 @@ linear_sp_sign_wflow <-
   add_recipe(sp_signed)
 
 linear_sp_sign_wflow
-}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+}\if{html}{\out{</div>}}\preformatted{## ══ Workflow ══════════════════════════════════════════════════════════
 ## Preprocessor: Recipe
 ## Model: linear_reg()
 ## 
-## ── Preprocessor ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+## ── Preprocessor ──────────────────────────────────────────────────────
 ## 2 Recipe Steps
 ## 
 ## • step_normalize()
 ## • step_spatialsign()
 ## 
-## ── Model ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+## ── Model ─────────────────────────────────────────────────────────────
 ## Linear Regression Model Specification (regression)
 ## 
 ## Computational engine: lm

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -135,7 +135,7 @@ sp_signed <-
   step_normalize(all_numeric_predictors()) \%>\%
   step_spatialsign(all_numeric_predictors())
 sp_signed
-}\if{html}{\out{</div>}}\preformatted{## Data Recipe
+}\if{html}{\out{</div>}}\preformatted{## Recipe
 ## 
 ## Inputs:
 ## 
@@ -212,7 +212,7 @@ pca_rec <-
 
 Now to estimate the normalization statistics and the PCA loadings:\if{html}{\out{<div class="sourceCode r">}}\preformatted{pca_rec <- prep(pca_rec, training = biomass_tr)
 pca_rec
-}\if{html}{\out{</div>}}\preformatted{## Data Recipe
+}\if{html}{\out{</div>}}\preformatted{## Recipe
 ## 
 ## Inputs:
 ## 

--- a/man/summary.recipe.Rd
+++ b/man/summary.recipe.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/recipe.R
 \name{summary.recipe}
 \alias{summary.recipe}
-\title{Summarize a Recipe}
+\title{Summarize a recipe}
 \usage{
 \method{summary}{recipe}(object, original = FALSE, ...)
 }


### PR DESCRIPTION
Closes #786 

I definitely agree with @EmilHvitfeldt that the phrase is a bit out of place and not consistent with how we now talk about recipes; I took a stab at changed wording here. I also updated to [sentence case for titles](https://style.tidyverse.org/documentation.html#title-and-description).