### PR TITLE
Speedup of `estimate_yj()`

### DIFF
--- a/man/recipes-internal.Rd
+++ b/man/recipes-internal.Rd
@@ -10,7 +10,7 @@
 \alias{sel2char}
 \title{Internal Functions}
 \usage{
-yj_transform(x, lambda, eps = 0.001)
+yj_transform(x, lambda, ind_neg = NULL, eps = 0.001)
 
 estimate_yj(dat, limits = c(-5, 5), num_unique = 5, na_rm = TRUE)
 


### PR DESCRIPTION
This PR attempts to close #782.

It does a couple of different things to reduce the running time.

- Reduces the number of functions that check for missing values
- Remove unused calculations: https://github.com/tidymodels/recipes/compare/speedy-YeoJohnson#diff-7cb7bdc602ef55153be9c1a29e23cc4a90cc80452d022f6b28898bfffc4211c1L194
- Calculate objects and passing them into `yj_obj()` instead of having them be recalculated every iteration of `optimize()`.

These changes don't change the behavior of the function `estimate_yj()`, e.i. the result should remain unchanged.

I tried to do minimal changes to the formatting of this code. I can lint the code as well if you want.

Speedup reprex below:

``` r
set.seed(123)
bench::press(
  n = 10 ^ (2:6),
  {
    data <- rgamma(n, 1, 1)
    bench::mark(iterations = 10,
      old = recipes::estimate_yj(data),
      new = estimate_yj(data)
    )
  }
)

#> # A tibble: 10 × 7
#>    expression       n      min   median `itr/sec` mem_alloc `gc/sec`
#>    <bch:expr>   <dbl> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#>  1 old            100 463.03µs 498.83µs  1996.      89.68MB     0   
#>  2 new            100 346.45µs 355.72µs  2728.     985.81KB     0   
#>  3 old           1000   1.25ms   1.28ms   737.       1.27MB     0   
#>  4 new           1000 762.58µs 868.37µs  1169.     346.21KB     0   
#>  5 old          10000  10.94ms  13.13ms    74.9     12.69MB    32.1 
#>  6 new          10000   5.16ms   5.55ms   181.       3.41MB    20.1 
#>  7 old         100000 115.26ms 129.52ms     7.88   126.52MB    31.5 
#>  8 new         100000  51.41ms  57.82ms    17.4     33.81MB    20.9 
#>  9 old        1000000    1.34s    1.55s     0.645    1.23GB    13.9 
#> 10 new        1000000  639.9ms 678.57ms     1.44   336.07MB     8.65
```

<sup>Created on 2021-09-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>