### PR TITLE
Fix randomness in `recipe()` documentation

### DIFF
--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -236,8 +236,8 @@ prepped or unprepped, to learn more about its components.\if{html}{\out{<div cla
 }\if{html}{\out{</div>}}\preformatted{## # A tibble: 2 × 6
 ##   number operation type      trained skip  id             
 ##    <int> <chr>     <chr>     <lgl>   <lgl> <chr>          
-## 1      1 step      normalize TRUE    FALSE normalize_8WF2w
-## 2      2 step      pca       TRUE    FALSE pca_8BSFb
+## 1      1 step      normalize TRUE    FALSE normalize_AeYA4
+## 2      2 step      pca       TRUE    FALSE pca_Zn1yz
 }
 
 You can also \code{tidy()} recipe \emph{steps} with a \code{number} or \code{id} argument.

--- a/man/rmd/recipes.Rmd
+++ b/man/rmd/recipes.Rmd
@@ -1,5 +1,6 @@
 ```{r startup, include = FALSE}
 options(width = 70)
+set.seed(123)
 
 library(dplyr)
 library(workflows)


### PR DESCRIPTION
So I don't have to continue to remember to ignore this file every time I redocument 