### PR TITLE
Don't limit detect_step() to recipes steps 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * All recipe steps now officially support empty selections to be more aligned with dplyr and other packages that use tidyselect (#603, #531). For example, if a previous step removed all of the columns need for a later step, the recipe does not fail when it is estimated (with the exception of `step_mutate()`). The documentation in `?selections` has been updated with advice for writing selectors when filtering steps are used. (#813) 
 
+* `detect_step()` is no longer restricted to steps created in recipes (#869).
+
 
 # recipes 0.1.17
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -402,11 +402,8 @@ fully_trained <- function(x) {
 #' rec <- recipe(Species ~ ., data = iris) %>%
 #'   step_intercept()
 #'
-#' detect_step(rec, "step_intercept")
+#' detect_step(rec, "intercept")
 detect_step <- function(recipe, name) {
-  exports <- getNamespaceExports("recipes")
-  if (!any(grepl(paste0(".*", name, ".*"), exports)))
-    rlang::abort("Please provide the name of valid step or check (ex: `center`).")
   name %in% tidy(recipe)$type
 }
 

--- a/man/detect_step.Rd
+++ b/man/detect_step.Rd
@@ -22,5 +22,5 @@ Detect if a particular step or check is used in a recipe
 rec <- recipe(Species ~ ., data = iris) \%>\%
   step_intercept()
 
-detect_step(rec, "step_intercept")
+detect_step(rec, "intercept")
 }

--- a/tests/testthat/test_basics.R
+++ b/tests/testthat/test_basics.R
@@ -73,10 +73,6 @@ test_that("detect_step function works", {
 
   prepped_rec <- prep(rec, iris)
 
-  # only allow checking for valid steps
-  expect_error(detect_step(rec, "not_a_step"))
-  expect_error(detect_step(prepped_rec, "not_a_step"))
-
   # detect untrained steps
   expect_true(detect_step(rec, "center"))
   expect_true(detect_step(rec, "scale"))


### PR DESCRIPTION
This PR aims to close #869.

Simply removes the check. Should now work with extension packages

``` r
library(recipes)
library(themis)

rec <- recipe(Species ~ ., data = iris) %>%
  step_intercept() %>%
  step_smote(Species)

detect_step(rec, "smote")
#> [1] TRUE
```

<sup>Created on 2021-12-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>