### PR TITLE
Add `keep_original_cols` to `step_kpca()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 
 * A bug was fixed where imputed values via bagged trees would have the wrong levels.
 
-* `step_kpca()` was un-deprecated.
+* `step_kpca()` was un-deprecated and gained the `keep_original_cols` argument.
 
 * The deprecation of the `preserve` argument to `step_pls()` and `step_dummy()` was escalated from a soft deprecation to regular deprecation. 
 

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -63,6 +63,7 @@ step_kpca <-
            options = list(kernel = "rbfdot",
                           kpar = list(sigma = 0.2)),
            prefix = "kPC",
+           keep_original_cols = FALSE,
            skip = FALSE,
            id = rand_id("kpca")) {
 
@@ -78,6 +79,7 @@ step_kpca <-
         res = res,
         options = options,
         prefix = prefix,
+        keep_original_cols = keep_original_cols,
         skip = skip,
         id = id
       )
@@ -85,7 +87,8 @@ step_kpca <-
 }
 
 step_kpca_new <-
-  function(terms, role, trained, num_comp, res, options, prefix, skip, id) {
+  function(terms, role, trained, num_comp, res, options, prefix,
+           keep_original_cols, skip, id) {
     step(
       subclass = "kpca",
       terms = terms,
@@ -95,6 +98,7 @@ step_kpca_new <-
       res = res,
       options = options,
       prefix = prefix,
+      keep_original_cols = keep_original_cols,
       skip = skip,
       id = id
     )
@@ -132,6 +136,7 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
     options = x$options,
     res = kprc,
     prefix = x$prefix,
+    keep_original_cols = get_keep_original_cols(x),
     skip = x$skip,
     id = x$id
   )
@@ -147,7 +152,11 @@ bake.step_kpca <- function(object, new_data, ...) {
     comps <- comps[, 1:object$num_comp, drop = FALSE]
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))
-    new_data <- new_data[, !(colnames(new_data) %in% pca_vars), drop = FALSE]
+    keep_original_cols <- get_keep_original_cols(object)
+
+    if (!keep_original_cols) {
+      new_data <- new_data[, !(colnames(new_data) %in% pca_vars), drop = FALSE]
+    }
   }
   as_tibble(new_data)
 }

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -13,6 +13,7 @@ step_kpca(
   res = NULL,
   options = list(kernel = "rbfdot", kpar = list(sigma = 0.2)),
   prefix = "kPC",
+  keep_original_cols = FALSE,
   skip = FALSE,
   id = rand_id("kpca")
 )
@@ -45,6 +46,9 @@ the arguments \code{kernel} and \code{kpar} but others can be passed in.
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}
+
+\item{keep_original_cols}{A logical to keep the original variables in the
+output. Defaults to \code{FALSE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/tests/testthat/_snaps/kpca_poly.md
+++ b/tests/testthat/_snaps/kpca_poly.md
@@ -1,11 +1,6 @@
 # printing
 
     Code
-      kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6)
-
----
-
-    Code
       kpca_rec
     Output
       Recipe
@@ -18,14 +13,14 @@
       
       Operations:
       
-      Kernel PCA extraction with X2, X3, X4, X5, X6
+      Polynomial kernel PCA extraction with X2, X3, X4, X5, X6
 
 ---
 
     Code
       prep(kpca_rec, training = tr_dat, verbose = TRUE)
     Output
-      oper 1 step kpca [training] 
+      oper 1 step kpca poly [training] 
       The retained training set is ~ 0.01 Mb  in memory.
       
       Recipe
@@ -40,15 +35,9 @@
       
       Operations:
       
-      Kernel PCA (rbfdot) extraction with X2, X3, X4, X5, X6 [trained]
+      Polynomial kernel PCA (polydot) extraction with X2, X3, X4, X5, X6 [trained]
 
 # No kPCA comps
-
-    Code
-      pca_extract <- rec %>% step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
-        prep()
-
----
 
     Code
       pca_extract
@@ -73,6 +62,6 @@
     Code
       kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
     Warning <warning>
-      'keep_original_cols' was added to `step_kpca()` after this recipe was created.
+      'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/_snaps/kpca_rbf.md
+++ b/tests/testthat/_snaps/kpca_rbf.md
@@ -1,11 +1,6 @@
 # printing
 
     Code
-      kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6)
-
----
-
-    Code
       kpca_rec
     Output
       Recipe
@@ -18,14 +13,14 @@
       
       Operations:
       
-      Kernel PCA extraction with X2, X3, X4, X5, X6
+      RBF kernel PCA extraction with X2, X3, X4, X5, X6
 
 ---
 
     Code
       prep(kpca_rec, training = tr_dat, verbose = TRUE)
     Output
-      oper 1 step kpca [training] 
+      oper 1 step kpca rbf [training] 
       The retained training set is ~ 0.01 Mb  in memory.
       
       Recipe
@@ -40,15 +35,9 @@
       
       Operations:
       
-      Kernel PCA (rbfdot) extraction with X2, X3, X4, X5, X6 [trained]
+      RBF kernel PCA (rbfdot) extraction with X2, X3, X4, X5, X6 [trained]
 
 # No kPCA comps
-
-    Code
-      pca_extract <- rec %>% step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
-        prep()
-
----
 
     Code
       pca_extract
@@ -73,6 +62,6 @@
     Code
       kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
     Warning <warning>
-      'keep_original_cols' was added to `step_kpca()` after this recipe was created.
+      'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/test_kpca.R
+++ b/tests/testthat/test_kpca.R
@@ -50,8 +50,8 @@ test_that('printing', {
     kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6)
   )
 
-  expect_output(print(kpca_rec))
-  expect_output(prep(kpca_rec, training = tr_dat, verbose = TRUE))
+  expect_snapshot(kpca_rec)
+  expect_snapshot(prep(kpca_rec, training = tr_dat, verbose = TRUE))
 })
 
 
@@ -67,8 +67,7 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_true(inherits(pca_extract$steps[[1]]$res, "list"))
-  expect_output(print(pca_extract),
-                regexp = "No kPCA components were extracted")
+  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
@@ -105,9 +104,8 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_warning(
+  expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
-    "'keep_original_cols' was added to"
   )
 
   expect_error(

--- a/tests/testthat/test_kpca.R
+++ b/tests/testthat/test_kpca.R
@@ -74,3 +74,45 @@ test_that('No kPCA comps', {
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
 })
+
+
+test_that('keep_original_cols works', {
+
+  skip_if_not_installed("dimRed")
+  skip_if_not_installed("kernlab")
+
+  kpca_rec <- rec %>%
+    step_kpca(X2, X3, X4, X5, X6, id = "", keep_original_cols = TRUE)
+
+  kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+
+  pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors())
+
+  expect_equal(
+    colnames(pca_pred),
+    c("X2", "X3", "X4", "X5", "X6",
+      "kPC1", "kPC2", "kPC3", "kPC4", "kPC5")
+  )
+
+})
+
+test_that('can prep recipes with no keep_original_cols', {
+  skip_if_not_installed("dimRed")
+  skip_if_not_installed("kernlab")
+
+  kpca_rec <- rec %>%
+    step_kpca(X2, X3, X4, X5, X6, id = "")
+
+  kpca_rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_warning(
+    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
+    "'keep_original_cols' was added to"
+  )
+
+  expect_error(
+    pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
+    NA
+  )
+
+})

--- a/tests/testthat/test_kpca_poly.R
+++ b/tests/testthat/test_kpca_poly.R
@@ -47,8 +47,8 @@ test_that('printing', {
 
   kpca_rec <- rec %>%
     step_kpca_poly(X2, X3, X4, X5, X6)
-  expect_output(print(kpca_rec))
-  expect_output(prep(kpca_rec, training = tr_dat, verbose = TRUE))
+  expect_snapshot(kpca_rec)
+  expect_snapshot(prep(kpca_rec, training = tr_dat, verbose = TRUE))
 })
 
 
@@ -62,8 +62,7 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_true(inherits(pca_extract$steps[[1]]$res, "list"))
-  expect_output(print(pca_extract),
-                regexp = "No kPCA components were extracted")
+  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
@@ -115,9 +114,8 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_warning(
+  expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
-    "'keep_original_cols' was added to"
   )
 
   expect_error(

--- a/tests/testthat/test_kpca_rbf.R
+++ b/tests/testthat/test_kpca_rbf.R
@@ -47,8 +47,8 @@ test_that('printing', {
 
   kpca_rec <- rec %>%
     step_kpca_rbf(X2, X3, X4, X5, X6)
-  expect_output(print(kpca_rec))
-  expect_output(prep(kpca_rec, training = tr_dat, verbose = TRUE))
+  expect_snapshot(kpca_rec)
+  expect_snapshot(prep(kpca_rec, training = tr_dat, verbose = TRUE))
 })
 
 
@@ -62,8 +62,7 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_true(inherits(pca_extract$steps[[1]]$res, "list"))
-  expect_output(print(pca_extract),
-                regexp = "No kPCA components were extracted")
+  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
@@ -115,9 +114,8 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_warning(
+  expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
-    "'keep_original_cols' was added to"
   )
 
   expect_error(


### PR DESCRIPTION
Closes #808 

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
library(modeldata)
data(biomass)

biomass_tr <- biomass[biomass$dataset == "Training",]

rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
              data = biomass_tr) %>%
  step_YeoJohnson(all_numeric_predictors()) %>%
  step_normalize(all_numeric_predictors()) 

rec %>%
  step_kpca(all_numeric_predictors(), keep_original_cols = TRUE) %>%
  prep() %>% juice()
#> # A tibble: 456 × 11
#>     carbon hydrogen   oxygen nitrogen sulfur   HHV   kPC1  kPC2   kPC3    kPC4
#>      <dbl>    <dbl>    <dbl>    <dbl>  <dbl> <dbl>  <dbl> <dbl>  <dbl>   <dbl>
#>  1  0.250    0.0610  0.368     -0.577 -1.23   20.0 -11.5  -2.51 -3.78   1.04  
#>  2  0.219    0.120   0.178     -1.11  -1.23   19.2 -13.6   1.51 -1.87   0.781 
#>  3  0.0469   0.221   0.770     -1.40  -0.966  18.3 -13.3   3.48  1.88   1.45  
#>  4 -0.245   -0.562  -0.439      1.67   0.298  18.2  11.1  -1.94 -5.81  -3.21  
#>  5 -0.0649  -0.170   0.112      0.361 -0.966  18.4  -2.52 -8.48 -7.85  -1.88  
#>  6 -0.212    0.170   0.0532     1.18  -0.145  18.5   8.46 -8.41 -5.03   1.93  
#>  7 -0.0214   0.415  -0.168      1.47   0.535  18.7  12.3  -3.92 -1.86   4.53  
#>  8 -0.179    0.120  -0.00253    0.976  0.535  18.3  10.9  -6.50  0.943  0.0802
#>  9  0.148   -0.0751  0.132      0.106 -1.23   18.6  -5.99 -6.51 -7.97  -0.0517
#> 10 -0.0288   0.322   0.0309     0.573 -0.145  18.9   4.00 -9.88 -1.72   1.64  
#> # … with 446 more rows, and 1 more variable: kPC5 <dbl>
rec %>%
  step_kpca(all_numeric_predictors(), keep_original_cols = FALSE) %>%
  prep() %>% juice()
#> # A tibble: 456 × 6
#>      HHV   kPC1  kPC2   kPC3    kPC4   kPC5
#>    <dbl>  <dbl> <dbl>  <dbl>   <dbl>  <dbl>
#>  1  20.0 -11.5  -2.51 -3.78   1.04   -0.856
#>  2  19.2 -13.6   1.51 -1.87   0.781   2.24 
#>  3  18.3 -13.3   3.48  1.88   1.45    0.271
#>  4  18.2  11.1  -1.94 -5.81  -3.21    4.79 
#>  5  18.4  -2.52 -8.48 -7.85  -1.88   -3.23 
#>  6  18.5   8.46 -8.41 -5.03   1.93    0.684
#>  7  18.7  12.3  -3.92 -1.86   4.53    6.34 
#>  8  18.3  10.9  -6.50  0.943  0.0802  4.09 
#>  9  18.6  -5.99 -6.51 -7.97  -0.0517 -2.75 
#> 10  18.9   4.00 -9.88 -1.72   1.64    1.26 
#> # … with 446 more rows
```

<sup>Created on 2021-09-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>