### PR TITLE
document how data leakage could happen in step_mutate

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -18,8 +18,14 @@
 #'  contains the `mutate()` expressions as character strings
 #'  (and are not reparsable), is returned.
 #'
-#' If a preceding step removes a column that is selected by name in
-#' `step_mutate()`, the recipe will error when being estimated with `prep()`.
+#'  If a preceding step removes a column that is selected by name in
+#'  `step_mutate()`, the recipe will error when being estimated with `prep()`.
+#'
+#'  Please be aware that it is easy to create data leakage by having
+#'  the calculations depend on the characteristics of the data set itself.
+#'  The expression `x = w > mean(w)` would when applied to the testing
+#'  data set use the mean of w in the testing data set instead of the
+#'  training data set as it should.
 #'
 #' @family individual transformation steps
 #' @family dplyr steps

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -8,6 +8,7 @@
 #' @param ... Name-value pairs of expressions. See [dplyr::mutate()].
 #' @param inputs Quosure(s) of `...`.
 #' @template step-return
+#' @template mutate-leakage
 #' @details When an object in the user's global environment is
 #'  referenced in the expression defining the new variable(s),
 #'  it is a good idea to use quasiquotation (e.g. `!!`) to embed
@@ -20,12 +21,6 @@
 #'
 #'  If a preceding step removes a column that is selected by name in
 #'  `step_mutate()`, the recipe will error when being estimated with `prep()`.
-#'
-#'  Please be aware that it is easy to create data leakage by having
-#'  the calculations depend on the characteristics of the data set itself.
-#'  The expression `x = w > mean(w)` would when applied to the testing
-#'  data set use the mean of w in the testing data set instead of the
-#'  training data set as it should.
 #'
 #' @family individual transformation steps
 #' @family dplyr steps

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -10,14 +10,9 @@
 #' named**.
 #' @param inputs A vector of column names populated by `prep()`.
 #' @template step-return
+#' @template mutate-leakage
 #' @details When you [`tidy()`] this step, a tibble with
 #'  column `terms` which contains the columns being transformed is returned.
-#'
-#'  Please be aware that it is easy to create data leakage by having
-#'  the calculations depend on the characteristics of the data set itself.
-#'  The expression `x = w > mean(w)` would when applied to the testing
-#'  data set use the mean of w in the testing data set instead of the
-#'  training data set as it should.
 #'
 #' @family multivariate transformation steps
 #' @family dplyr steps

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -12,6 +12,13 @@
 #' @template step-return
 #' @details When you [`tidy()`] this step, a tibble with
 #'  column `terms` which contains the columns being transformed is returned.
+#'
+#'  Please be aware that it is easy to create data leakage by having
+#'  the calculations depend on the characteristics of the data set itself.
+#'  The expression `x = w > mean(w)` would when applied to the testing
+#'  data set use the mean of w in the testing data set instead of the
+#'  training data set as it should.
+#'
 #' @family multivariate transformation steps
 #' @family dplyr steps
 #' @export

--- a/man-roxygen/mutate-leakage.R
+++ b/man-roxygen/mutate-leakage.R
@@ -1,0 +1,5 @@
+#' @details
+#' When using this flexible step, use extra care to avoid data leakage in your
+#' preprocessing. Consider, for example, the transformation `x = w > mean(w)`.
+#' When applied to new data or testing data, this transformation would use the
+#' mean of `w` from the _new_ data, not the mean of `w` from the training data.

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -47,6 +47,11 @@ sequence of any existing operations.
 that will add variables using \code{\link[dplyr:mutate]{dplyr::mutate()}}.
 }
 \details{
+When using this flexible step, use extra care to avoid data leakage in your
+preprocessing. Consider, for example, the transformation \code{x = w > mean(w)}.
+When applied to new data or testing data, this transformation would use the
+mean of \code{w} from the \emph{new} data, not the mean of \code{w} from the training data.
+
 When an object in the user's global environment is
 referenced in the expression defining the new variable(s),
 it is a good idea to use quasiquotation (e.g. \verb{!!}) to embed
@@ -59,12 +64,6 @@ contains the \code{mutate()} expressions as character strings
 
 If a preceding step removes a column that is selected by name in
 \code{step_mutate()}, the recipe will error when being estimated with \code{prep()}.
-
-Please be aware that it is easy to create data leakage by having
-the calculations depend on the characteristics of the data set itself.
-The expression \code{x = w > mean(w)} would when applied to the testing
-data set use the mean of w in the testing data set instead of the
-training data set as it should.
 }
 \examples{
 rec <-

--- a/man/step_mutate.Rd
+++ b/man/step_mutate.Rd
@@ -59,6 +59,12 @@ contains the \code{mutate()} expressions as character strings
 
 If a preceding step removes a column that is selected by name in
 \code{step_mutate()}, the recipe will error when being estimated with \code{prep()}.
+
+Please be aware that it is easy to create data leakage by having
+the calculations depend on the characteristics of the data set itself.
+The expression \code{x = w > mean(w)} would when applied to the testing
+data set use the mean of w in the testing data set instead of the
+training data set as it should.
 }
 \examples{
 rec <-

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -53,14 +53,13 @@ sequence of any existing operations.
 the selected variables using a common function via \code{\link[dplyr:mutate_all]{dplyr::mutate_at()}}.
 }
 \details{
+When using this flexible step, use extra care to avoid data leakage in your
+preprocessing. Consider, for example, the transformation \code{x = w > mean(w)}.
+When applied to new data or testing data, this transformation would use the
+mean of \code{w} from the \emph{new} data, not the mean of \code{w} from the training data.
+
 When you \code{\link[=tidy]{tidy()}} this step, a tibble with
 column \code{terms} which contains the columns being transformed is returned.
-
-Please be aware that it is easy to create data leakage by having
-the calculations depend on the characteristics of the data set itself.
-The expression \code{x = w > mean(w)} would when applied to the testing
-data set use the mean of w in the testing data set instead of the
-training data set as it should.
 }
 \examples{
 library(dplyr)

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -55,6 +55,12 @@ the selected variables using a common function via \code{\link[dplyr:mutate_all]
 \details{
 When you \code{\link[=tidy]{tidy()}} this step, a tibble with
 column \code{terms} which contains the columns being transformed is returned.
+
+Please be aware that it is easy to create data leakage by having
+the calculations depend on the characteristics of the data set itself.
+The expression \code{x = w > mean(w)} would when applied to the testing
+data set use the mean of w in the testing data set instead of the
+training data set as it should.
 }
 \examples{
 library(dplyr)


### PR DESCRIPTION
This PR tries to handle one part of #765 by adding a couple of sentences about how data leakage can happen in `step_mutate()` and `step_mutate_at()`. 