### PR TITLE
add textrecipes_tokenlist to var_types in get_types()

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -15,7 +15,8 @@ get_types <- function(x) {
       logical = "logical",
       Date = "date",
       POSIXct = "date",
-      list = "list"
+      list = "list",
+      textrecipes_tokenlist = "tokenlist"
     )
 
   classes <- lapply(x, class)


### PR DESCRIPTION
This PR adds the case for `textrecipes_tokenlist` vectors in `get_types()` such that I can write `all_tokenized_predictors()` for https://github.com/tidymodels/textrecipes/issues/132.