### PR TITLE
Add group argument to step_zv()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * All recipe steps now officially support empty selections to be more aligned with dplyr and other packages that use tidyselect (#603, #531). For example, if a previous step removed all of the columns need for a later step, the recipe does not fail when it is estimated (with the exception of `step_mutate()`). The documentation in `?selections` has been updated with advice for writing selectors when filtering steps are used. (#813) 
 
+* `step_zv()` now has a `group` argument. The same filter is applied but looks for zero-variance within 1 or more columns that define groups. (#711)
 
 # recipes 0.1.17
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -518,19 +518,6 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   if (rlang::is_missing(new_data)) {
     rlang::abort("'new_data' must be either a data frame or NULL. No value is not allowed.")
   }
-
-  original_vars <- object$var_info %>%
-    filter(source == "original") %>%
-    pull(variable)
-
-  if (!is.null(new_data) && !all(original_vars %in% names(new_data))) {
-    missing_vars <- format_ch_vec(
-      setdiff(original_vars, names(new_data)),
-      width = options()$width - 35
-    )
-    rlang::abort(glue::glue("Missing variable in `new_data`: {missing_vars}"))
-  }
-
   if (is.null(new_data)) {
     return(juice(object, ..., composition = composition))
   }

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -518,6 +518,19 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   if (rlang::is_missing(new_data)) {
     rlang::abort("'new_data' must be either a data frame or NULL. No value is not allowed.")
   }
+
+  original_vars <- object$var_info %>%
+    filter(source == "original") %>%
+    pull(variable)
+
+  if (!is.null(new_data) && !all(original_vars %in% names(new_data))) {
+    missing_vars <- format_ch_vec(
+      setdiff(original_vars, names(new_data)),
+      width = options()$width - 35
+    )
+    rlang::abort(glue::glue("Missing variable in `new_data`: {missing_vars}"))
+  }
+
   if (is.null(new_data)) {
     return(juice(object, ..., composition = composition))
   }

--- a/R/zv.R
+++ b/R/zv.R
@@ -7,8 +7,11 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @param group An optional character string or call to [dplyr::vars()] that can be used to
-#'  specify a group(s) within which to identify variables that contain only a single value.
+#' @param group An optional character string or call to [dplyr::vars()]
+#'  that can be used to specify a group(s) within which to identify
+#'  variables that contain only a single value. If the grouping variables
+#'  are contained in terms selector, they will not be considered for
+#'  removal.
 #' @template step-return
 #' @template filter-steps
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the

--- a/R/zv.R
+++ b/R/zv.R
@@ -7,8 +7,8 @@
 #' @param removals A character string that contains the names of
 #'  columns that should be removed. These values are not determined
 #'  until [prep.recipe()] is called.
-#' @param group A character string or call to dplyr::vars() can be used to
-#'  specify the group(s) variable.
+#' @param group An optional character string or call to [dplyr::vars()] that can be used to
+#'  specify a group(s) within which to identify variables that contain only a single value.
 #' @template step-return
 #' @template filter-steps
 #' @details When you [`tidy()`] this step, a tibble with column `terms` (the

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -28,8 +28,11 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{group}{A character string or call to dplyr::vars() can be used to
-specify the group(s) variable.}
+\item{group}{An optional character string or call to \code{\link[dplyr:vars]{dplyr::vars()}}
+that can be used to specify a group(s) within which to identify
+variables that contain only a single value. If the grouping variables
+are contained in terms selector, they will not be considered for
+removal.}
 
 \item{removals}{A character string that contains the names of
 columns that should be removed. These values are not determined

--- a/man/step_zv.Rd
+++ b/man/step_zv.Rd
@@ -9,6 +9,7 @@ step_zv(
   ...,
   role = NA,
   trained = FALSE,
+  group = NULL,
   removals = NULL,
   skip = FALSE,
   id = rand_id("zv")
@@ -26,6 +27,9 @@ created.}
 
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
+
+\item{group}{A character string or call to dplyr::vars() can be used to
+specify the group(s) variable.}
 
 \item{removals}{A character string that contains the names of
 columns that should be removed. These values are not determined


### PR DESCRIPTION
This PR aims to close #711.

`group` can be one or more character strings or a call to `dplyr::vars()`.
`group` Is currently not restricted to refer to any types. Hence the examples before refer to two integer variables to define the groups.

Should I expand this to work for `step_nzv()` as well since the steps are so similar?

``` r
library(recipes)

recipe(~ ., data = mtcars) %>%
  step_zv(all_predictors(), group = "am") %>%
  prep() %>%
  tidy(1)
#> # A tibble: 0 × 2
#> # … with 2 variables: terms <chr>, id <chr>

recipe(~ ., data = mtcars) %>%
  step_zv(all_predictors(), group = c("am", "vs")) %>%
  prep() %>%
  tidy(1)
#> # A tibble: 2 × 2
#>   terms id      
#>   <chr> <chr>   
#> 1 cyl   zv_zSLT3
#> 2 gear  zv_zSLT3

recipe(~ ., data = mtcars) %>%
  step_zv(all_predictors(), group = vars(am, vs)) %>%
  prep() %>%
  tidy(1)
#> # A tibble: 2 × 2
#>   terms id      
#>   <chr> <chr>   
#> 1 cyl   zv_bnxSp
#> 2 gear  zv_bnxSp
```

<sup>Created on 2021-12-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>