### PR TITLE
fix step_harmonic printing bug issue #822

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Improvements and Other Changes
 
+* Fixed bug in `step_harmonic()` printing and changed defaults to `role = "predictor"` and `keep_original_cols = FALSE` (#822).
+
 * Improved the efficiency of computations for the Box-Cox transformation (#820).
 
 * All recipe steps now officially support empty selections to be more aligned with dplyr and other packages that use tidyselect (#603, #531). For example, if a previous step removed all of the columns need for a later step, the recipe does not fail when it is estimated (with the exception of `step_mutate()`). The documentation in `?selections` has been updated with advice for writing selectors when filtering steps are used. (#813) 

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -131,12 +131,13 @@
 step_harmonic <-
   function(recipe,
            ...,
-           role = NA,
+           role = "predictor",
            trained = FALSE,
            frequency = NA_real_,
            cycle_size = NA_real_,
            starting_val = NA_real_,
-           keep_original_cols = TRUE,
+           keep_original_cols = FALSE,
+           columns = NULL,
            skip = FALSE,
            id = rand_id("harmonic")) {
 
@@ -161,6 +162,7 @@ step_harmonic <-
         cycle_size = cycle_size,
         starting_val = starting_val,
         keep_original_cols = keep_original_cols,
+        columns = columns,
         skip = skip,
         id = id
       )
@@ -181,6 +183,7 @@ step_harmonic_new <-
       cycle_size = cycle_size,
       starting_val = starting_val,
       keep_original_cols = keep_original_cols,
+      columns = columns,
       skip = skip,
       id = id
     )
@@ -238,6 +241,7 @@ prep.step_harmonic <- function(x, training, info = NULL, ...) {
     cycle_size = cycle_sizes,
     starting_val = starting_vals,
     keep_original_cols = get_keep_original_cols(x),
+    columns = col_names,
     skip = x$skip,
     id = x$id
   )
@@ -309,8 +313,7 @@ bake.step_harmonic <- function(object, new_data, ...) {
 print.step_harmonic <-
   function(x, width = max(20, options()$width - 30), ...) {
     cat("Harmonic numeric variables for ", sep = "")
-    printer(tr_obj = names(x$object), untr_obj = x$terms,
-            trained = x$trained, width = width)
+    printer(x$columns, x$terms, x$trained, width = width)
     invisible(x)
   }
 

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -3,8 +3,8 @@
 #' `step_harmonic` creates a *specification* of a recipe step that
 #'   will add sin and cos terms for harmonic analysis.
 #'
-#' @inheritParams step_date
 #' @inheritParams step_pca
+#' @inheritParams step_date
 #' @inheritParams step_center
 #'
 #' @param ... One or more selector functions to choose variables

--- a/man/step_harmonic.Rd
+++ b/man/step_harmonic.Rd
@@ -48,11 +48,10 @@ over the signal phase.  If \code{starting_val} is not specified the default
 is 0.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{TRUE}.}
+output. Defaults to \code{FALSE}.}
 
-\item{columns}{A character string of variables that will be
-used as inputs. This field is a placeholder and will be
-populated once \code{\link[=prep.recipe]{prep.recipe()}} is used.}
+\item{columns}{A character string of variable names that will
+be populated elsewhere.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/man/step_harmonic.Rd
+++ b/man/step_harmonic.Rd
@@ -7,12 +7,13 @@
 step_harmonic(
   recipe,
   ...,
-  role = NA,
+  role = "predictor",
   trained = FALSE,
   frequency = NA_real_,
   cycle_size = NA_real_,
   starting_val = NA_real_,
-  keep_original_cols = TRUE,
+  keep_original_cols = FALSE,
+  columns = NULL,
   skip = FALSE,
   id = rand_id("harmonic")
 )
@@ -48,6 +49,10 @@ is 0.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{TRUE}.}
+
+\item{columns}{A character string of variables that will be
+used as inputs. This field is a placeholder and will be
+populated once \code{\link[=prep.recipe]{prep.recipe()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake.recipe]{bake.recipe()}}? While all operations are baked

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -1,3 +1,42 @@
+# printing
+
+    Code
+      print(with_harmonic)
+    Output
+      Recipe
+      
+      Inputs:
+      
+            role #variables
+         outcome          1
+       predictor         10
+      
+      Operations:
+      
+      Harmonic numeric variables for hp
+
+---
+
+    Code
+      prep(with_harmonic, training = mtcars, verbose = TRUE)
+    Output
+      oper 1 step harmonic [training] 
+      The retained training set is ~ 0.01 Mb  in memory.
+      
+      Recipe
+      
+      Inputs:
+      
+            role #variables
+         outcome          1
+       predictor         10
+      
+      Training data contained 32 data points and no missing data.
+      
+      Operations:
+      
+      Harmonic numeric variables for hp [trained]
+
 # empty printing
 
     Code

--- a/tests/testthat/test_harmonic.R
+++ b/tests/testthat/test_harmonic.R
@@ -76,12 +76,11 @@ test_that("harmonic frequencies", {
   rec <- recipe(osc ~ time_var, data = harmonic_dat) %>%
     step_harmonic(time_var,
                   frequency = c(1, 1.93, 2),
-                  cycle_size = 86400,
-                  keep_original_cols = TRUE) %>%
+                  cycle_size = 86400) %>%
     prep() %>%
     bake(new_data = NULL)
 
-  expect_equal(ncol(rec), 2+6)
+  expect_equal(ncol(rec), 7)
 
 })
 
@@ -94,11 +93,11 @@ test_that("harmonic keep_original_cols", {
     step_harmonic(time_var,
                   frequency = c(1, 1.93, 2),
                   cycle_size = 86400,
-                  keep_original_cols = FALSE) %>%
+                  keep_original_cols = TRUE) %>%
     prep() %>%
     bake(new_data = NULL)
 
-  expect_equal(ncol(rec), 1+6)
+  expect_equal(ncol(rec), 8)
 
 })
 
@@ -381,8 +380,8 @@ test_that("empty selection tidy method works", {
 test_that('printing', {
   rec <- recipe(mpg ~ ., mtcars)
   with_harmonic <- rec %>%  step_harmonic(hp, frequency = 1/11, cycle_size = 1)
-  expect_output(print(with_harmonic))
-  expect_output(prep(with_harmonic, training = mtcars, verbose = TRUE))
+  expect_snapshot(print(with_harmonic))
+  expect_snapshot(prep(with_harmonic, training = mtcars, verbose = TRUE))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test_harmonic.R
+++ b/tests/testthat/test_harmonic.R
@@ -76,7 +76,8 @@ test_that("harmonic frequencies", {
   rec <- recipe(osc ~ time_var, data = harmonic_dat) %>%
     step_harmonic(time_var,
                   frequency = c(1, 1.93, 2),
-                  cycle_size = 86400) %>%
+                  cycle_size = 86400,
+                  keep_original_cols = TRUE) %>%
     prep() %>%
     bake(new_data = NULL)
 
@@ -232,7 +233,8 @@ test_that("harmonic NA in term", {
   rec_na <- recipe(osc ~ time_var, data = harmonic_dat) %>%
     step_harmonic(time_var,
                   frequency = 4,
-                  cycle_size = 86400) %>%
+                  cycle_size = 86400,
+                  keep_original_cols = TRUE) %>%
     prep() %>%
     bake(new_data = NULL)
 
@@ -374,6 +376,13 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that('printing', {
+  rec <- recipe(mpg ~ ., mtcars)
+  with_harmonic <- rec %>%  step_harmonic(hp, frequency = 1/11, cycle_size = 1)
+  expect_output(print(with_harmonic))
+  expect_output(prep(with_harmonic, training = mtcars, verbose = TRUE))
 })
 
 test_that("empty printing", {


### PR DESCRIPTION
Defaults were updated to `role = "predictor"` and `keep_original_cols = FALSE`

The bug in `print.step_harmonic` should be fixed.

Tests were updated to handle the changes to the defaults and also that printing does not fail.