### PR TITLE
Adjust `expect_warning()` tests to capture objects

### DIFF
--- a/tests/testthat/test_corr.R
+++ b/tests/testthat/test_corr.R
@@ -38,11 +38,10 @@ test_that('many missing values', {
   filtering <- rec %>%
     step_corr(all_predictors(), threshold = .25)
 
-  filtering_trained <-
-    expect_warning(
-      prep(filtering, training = dat2, verbose = FALSE),
-      "1 columns were excluded from the filter"
-    )
+  expect_warning(
+    filtering_trained <- prep(filtering, training = dat2, verbose = FALSE),
+    "1 columns were excluded from the filter"
+  )
 
   expect_equal(filtering_trained$steps[[1]]$removals, paste0("V", 1:2))
 })
@@ -55,11 +54,10 @@ test_that('occasional missing values', {
   filtering <- rec %>%
     step_corr(all_predictors(), threshold = .25, use = "everything")
 
-  filtering_trained <-
-    expect_warning(
-      prep(filtering, training = dat3, verbose = FALSE),
-      "Some columns were excluded from the filter"
-    )
+  expect_warning(
+    filtering_trained <- prep(filtering, training = dat3, verbose = FALSE),
+    "Some columns were excluded from the filter"
+  )
 
   expect_equal(filtering_trained$steps[[1]]$removals, "V2")
 })

--- a/tests/testthat/test_interact.R
+++ b/tests/testthat/test_interact.R
@@ -195,7 +195,7 @@ test_that('missing columns', {
     rec %>%
     step_rm(x1) %>%
     step_interact(~x1:x2)
-  no_fail_rec <- expect_warning(prep(no_fail, dat_tr))
+  expect_warning(no_fail_rec <- prep(no_fail, dat_tr))
   no_fail_res <- juice(no_fail_rec) %>% names()
   expect_true(!any(grepl("_x_", no_fail_res)))
 
@@ -204,7 +204,7 @@ test_that('missing columns', {
     step_rm(x1) %>%
     step_interact(~x1:x2) %>%
     step_interact(~x3:x2)
-  one_int_rec <- expect_warning(prep(one_int, dat_tr))
+  expect_warning(one_int_rec <- prep(one_int, dat_tr))
   one_int_res <- juice(one_int_rec) %>% names()
   expect_true(sum(grepl("_x_", one_int_res)) == 1)
 

--- a/tests/testthat/test_roles.R
+++ b/tests/testthat/test_roles.R
@@ -277,49 +277,41 @@ test_that("can use tidyselect ops in role selection", {
 test_that("empty dots and zero column selections return input with a warning", {
   rec <- recipe(x = biomass)
 
-  expect_identical(
-    expect_warning(
-      add_role(rec),
-      "No columns were selected in `add_role[(][)]`"
-    ),
-    rec
+  expect_warning(
+    rec2 <- add_role(rec),
+    "No columns were selected in `add_role[(][)]`"
   )
-  expect_identical(
-    expect_warning(
-      update_role(rec),
-      "No columns were selected in `update_role[(][)]`"
-    ),
-    rec
-  )
-  expect_identical(
-    expect_warning(
-      remove_role(rec, old_role = "foo"),
-      "No columns were selected in `remove_role[(][)]`"
-    ),
-    rec
-  )
+  expect_identical(rec2, rec)
 
-  expect_identical(
-    expect_warning(
-      add_role(rec, starts_with("foobar")),
-      "No columns were selected in `add_role[(][)]`"
-    ),
-    rec
+  expect_warning(
+    rec2 <- update_role(rec),
+    "No columns were selected in `update_role[(][)]`"
   )
-  expect_identical(
-    expect_warning(
-      update_role(rec, starts_with("foobar")),
-      "No columns were selected in `update_role[(][)]`"
-    ),
-    rec
+  expect_identical(rec2, rec)
+
+  expect_warning(
+    rec2 <- remove_role(rec, old_role = "foo"),
+    "No columns were selected in `remove_role[(][)]`"
   )
-  expect_identical(
-    expect_warning(
-      remove_role(rec, starts_with("foobar"), old_role = "foo"),
-      "No columns were selected in `remove_role[(][)]`"
-    ),
-    rec
+  expect_identical(rec2, rec)
+
+  expect_warning(
+    rec2 <- add_role(rec, starts_with("foobar")),
+    "No columns were selected in `add_role[(][)]`"
   )
+  expect_identical(rec2, rec)
+
+  expect_warning(
+    rec2 <- update_role(rec, starts_with("foobar")),
+    "No columns were selected in `update_role[(][)]`"
+  )
+  expect_identical(rec2, rec)
+
+  expect_warning(
+    rec2 <- remove_role(rec, starts_with("foobar"), old_role = "foo"),
+    "No columns were selected in `remove_role[(][)]`"
+  )
+  expect_identical(rec2, rec)
 })
 
 test_that('bad args', {


### PR DESCRIPTION
@topepo these changes correspond to this breaking change in testthat https://testthat.r-lib.org/news/index.html#breaking-changes