### PR TITLE
Deprecation clean-up

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
 
 * The deprecation of the `preserve` argument to `step_pls()` and `step_dummy()` was escalated from a soft deprecation to regular deprecation. 
 
+* The deprecation of the `options` argument to `step_nzv()` was escalated to a deprecation error.
+
 
 # recipes 0.1.16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@
 
 * `step_kpca()` was un-deprecated.
 
+* The deprecation of the `preserve` argument to `step_pls()` and `step_dummy()` was escalated from a soft deprecation to regular deprecation. 
+
 
 # recipes 0.1.16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
 
 * A bug was fixed where imputed values via bagged trees would have the wrong levels.
 
+* `step_kpca()` was un-deprecated.
+
+
 # recipes 0.1.16
 
 ## New Steps

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -118,7 +118,7 @@ step_dummy <-
            id = rand_id("dummy")) {
 
     if (lifecycle::is_present(preserve)) {
-      lifecycle::deprecate_soft(
+      lifecycle::deprecate_warn(
         "0.1.16",
         "step_dummy(preserve = )",
         "step_dummy(keep_original_cols = )"

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -6,20 +6,14 @@
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param num_comp The number of PCA components to retain as new
-#'  predictors. If `num_comp` is greater than the number of columns
-#'  or the number of possible components, a smaller value will be
-#'  used.
-#' @param options A list of options to
-#'  [kernlab::kpca()]. Defaults are set for the arguments
-#'  `kernel` and `kpar` but others can be passed in.
-#'  **Note** that the arguments `x` and `features`
-#'  should not be passed here (or at all).
-#' @param res An S4 [kernlab::kpca()] object is stored
-#'  here once this preprocessing step has be trained by
-#'  [prep.recipe()].
+#' @param options A list of options to [kernlab::kpca()]. Defaults are set for
+#'  the arguments `kernel` and `kpar` but others can be passed in.
+#'  **Note** that the arguments `x` and `features` should not be passed here
+#'  (or at all).
+#' @param res An S4 [kernlab::kpca()] object is stored here once this
+#'  preprocessing step has be trained by [prep.recipe()].
 #' @template step-return
-#' @keywords internal
+#' @family {multivariate transformation steps}
 #' @export
 #' @details Kernel principal component analysis (kPCA) is an
 #'  extension of a PCA analysis that conducts the calculations in a
@@ -35,15 +29,15 @@
 #' these packages.
 #'
 #' As with ordinary PCA, it is important to standardize the
-#'  variables prior to running PCA (`step_center` and
-#'  `step_scale` can be used for this purpose).
+#'  variables prior to running PCA ([`step_center()`] and
+#'  [`step_scale()`] can be used for this purpose).
 #'
 #' When performing kPCA, the kernel function (and any important
 #'  kernel parameters) must be chosen. The \pkg{kernlab} package is
 #'  used and the reference below discusses the types of kernels
 #'  available and their parameter(s). These specifications can be
 #'  made in the `kernel` and `kpar` slots of the
-#'  `options` argument to `step_kpca`.
+#'  `options` argument to `step_kpca()`.
 #'
 #' The argument `num_comp` controls the number of components that
 #'  will be retained (the original variables that are used to derive
@@ -92,10 +86,6 @@
 #'   tidy(kpca_trans, number = 3)
 #'   tidy(kpca_estimates, number = 3)
 #' }
-#' @seealso [step_pca()] [step_ica()]
-#'   [step_isomap()] [recipe()] [prep.recipe()]
-#'   [bake.recipe()]
-#'
 step_kpca <-
   function(recipe,
            ...,
@@ -110,12 +100,6 @@ step_kpca <-
            id = rand_id("kpca")) {
 
     recipes_pkg_check(required_pkgs.step_kpca())
-    rlang::inform(
-      paste(
-        "`step_kpca()` is deprecated in favor of either `step_kpca_rbf()`",
-        "or `step_kpca_poly()`. It will be removed in future versions."
-      )
-    )
 
     add_step(
       recipe,
@@ -150,7 +134,6 @@ step_kpca_new <-
   }
 
 #' @export
-#' @keywords internal
 prep.step_kpca <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
   check_type(training[, col_names])
@@ -188,7 +171,6 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
 }
 
 #' @export
-#' @keywords internal
 bake.step_kpca <- function(object, new_data, ...) {
   if (object$num_comp > 0) {
     pca_vars <- colnames(environment(object$res@apply)$indata)
@@ -223,7 +205,6 @@ print.step_kpca <- function(x, width = max(20, options()$width - 40), ...) {
 #' @rdname tidy.recipe
 #' @param x A `step_kpca` object
 #' @export
-#' @keywords internal
 tidy.step_kpca <- function(x, ...) {
   if (is_trained(x)) {
     if (x$num_comp > 0) {

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -17,12 +17,12 @@
 #' @export
 #' @details
 #' When performing kPCA with `step_kpca()`, you must choose the kernel
-#' function (and any important kernel parameters). This step uses \pkg{kernlab}
-#' package; the reference below discusses the types of kernels available and
-#' their parameter(s). These specifications can be made in the `kernel` and
-#' `kpar` slots of the `options` argument to `step_kpca()`. Consider using
-#' [step_kpca_rbf()] for a radial basis function kernel or [step_kpca_poly()]
-#' for a polynomial kernel.
+#' function (and any important kernel parameters). This step uses the
+#' \pkg{kernlab} package; the reference below discusses the types of kernels
+#' available and their parameter(s). These specifications can be made in the
+#' `kernel` and `kpar` slots of the `options` argument to `step_kpca()`.
+#' Consider using [step_kpca_rbf()] for a radial basis function kernel or
+#' [step_kpca_poly()] for a polynomial kernel.
 #'
 #' @template kpca-info
 #'

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -1,6 +1,6 @@
 #' Kernel PCA Signal Extraction
 #'
-#' `step_kpca` a *specification* of a recipe step that
+#' `step_kpca` creates a *specification* of a recipe step that
 #'  will convert numeric data into one or more principal components
 #'  using a kernel basis expansion.
 #'
@@ -11,53 +11,20 @@
 #'  **Note** that the arguments `x` and `features` should not be passed here
 #'  (or at all).
 #' @param res An S4 [kernlab::kpca()] object is stored here once this
-#'  preprocessing step has be trained by [prep.recipe()].
+#'  preprocessing step has be trained by [`prep()`][prep.recipe()].
 #' @template step-return
 #' @family {multivariate transformation steps}
 #' @export
-#' @details Kernel principal component analysis (kPCA) is an
-#'  extension of a PCA analysis that conducts the calculations in a
-#'  broader dimensionality defined by a kernel function. For
-#'  example, if a quadratic kernel function were used, each variable
-#'  would be represented by its original values as well as its
-#'  square. This nonlinear mapping is used during the PCA analysis
-#'  and can potentially help find better representations of the
-#'  original data.
+#' @details
+#' When performing kPCA with `step_kpca()`, you must choose the kernel
+#' function (and any important kernel parameters). This step uses \pkg{kernlab}
+#' package; the reference below discusses the types of kernels available and
+#' their parameter(s). These specifications can be made in the `kernel` and
+#' `kpar` slots of the `options` argument to `step_kpca()`. Consider using
+#' [step_kpca_rbf()] for a radial basis function kernel or [step_kpca_poly()]
+#' for a polynomial kernel.
 #'
-#' This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-#' If not installed, the step will stop with a note about installing
-#' these packages.
-#'
-#' As with ordinary PCA, it is important to standardize the
-#'  variables prior to running PCA ([`step_center()`] and
-#'  [`step_scale()`] can be used for this purpose).
-#'
-#' When performing kPCA, the kernel function (and any important
-#'  kernel parameters) must be chosen. The \pkg{kernlab} package is
-#'  used and the reference below discusses the types of kernels
-#'  available and their parameter(s). These specifications can be
-#'  made in the `kernel` and `kpar` slots of the
-#'  `options` argument to `step_kpca()`.
-#'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num_comp < 10`, their names will be `kPC1` -
-#'  `kPC9`. If `num_comp = 101`, the names would be
-#'  `kPC001` - `kPC101`.
-#'
-#' When you [`tidy()`] this step, a tibble with column `terms` (the
-#'  selectors or variables selected) is returned.
-#'
-#' @references Scholkopf, B., Smola, A., and Muller, K. (1997).
-#'  Kernel principal component analysis. *Lecture Notes in
-#'  Computer Science*, 1327, 583-588.
-#'
-#' Karatzoglou, K., Smola, A., Hornik, K., and Zeileis, A. (2004).
-#'  kernlab - An S4 package for kernel methods in R. *Journal
-#'  of Statistical Software*, 11(1), 1-20.
+#' @template kpca-info
 #'
 #' @examples
 #' library(modeldata)

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -1,58 +1,19 @@
 #' Polynomial Kernel PCA Signal Extraction
 #'
-#' `step_kpca_poly` a *specification* of a recipe step that
+#' `step_kpca_poly` creates a *specification* of a recipe step that
 #'  will convert numeric data into one or more principal components
 #'  using a polynomial kernel basis expansion.
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param num_comp The number of PCA components to retain as new
-#'  predictors. If `num_comp` is greater than the number of columns
-#'  or the number of possible components, a smaller value will be
-#'  used.
 #' @param degree,scale_factor,offset Numeric values for the polynomial kernel function.
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
-#'  [prep.recipe()].
+#'  [`prep()`][prep.recipe()].
 #' @template step-return
 #' @family {multivariate transformation steps}
 #' @export
-#' @details Kernel principal component analysis (kPCA) is an
-#'  extension of a PCA analysis that conducts the calculations in a
-#'  broader dimensionality defined by a kernel function. For
-#'  example, if a quadratic kernel function were used, each variable
-#'  would be represented by its original values as well as its
-#'  square. This nonlinear mapping is used during the PCA analysis
-#'  and can potentially help find better representations of the
-#'  original data.
-#'
-#' This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-#' If not installed, the step will stop with a note about installing
-#' these packages.
-#'
-#' As with ordinary PCA, it is important to standardize the
-#'  variables prior to running PCA (`step_center` and
-#'  `step_scale` can be used for this purpose).
-#'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num_comp < 10`, their names will be `kPC1` -
-#'  `kPC9`. If `num_comp = 101`, the names would be
-#'  `kPC001` - `kPC101`.
-#'
-#' When you [`tidy()`] this step, a tibble with column `terms` (the
-#'  selectors or variables selected) is returned.
-#'
-#' @references Scholkopf, B., Smola, A., and Muller, K. (1997).
-#'  Kernel principal component analysis. *Lecture Notes in
-#'  Computer Science*, 1327, 583-588.
-#'
-#' Karatzoglou, K., Smola, A., Hornik, K., and Zeileis, A. (2004).
-#'  kernlab - An S4 package for kernel methods in R. *Journal
-#'  of Statistical Software*, 11(1), 1-20.
+#' @template kpca-info
 #'
 #' @examples
 #' library(modeldata)

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -1,58 +1,19 @@
 #' Radial Basis Function Kernel PCA Signal Extraction
 #'
-#' `step_kpca_rbf` a *specification* of a recipe step that
+#' `step_kpca_rbf` creates a *specification* of a recipe step that
 #'  will convert numeric data into one or more principal components
 #'  using a radial basis function kernel basis expansion.
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param num_comp The number of PCA components to retain as new
-#'  predictors. If `num_comp` is greater than the number of columns
-#'  or the number of possible components, a smaller value will be
-#'  used.
 #' @param sigma A numeric value for the radial basis function parameter.
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
-#'  [prep.recipe()].
+#'  [`prep()`][prep.recipe()].
 #' @template step-return
 #' @family {multivariate transformation steps}
 #' @export
-#' @details Kernel principal component analysis (kPCA) is an
-#'  extension of a PCA analysis that conducts the calculations in a
-#'  broader dimensionality defined by a kernel function. For
-#'  example, if a quadratic kernel function were used, each variable
-#'  would be represented by its original values as well as its
-#'  square. This nonlinear mapping is used during the PCA analysis
-#'  and can potentially help find better representations of the
-#'  original data.
-#'
-#' This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-#' If not installed, the step will stop with a note about installing
-#' these packages.
-#'
-#' As with ordinary PCA, it is important to standardize the
-#'  variables prior to running PCA (`step_center` and
-#'  `step_scale` can be used for this purpose).
-#'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num_comp < 10`, their names will be `kPC1` -
-#'  `kPC9`. If `num_comp = 101`, the names would be
-#'  `kPC001` - `kPC101`.
-#'
-#' When you [`tidy()`] this step, a tibble with column `terms` (the
-#'  selectors or variables selected) is returned.
-#'
-#' @references Scholkopf, B., Smola, A., and Muller, K. (1997).
-#'  Kernel principal component analysis. *Lecture Notes in
-#'  Computer Science*, 1327, 583-588.
-#'
-#' Karatzoglou, K., Smola, A., Hornik, K., and Zeileis, A. (2004).
-#'  kernlab - An S4 package for kernel methods in R. *Journal
-#'  of Statistical Software*, 11(1), 1-20.
+#' @template kpca-info
 #'
 #' @examples
 #' library(modeldata)

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -82,14 +82,12 @@ step_nzv <-
     if (!isTRUE(all.equal(exp_list, options))) {
       freq_cut <- options$freq_cut
       unique_cut <- options$unique_cut
-      message(
-        paste(
-          "The argument `options` is deprecated in favor of `freq_cut`",
-          "and `unique_cut`. options` will be removed in next version."
-        )
+      lifecycle::deprecate_stop(
+        "0.1.7",
+        "step_nzv(options)",
+        details = "Please use the arguments `freq_cut` and `unique_cut` instead."
       )
     }
-
 
     add_step(
       recipe,

--- a/R/pls.R
+++ b/R/pls.R
@@ -124,7 +124,7 @@ step_pls <-
     }
 
     if (lifecycle::is_present(preserve)) {
-      lifecycle::deprecate_soft(
+      lifecycle::deprecate_warn(
         "0.1.16",
         "step_pls(preserve = )",
         "step_pls(keep_original_cols = )"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -90,6 +90,7 @@ reference:
     - step_geodist
     - step_ica
     - step_isomap
+    - step_kpca
     - step_kpca_poly
     - step_kpca_rbf
     - step_mutate_at

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -29,10 +29,7 @@ reference:
     - bake
     - juice
     - selections
-    - starts_with("all_")
     - has_role
-    - has_type
-    - current_info
     - add_role
   - title: Step Functions - Imputation
     contents:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,7 +20,11 @@ figures:
 reference:
   - title: Basic Functions
     contents:
-    - matches("recipe")
+    - recipes
+    - recipe
+    - formula.recipe
+    - print.recipe
+    - summary.recipe
     - prep
     - bake
     - juice
@@ -52,7 +56,8 @@ reference:
     - step_YeoJohnson
   - title: Step Functions - Discretization
     contents:
-    - matches("discreti")
+    - step_discretize
+    - discretize
     - step_cut
   - title: Step Functions - Dummy Variables and Encodings
     contents:

--- a/man-roxygen/kpca-info.R
+++ b/man-roxygen/kpca-info.R
@@ -1,0 +1,39 @@
+#' @details
+#' Kernel principal component analysis (kPCA) is an extension of a PCA analysis
+#' that conducts the calculations in a broader dimensionality defined by a
+#' kernel function. For example, if a quadratic kernel function were used,
+#' each variable would be represented by its original values as well as its
+#' square. This nonlinear mapping is used during the PCA analysis and can
+#' potentially help find better representations of the original data.
+#'
+#' This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
+#' If not installed, the step will stop with a prompt about installing
+#' these packages.
+#'
+#' As with ordinary PCA, it is important to center and scale the variables
+#' prior to computing PCA components ([step_normalize()] can be used for
+#' this purpose).
+#'
+#' The argument `num_comp` controls the number of components that will be
+#' retained; the original variables that are used to derive the components are
+#' removed from the data when `keep_original_cols = FALSE`. The new components
+#' will have names that begin with `prefix` and a sequence of numbers. The
+#' variable names are padded with zeros. For example, if `num_comp < 10`, the
+#' new names will be `kPC1` - `kPC9`. If `num_comp = 101`, the names would be
+#' `kPC001` - `kPC101`.
+#'
+#' When you [`tidy()`][tidy.recipe()] this step, a tibble with column `terms`
+#' (the selectors or variables selected) is returned.
+#'
+#' @references Scholkopf, B., Smola, A., and Muller, K. (1997).
+#'  Kernel principal component analysis. *Lecture Notes in
+#'  Computer Science*, 1327, 583-588.
+#'
+#' Karatzoglou, K., Smola, A., Hornik, K., and Zeileis, A. (2004).
+#'  kernlab - An S4 package for kernel methods in R. *Journal
+#'  of Statistical Software*, 11(1), 1-20.
+
+
+
+
+

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -123,6 +123,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -132,6 +132,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -108,6 +108,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -140,6 +140,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -145,6 +145,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_ica}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -66,12 +66,12 @@ using a kernel basis expansion.
 }
 \details{
 When performing kPCA with \code{step_kpca()}, you must choose the kernel
-function (and any important kernel parameters). This step uses \pkg{kernlab}
-package; the reference below discusses the types of kernels available and
-their parameter(s). These specifications can be made in the \code{kernel} and
-\code{kpar} slots of the \code{options} argument to \code{step_kpca()}. Consider using
-\code{\link[=step_kpca_rbf]{step_kpca_rbf()}} for a radial basis function kernel or \code{\link[=step_kpca_poly]{step_kpca_poly()}}
-for a polynomial kernel.
+function (and any important kernel parameters). This step uses the
+\pkg{kernlab} package; the reference below discusses the types of kernels
+available and their parameter(s). These specifications can be made in the
+\code{kernel} and \code{kpar} slots of the \code{options} argument to \code{step_kpca()}.
+Consider using \code{\link[=step_kpca_rbf]{step_kpca_rbf()}} for a radial basis function kernel or
+\code{\link[=step_kpca_poly]{step_kpca_poly()}} for a polynomial kernel.
 
 Kernel principal component analysis (kPCA) is an extension of a PCA analysis
 that conducts the calculations in a broader dimensionality defined by a

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -31,20 +31,17 @@ the original variables will be used as \emph{predictors} in a model.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{num_comp}{The number of PCA components to retain as new
-predictors. If \code{num_comp} is greater than the number of columns
-or the number of possible components, a smaller value will be
-used.}
+\item{num_comp}{The number of PCA components to retain as new predictors.
+If \code{num_comp} is greater than the number of columns or the number of
+possible components, a smaller value will be used.}
 
-\item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored
-here once this preprocessing step has be trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored here once this
+preprocessing step has be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
 
-\item{options}{A list of options to
-\code{\link[kernlab:kpca]{kernlab::kpca()}}. Defaults are set for the arguments
-\code{kernel} and \code{kpar} but others can be passed in.
-\strong{Note} that the arguments \code{x} and \code{features}
-should not be passed here (or at all).}
+\item{options}{A list of options to \code{\link[kernlab:kpca]{kernlab::kpca()}}. Defaults are set for
+the arguments \code{kernel} and \code{kpar} but others can be passed in.
+\strong{Note} that the arguments \code{x} and \code{features} should not be passed here
+(or at all).}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}
@@ -82,15 +79,15 @@ If not installed, the step will stop with a note about installing
 these packages.
 
 As with ordinary PCA, it is important to standardize the
-variables prior to running PCA (\code{step_center} and
-\code{step_scale} can be used for this purpose).
+variables prior to running PCA (\code{\link[=step_center]{step_center()}} and
+\code{\link[=step_scale]{step_scale()}} can be used for this purpose).
 
 When performing kPCA, the kernel function (and any important
 kernel parameters) must be chosen. The \pkg{kernlab} package is
 used and the reference below discusses the types of kernels
 available and their parameter(s). These specifications can be
 made in the \code{kernel} and \code{kpar} slots of the
-\code{options} argument to \code{step_kpca}.
+\code{options} argument to \code{step_kpca()}.
 
 The argument \code{num_comp} controls the number of components that
 will be retained (the original variables that are used to derive
@@ -142,8 +139,19 @@ kernlab - An S4 package for kernel methods in R. \emph{Journal
 of Statistical Software}, 11(1), 1-20.
 }
 \seealso{
-\code{\link[=step_pca]{step_pca()}} \code{\link[=step_ica]{step_ica()}}
-\code{\link[=step_isomap]{step_isomap()}} \code{\link[=recipe]{recipe()}} \code{\link[=prep.recipe]{prep.recipe()}}
-\code{\link[=bake.recipe]{bake.recipe()}}
+Other {multivariate transformation steps}: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
 }
-\keyword{internal}
+\concept{{multivariate transformation steps}}

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -36,7 +36,7 @@ If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored here once this
-preprocessing step has be trained by \code{\link[=prep.recipe]{prep.recipe()}}.}
+preprocessing step has be trained by \code{\link[=prep.recipe]{prep()}}.}
 
 \item{options}{A list of options to \code{\link[kernlab:kpca]{kernlab::kpca()}}. Defaults are set for
 the arguments \code{kernel} and \code{kpar} but others can be passed in.
@@ -60,46 +60,44 @@ An updated version of \code{recipe} with the new step added to the
 sequence of any existing operations.
 }
 \description{
-\code{step_kpca} a \emph{specification} of a recipe step that
+\code{step_kpca} creates a \emph{specification} of a recipe step that
 will convert numeric data into one or more principal components
 using a kernel basis expansion.
 }
 \details{
-Kernel principal component analysis (kPCA) is an
-extension of a PCA analysis that conducts the calculations in a
-broader dimensionality defined by a kernel function. For
-example, if a quadratic kernel function were used, each variable
-would be represented by its original values as well as its
-square. This nonlinear mapping is used during the PCA analysis
-and can potentially help find better representations of the
-original data.
+When performing kPCA with \code{step_kpca()}, you must choose the kernel
+function (and any important kernel parameters). This step uses \pkg{kernlab}
+package; the reference below discusses the types of kernels available and
+their parameter(s). These specifications can be made in the \code{kernel} and
+\code{kpar} slots of the \code{options} argument to \code{step_kpca()}. Consider using
+\code{\link[=step_kpca_rbf]{step_kpca_rbf()}} for a radial basis function kernel or \code{\link[=step_kpca_poly]{step_kpca_poly()}}
+for a polynomial kernel.
+
+Kernel principal component analysis (kPCA) is an extension of a PCA analysis
+that conducts the calculations in a broader dimensionality defined by a
+kernel function. For example, if a quadratic kernel function were used,
+each variable would be represented by its original values as well as its
+square. This nonlinear mapping is used during the PCA analysis and can
+potentially help find better representations of the original data.
 
 This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-If not installed, the step will stop with a note about installing
+If not installed, the step will stop with a prompt about installing
 these packages.
 
-As with ordinary PCA, it is important to standardize the
-variables prior to running PCA (\code{\link[=step_center]{step_center()}} and
-\code{\link[=step_scale]{step_scale()}} can be used for this purpose).
+As with ordinary PCA, it is important to center and scale the variables
+prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
+this purpose).
 
-When performing kPCA, the kernel function (and any important
-kernel parameters) must be chosen. The \pkg{kernlab} package is
-used and the reference below discusses the types of kernels
-available and their parameter(s). These specifications can be
-made in the \code{kernel} and \code{kpar} slots of the
-\code{options} argument to \code{step_kpca()}.
-
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num_comp < 10}, their names will be \code{kPC1} -
-\code{kPC9}. If \code{num_comp = 101}, the names would be
+The argument \code{num_comp} controls the number of components that will be
+retained; the original variables that are used to derive the components are
+removed from the data when \code{keep_original_cols = FALSE}. The new components
+will have names that begin with \code{prefix} and a sequence of numbers. The
+variable names are padded with zeros. For example, if \code{num_comp < 10}, the
+new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
 \code{kPC001} - \code{kPC101}.
 
-When you \code{\link[=tidy]{tidy()}} this step, a tibble with column \code{terms} (the
-selectors or variables selected) is returned.
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column \code{terms}
+(the selectors or variables selected) is returned.
 }
 \examples{
 library(modeldata)

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -34,14 +34,13 @@ the original variables will be used as \emph{predictors} in a model.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{num_comp}{The number of PCA components to retain as new
-predictors. If \code{num_comp} is greater than the number of columns
-or the number of possible components, a smaller value will be
-used.}
+\item{num_comp}{The number of PCA components to retain as new predictors.
+If \code{num_comp} is greater than the number of columns or the number of
+possible components, a smaller value will be used.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored
 here once this preprocessing step has be trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\code{\link[=prep.recipe]{prep()}}.}
 
 \item{degree, scale_factor, offset}{Numeric values for the polynomial kernel function.}
 
@@ -65,39 +64,36 @@ An updated version of \code{recipe} with the new step added to the
 sequence of any existing operations.
 }
 \description{
-\code{step_kpca_poly} a \emph{specification} of a recipe step that
+\code{step_kpca_poly} creates a \emph{specification} of a recipe step that
 will convert numeric data into one or more principal components
 using a polynomial kernel basis expansion.
 }
 \details{
-Kernel principal component analysis (kPCA) is an
-extension of a PCA analysis that conducts the calculations in a
-broader dimensionality defined by a kernel function. For
-example, if a quadratic kernel function were used, each variable
-would be represented by its original values as well as its
-square. This nonlinear mapping is used during the PCA analysis
-and can potentially help find better representations of the
-original data.
+Kernel principal component analysis (kPCA) is an extension of a PCA analysis
+that conducts the calculations in a broader dimensionality defined by a
+kernel function. For example, if a quadratic kernel function were used,
+each variable would be represented by its original values as well as its
+square. This nonlinear mapping is used during the PCA analysis and can
+potentially help find better representations of the original data.
 
 This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-If not installed, the step will stop with a note about installing
+If not installed, the step will stop with a prompt about installing
 these packages.
 
-As with ordinary PCA, it is important to standardize the
-variables prior to running PCA (\code{step_center} and
-\code{step_scale} can be used for this purpose).
+As with ordinary PCA, it is important to center and scale the variables
+prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
+this purpose).
 
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num_comp < 10}, their names will be \code{kPC1} -
-\code{kPC9}. If \code{num_comp = 101}, the names would be
+The argument \code{num_comp} controls the number of components that will be
+retained; the original variables that are used to derive the components are
+removed from the data when \code{keep_original_cols = FALSE}. The new components
+will have names that begin with \code{prefix} and a sequence of numbers. The
+variable names are padded with zeros. For example, if \code{num_comp < 10}, the
+new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
 \code{kPC001} - \code{kPC101}.
 
-When you \code{\link[=tidy]{tidy()}} this step, a tibble with column \code{terms} (the
-selectors or variables selected) is returned.
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column \code{terms}
+(the selectors or variables selected) is returned.
 }
 \examples{
 library(modeldata)

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -145,6 +145,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_ica}()},
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -143,6 +143,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_ica}()},
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -32,14 +32,13 @@ the original variables will be used as \emph{predictors} in a model.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{num_comp}{The number of PCA components to retain as new
-predictors. If \code{num_comp} is greater than the number of columns
-or the number of possible components, a smaller value will be
-used.}
+\item{num_comp}{The number of PCA components to retain as new predictors.
+If \code{num_comp} is greater than the number of columns or the number of
+possible components, a smaller value will be used.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored
 here once this preprocessing step has be trained by
-\code{\link[=prep.recipe]{prep.recipe()}}.}
+\code{\link[=prep.recipe]{prep()}}.}
 
 \item{sigma}{A numeric value for the radial basis function parameter.}
 
@@ -63,39 +62,36 @@ An updated version of \code{recipe} with the new step added to the
 sequence of any existing operations.
 }
 \description{
-\code{step_kpca_rbf} a \emph{specification} of a recipe step that
+\code{step_kpca_rbf} creates a \emph{specification} of a recipe step that
 will convert numeric data into one or more principal components
 using a radial basis function kernel basis expansion.
 }
 \details{
-Kernel principal component analysis (kPCA) is an
-extension of a PCA analysis that conducts the calculations in a
-broader dimensionality defined by a kernel function. For
-example, if a quadratic kernel function were used, each variable
-would be represented by its original values as well as its
-square. This nonlinear mapping is used during the PCA analysis
-and can potentially help find better representations of the
-original data.
+Kernel principal component analysis (kPCA) is an extension of a PCA analysis
+that conducts the calculations in a broader dimensionality defined by a
+kernel function. For example, if a quadratic kernel function were used,
+each variable would be represented by its original values as well as its
+square. This nonlinear mapping is used during the PCA analysis and can
+potentially help find better representations of the original data.
 
 This step requires the \pkg{dimRed} and \pkg{kernlab} packages.
-If not installed, the step will stop with a note about installing
+If not installed, the step will stop with a prompt about installing
 these packages.
 
-As with ordinary PCA, it is important to standardize the
-variables prior to running PCA (\code{step_center} and
-\code{step_scale} can be used for this purpose).
+As with ordinary PCA, it is important to center and scale the variables
+prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
+this purpose).
 
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num_comp < 10}, their names will be \code{kPC1} -
-\code{kPC9}. If \code{num_comp = 101}, the names would be
+The argument \code{num_comp} controls the number of components that will be
+retained; the original variables that are used to derive the components are
+removed from the data when \code{keep_original_cols = FALSE}. The new components
+will have names that begin with \code{prefix} and a sequence of numbers. The
+variable names are padded with zeros. For example, if \code{num_comp < 10}, the
+new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
 \code{kPC001} - \code{kPC101}.
 
-When you \code{\link[=tidy]{tidy()}} this step, a tibble with column \code{terms} (the
-selectors or variables selected) is returned.
+When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column \code{terms}
+(the selectors or variables selected) is returned.
 }
 \examples{
 library(modeldata)

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -80,6 +80,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -121,6 +121,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -139,6 +139,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pls}()},

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -171,6 +171,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -109,6 +109,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -106,6 +106,7 @@ Other {multivariate transformation steps}:
 \code{\link{step_isomap}()},
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},

--- a/man/tidy.recipe.Rd
+++ b/man/tidy.recipe.Rd
@@ -326,4 +326,3 @@ okc_rec_trained <- prep(okc_rec, training = okc)
 tidy(okc_rec_trained)
 tidy(okc_rec_trained, number = 3)
 }
-\keyword{internal}

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -2,21 +2,15 @@
 
     Code
       kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6, id = "")
-    Message <message>
-      `step_kpca()` is deprecated in favor of either `step_kpca_rbf()` or `step_kpca_poly()`. It will be removed in future versions.
 
 # printing
 
     Code
       kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6)
-    Message <message>
-      `step_kpca()` is deprecated in favor of either `step_kpca_rbf()` or `step_kpca_poly()`. It will be removed in future versions.
 
 # No kPCA comps
 
     Code
       pca_extract <- rec %>% step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
         prep()
-    Message <message>
-      `step_kpca()` is deprecated in favor of either `step_kpca_rbf()` or `step_kpca_poly()`. It will be removed in future versions.
 

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -1,8 +1,3 @@
-# correct kernel PCA values
-
-    Code
-      kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6, id = "")
-
 # printing
 
     Code

--- a/tests/testthat/_snaps/nzv.md
+++ b/tests/testthat/_snaps/nzv.md
@@ -1,0 +1,5 @@
+# altered freq_cut and unique_cut
+
+    The `options` argument of `step_nzv()` was deprecated in recipes 0.1.7 and is now defunct.
+    Please use the arguments `freq_cut` and `unique_cut` instead.
+

--- a/tests/testthat/test_kpca.R
+++ b/tests/testthat/test_kpca.R
@@ -15,10 +15,7 @@ test_that('correct kernel PCA values', {
   skip_if_not_installed("dimRed")
   skip_if_not_installed("kernlab")
 
-  # Capture deprecation message
-  expect_snapshot(
-    kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6, id = "")
-  )
+  kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6, id = "")
 
   kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
 

--- a/tests/testthat/test_nzv.R
+++ b/tests/testthat/test_nzv.R
@@ -42,14 +42,16 @@ test_that('nzv filtering', {
   expect_equal(filtering_trained$steps[[1]]$removals, removed)
 })
 
-test_that('altered options', {
+test_that('altered freq_cut and unique_cut', {
   rec <- recipe(y ~ ., data = dat)
 
-  expect_message(
-    filtering <- rec %>%
-      step_nzv(x1, x2, x3, x4, options = list(freq_cut = 50, unique_cut = 10)),
-    "deprecated in favor of"
+  expect_snapshot_error(
+    rec %>%
+      step_nzv(x1, x2, x3, x4, options = list(freq_cut = 50, unique_cut = 10))
   )
+
+  filtering <- rec %>%
+    step_nzv(x1, x2, x3, x4, freq_cut = 50, unique_cut = 10)
 
   filtering_trained <- prep(filtering, training = dat, verbose = FALSE)
 


### PR DESCRIPTION
This PR does a few things with regard to deprecation and sneaks in a bonus clean-up of the pkgdown site:

* undoes the deprecation of `step_kpca()`; closes #762
* escalates the deprecation of the `preserve` argument to `step_pls()` and `step_dummy()`
* adds lifecycle-style deprecation for the `options` argument to `step_nzv()` so it won't get overlooked next time 
* tidies up the pkgdown site so that the newly exported `recipes_eval_select()` shows up in the section for internal tools rather than at the top and removes the quadruplication of the section on selection via role

The imputation steps and the steps for up/downsampling were already in the correct stage of the deprecation process.