### PR TITLE
Speedup for `step_BoxCox()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Improved the efficiency of computations for the Box-Cox transformation (#820).
+
 # recipes 0.1.17
 
 ## New Steps

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -177,7 +177,6 @@ ll_bc <- function(lambda, y, gm, eps = .001) {
 
 ## eliminates missing data and returns -llh
 bc_obj <- function(lam, dat, geo_mean) {
-  dat <- dat[complete.cases(dat)]
   ll_bc(lambda = lam, y = dat, gm = geo_mean)
 }
 
@@ -190,7 +189,7 @@ estimate_bc <- function(dat,
   if (length(unique(dat)) < num_unique) {
     rlang::warn("Fewer than `num_unique` values in selected variable.")
     return(NA)
-  } else if (any(dat[complete.cases(dat)] <= 0)) {
+  } else if (any(dat <= 0)) {
     rlang::warn("Non-positive values in selected variable.")
     return(NA)
   }

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -176,9 +176,8 @@ ll_bc <- function(lambda, y, gm, eps = .001) {
 
 
 ## eliminates missing data and returns -llh
-bc_obj <- function(lam, dat) {
+bc_obj <- function(lam, dat, geo_mean) {
   dat <- dat[complete.cases(dat)]
-  geo_mean <- exp(mean(log(dat)))
   ll_bc(lambda = lam, y = dat, gm = geo_mean)
 }
 
@@ -195,11 +194,15 @@ estimate_bc <- function(dat,
     rlang::warn("Non-positive values in selected variable.")
     return(NA)
   }
+
+  geo_mean <- exp(mean(log(dat)))
+
   res <- optimize(
     bc_obj,
     interval = limits,
     maximum = TRUE,
     dat = dat,
+    geo_mean = geo_mean,
     tol = .0001
   )
   lam <- res$maximum


### PR DESCRIPTION
This PR will close #814. It doesn't change computation, just removes some unnecessary missing data adjustments and precomputes the geometric meann

```r
set.seed(123)
df = data.frame(x = rgamma(2e6, 1, 1))

new = function(df) {
  rec = recipes::recipe( ~ ., data = df)
  rec = recipes::step_BoxCox(rec, x)
  estimates = recipes::prep(rec, training = df, retain = TRUE)
  recipes::bake(estimates, new_data = NULL)
}

results = bench::mark(
  new = new(df)
)
results
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new           1.25s    1.25s     0.802     386MB     5.61

```