### PR TITLE
Fixes to account for changes made in rlang 1.0.0

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/R/rename.R
+++ b/R/rename.R
@@ -113,9 +113,10 @@ print.step_rename <-
 tidy.step_rename <- function(x, ...) {
   var_expr <- map(x$inputs, quo_get_expr)
   var_expr <- map_chr(var_expr, quo_text, width = options()$width, nlines = 1)
+
   tibble(
-    terms = names(x$inputs),
-    value = unname(var_expr),
+    terms = names(x$inputs) %||% character(),
+    value = unname(var_expr) %||% character(),
     id = rep(x$id, length(x$inputs))
   )
 }

--- a/R/rename.R
+++ b/R/rename.R
@@ -98,8 +98,13 @@ bake.step_rename <- function(object, new_data, ...) {
 print.step_rename <-
   function(x, width = max(20, options()$width - 35), ...) {
     title <- "Variable renaming for "
-    untrained_terms <- rlang::parse_quos(names(x$inputs), rlang::current_env())
-    print_step(names(x$inputs), untrained_terms, x$trained, title, width)
+    trained_names <- names(x$inputs)
+
+    untrained_terms <- rlang::parse_quos(
+      trained_names %||% "",
+      rlang::current_env()
+    )
+    print_step(trained_names, untrained_terms, x$trained, title, width)
     invisible(x)
   }
 

--- a/tests/testthat/_snaps/BoxCox.md
+++ b/tests/testthat/_snaps/BoxCox.md
@@ -2,7 +2,7 @@
 
     Code
       rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
-    Warning <warning>
+    Warning <rlang_warning>
       Non-positive values in selected variable.
       Fewer than `num_unique` values in selected variable.
       No Box-Cox transformation could be estimated for: `x2`, `x3`
@@ -27,7 +27,7 @@
 
     Code
       prep(rec, training = ex_dat)
-    Warning <warning>
+    Warning <rlang_warning>
       Non-positive values in selected variable.
       Fewer than `num_unique` values in selected variable.
       No Box-Cox transformation could be estimated for: `x2`, `x3`

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -71,7 +71,7 @@
 
     Code
       kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-    Warning <warning>
+    Warning <rlang_warning>
       'keep_original_cols' was added to `step_kpca()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/_snaps/kpca_poly.md
+++ b/tests/testthat/_snaps/kpca_poly.md
@@ -60,7 +60,7 @@
 
     Code
       kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-    Warning <warning>
+    Warning <rlang_warning>
       'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/_snaps/kpca_rbf.md
+++ b/tests/testthat/_snaps/kpca_rbf.md
@@ -60,7 +60,7 @@
 
     Code
       kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-    Warning <warning>
+    Warning <rlang_warning>
       'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/_snaps/pls_old.md
+++ b/tests/testthat/_snaps/pls_old.md
@@ -2,7 +2,7 @@
 
     Code
       new_values_te <- bake(old_pls, biom_te)
-    Warning <warning>
+    Warning <rlang_warning>
       'keep_original_cols' was added to `step_pls()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 

--- a/tests/testthat/_snaps/range_check.md
+++ b/tests/testthat/_snaps/range_check.md
@@ -9,7 +9,7 @@
 
     Code
       bake(rec3, test)
-    Warning <warning>
+    Warning <rlang_warning>
       min x is -10, lower bound is -5, max x is 110, upper bound is 105
       min y is -10, lower bound is -2.5, max x is 60, upper bound is 52.5
     Output

--- a/tests/testthat/test-dummy_multi_choice.R
+++ b/tests/testthat/test-dummy_multi_choice.R
@@ -120,6 +120,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_dummy_multi_choice(rec)
 

--- a/tests/testthat/test_BoxCox.R
+++ b/tests/testthat/test_BoxCox.R
@@ -48,7 +48,7 @@ test_that('simple Box Cox', {
   expect_equal(bc_tibble_un, tidy(rec, number = 1))
 
   # Capture warnings
-  expect_snapshot(
+  suppressWarnings(
     rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
   )
   rec_trans <- bake(rec_trained, new_data = ex_dat)
@@ -56,10 +56,17 @@ test_that('simple Box Cox', {
   expect_equal(names(exp_lambda)[!is.na(exp_lambda)], names(rec_trained$steps[[1]]$lambdas))
   expect_equal(exp_lambda[!is.na(exp_lambda)], rec_trained$steps[[1]]$lambdas, tolerance = .001)
   expect_equal(as.matrix(exp_dat), as.matrix(rec_trans), tolerance = .05)
+
+  skip_if(packageVersion("rlang") < "1.0.0")
+  # Capture warnings
+  expect_snapshot(
+    rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
+  )
 })
 
 
 test_that('printing', {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(~., data = ex_dat) %>%
     step_BoxCox(x1, x2, x3, x4)
 
@@ -98,6 +105,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_BoxCox(rec)
 

--- a/tests/testthat/test_YeoJohnson.R
+++ b/tests/testthat/test_YeoJohnson.R
@@ -110,6 +110,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_YeoJohnson(rec)
 

--- a/tests/testthat/test_arrange.R
+++ b/tests/testthat/test_arrange.R
@@ -74,6 +74,7 @@ test_that("empty tidying", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_arrange(rec)
 

--- a/tests/testthat/test_bin2factor.R
+++ b/tests/testthat/test_bin2factor.R
@@ -73,6 +73,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_bin2factor(rec)
 

--- a/tests/testthat/test_bs.R
+++ b/tests/testthat/test_bs.R
@@ -122,6 +122,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_bs(rec)
 

--- a/tests/testthat/test_center_scale_norm.R
+++ b/tests/testthat/test_center_scale_norm.R
@@ -174,6 +174,7 @@ test_that("center - empty selection tidy method works", {
 })
 
 test_that("center - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_center(rec)
 
@@ -211,6 +212,7 @@ test_that("scale - empty selection tidy method works", {
 })
 
 test_that("scale - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_scale(rec)
 
@@ -253,6 +255,7 @@ test_that("normalize - empty selection tidy method works", {
 })
 
 test_that("normalize - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_normalize(rec)
 

--- a/tests/testthat/test_class.R
+++ b/tests/testthat/test_class.R
@@ -135,6 +135,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- check_class(rec)
 

--- a/tests/testthat/test_classdist.R
+++ b/tests/testthat/test_classdist.R
@@ -125,6 +125,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(Species ~ ., iris)
   rec <- step_classdist(rec, class = "Species")
 

--- a/tests/testthat/test_colcheck.R
+++ b/tests/testthat/test_colcheck.R
@@ -60,6 +60,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- check_cols(rec)
 

--- a/tests/testthat/test_corr.R
+++ b/tests/testthat/test_corr.R
@@ -119,6 +119,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_corr(rec)
 

--- a/tests/testthat/test_count.R
+++ b/tests/testthat/test_count.R
@@ -81,6 +81,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_count(rec)
 

--- a/tests/testthat/test_cut.R
+++ b/tests/testthat/test_cut.R
@@ -144,6 +144,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_cut(rec, breaks = 5)
 

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -166,6 +166,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_date(rec)
 

--- a/tests/testthat/test_depth.R
+++ b/tests/testthat/test_depth.R
@@ -104,6 +104,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(Species ~ ., iris)
   rec <- step_depth(rec, class = "Species")
 

--- a/tests/testthat/test_discretized.R
+++ b/tests/testthat/test_discretized.R
@@ -155,6 +155,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_discretize(rec)
 

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -345,6 +345,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_dummy(rec)
 

--- a/tests/testthat/test_factors2strings.R
+++ b/tests/testthat/test_factors2strings.R
@@ -69,6 +69,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_factor2string(rec)
 

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -137,6 +137,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_filter(rec)
 

--- a/tests/testthat/test_filter_missing.R
+++ b/tests/testthat/test_filter_missing.R
@@ -101,6 +101,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_filter_missing(rec)
 

--- a/tests/testthat/test_harmonic.R
+++ b/tests/testthat/test_harmonic.R
@@ -378,6 +378,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that('printing', {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   with_harmonic <- rec %>%  step_harmonic(hp, frequency = 1/11, cycle_size = 1)
   expect_snapshot(print(with_harmonic))
@@ -385,6 +386,7 @@ test_that('printing', {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_harmonic(rec, frequency = 1/11, cycle_size = 1)
 

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -116,6 +116,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_holiday(rec)
 

--- a/tests/testthat/test_hyperbolic.R
+++ b/tests/testthat/test_hyperbolic.R
@@ -75,6 +75,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_hyperbolic(rec)
 

--- a/tests/testthat/test_ica.R
+++ b/tests/testthat/test_ica.R
@@ -200,6 +200,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   skip_if_not_installed("dimRed")
   skip_if_not_installed("fastICA")
   skip_if_not_installed("RSpectra")

--- a/tests/testthat/test_impute_bag.R
+++ b/tests/testthat/test_impute_bag.R
@@ -136,6 +136,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_bag(rec)
 

--- a/tests/testthat/test_impute_knn.R
+++ b/tests/testthat/test_impute_knn.R
@@ -208,6 +208,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_knn(rec)
 

--- a/tests/testthat/test_impute_linear.R
+++ b/tests/testthat/test_impute_linear.R
@@ -125,6 +125,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_linear(rec)
 

--- a/tests/testthat/test_impute_lower.R
+++ b/tests/testthat/test_impute_lower.R
@@ -95,6 +95,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_lower(rec)
 

--- a/tests/testthat/test_impute_mean.R
+++ b/tests/testthat/test_impute_mean.R
@@ -134,6 +134,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_mean(rec)
 

--- a/tests/testthat/test_impute_median.R
+++ b/tests/testthat/test_impute_median.R
@@ -104,6 +104,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_median(rec)
 

--- a/tests/testthat/test_impute_mode.R
+++ b/tests/testthat/test_impute_mode.R
@@ -118,6 +118,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_mode(rec)
 

--- a/tests/testthat/test_impute_roll.R
+++ b/tests/testthat/test_impute_roll.R
@@ -152,6 +152,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_impute_roll(rec)
 

--- a/tests/testthat/test_integer.R
+++ b/tests/testthat/test_integer.R
@@ -110,6 +110,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_integer(rec)
 

--- a/tests/testthat/test_inverse.R
+++ b/tests/testthat/test_inverse.R
@@ -71,6 +71,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_inverse(rec)
 

--- a/tests/testthat/test_invlogit.R
+++ b/tests/testthat/test_invlogit.R
@@ -59,6 +59,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_invlogit(rec)
 

--- a/tests/testthat/test_isomap.R
+++ b/tests/testthat/test_isomap.R
@@ -198,6 +198,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_isomap(rec)
 

--- a/tests/testthat/test_kpca.R
+++ b/tests/testthat/test_kpca.R
@@ -46,6 +46,7 @@ test_that('printing', {
 
   skip_if_not_installed("kernlab")
 
+  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(
     kpca_rec <- rec %>% step_kpca(X2, X3, X4, X5, X6)
   )
@@ -56,7 +57,7 @@ test_that('printing', {
 
 
 test_that('No kPCA comps', {
-  expect_snapshot(
+  suppressWarnings(
     pca_extract <- rec %>%
       step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
       prep()
@@ -67,11 +68,17 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)
-  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(
+    pca_extract <- rec %>%
+      step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
+      prep()
+  )
+  expect_snapshot(pca_extract)
 })
 
 
@@ -104,13 +111,17 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_snapshot(
+  suppressWarnings(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )
 
   expect_error(
     pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
     NA
+  )
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(
+    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )
 })
 
@@ -141,6 +152,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_kpca(rec)
 

--- a/tests/testthat/test_kpca_poly.R
+++ b/tests/testthat/test_kpca_poly.R
@@ -47,6 +47,7 @@ test_that('printing', {
 
   kpca_rec <- rec %>%
     step_kpca_poly(X2, X3, X4, X5, X6)
+  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(kpca_rec)
   expect_snapshot(prep(kpca_rec, training = tr_dat, verbose = TRUE))
 })
@@ -62,11 +63,12 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)
-  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(pca_extract)
 })
 
 
@@ -114,7 +116,7 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_snapshot(
+  suppressWarnings(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )
 
@@ -122,7 +124,10 @@ test_that('can prep recipes with no keep_original_cols', {
     pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
     NA
   )
-
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(
+    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
+  )
 })
 
 test_that("empty selection prep/bake is a no-op", {
@@ -158,7 +163,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
-
+  skip_if(packageVersion("rlang") < "1.0.0")
   skip_if_not_installed("kernlab")
 
   rec <- recipe(mpg ~ ., mtcars)

--- a/tests/testthat/test_kpca_rbf.R
+++ b/tests/testthat/test_kpca_rbf.R
@@ -42,7 +42,7 @@ test_that('correct kernel PCA values', {
 })
 
 test_that('printing', {
-
+  skip_if(packageVersion("rlang") < "1.0.0")
   skip_if_not_installed("kernlab")
 
   kpca_rec <- rec %>%
@@ -62,11 +62,12 @@ test_that('No kPCA comps', {
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)
-  expect_snapshot(pca_extract)
   expect_equal(
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(pca_extract)
 })
 
 
@@ -114,8 +115,8 @@ test_that('can prep recipes with no keep_original_cols', {
 
   kpca_rec$steps[[1]]$keep_original_cols <- NULL
 
-  expect_snapshot(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
+  suppressWarnings(
+    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
   )
 
   expect_error(
@@ -123,6 +124,10 @@ test_that('can prep recipes with no keep_original_cols', {
     NA
   )
 
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(
+    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+  )
 })
 
 test_that("empty selection prep/bake is a no-op", {
@@ -152,6 +157,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_kpca_rbf(rec)
 

--- a/tests/testthat/test_lag.R
+++ b/tests/testthat/test_lag.R
@@ -109,6 +109,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_lag(rec)
 

--- a/tests/testthat/test_lincomb.R
+++ b/tests/testthat/test_lincomb.R
@@ -94,6 +94,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_lincomb(rec)
 

--- a/tests/testthat/test_log.R
+++ b/tests/testthat/test_log.R
@@ -93,6 +93,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_log(rec)
 

--- a/tests/testthat/test_logit.R
+++ b/tests/testthat/test_logit.R
@@ -80,6 +80,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_logit(rec)
 

--- a/tests/testthat/test_missing.R
+++ b/tests/testthat/test_missing.R
@@ -78,6 +78,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- check_missing(rec)
 

--- a/tests/testthat/test_mutate.R
+++ b/tests/testthat/test_mutate.R
@@ -237,6 +237,7 @@ test_that("mutate_at - empty selection tidy method works", {
 })
 
 test_that("mutate_at - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_mutate_at(rec, fn = mean)
 

--- a/tests/testthat/test_naindicate.R
+++ b/tests/testthat/test_naindicate.R
@@ -122,6 +122,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_indicate_na(rec)
 

--- a/tests/testthat/test_naomit.R
+++ b/tests/testthat/test_naomit.R
@@ -71,6 +71,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_naomit(rec)
 

--- a/tests/testthat/test_newvalues.R
+++ b/tests/testthat/test_newvalues.R
@@ -175,6 +175,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- check_new_values(rec)
 

--- a/tests/testthat/test_novel.R
+++ b/tests/testthat/test_novel.R
@@ -130,6 +130,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_novel(rec)
 

--- a/tests/testthat/test_ns.R
+++ b/tests/testthat/test_ns.R
@@ -120,6 +120,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_ns(rec)
 

--- a/tests/testthat/test_num2factor.R
+++ b/tests/testthat/test_num2factor.R
@@ -85,6 +85,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_num2factor(rec, levels = "x")
 

--- a/tests/testthat/test_nzv.R
+++ b/tests/testthat/test_nzv.R
@@ -43,11 +43,6 @@ test_that('nzv filtering', {
 test_that('altered freq_cut and unique_cut', {
   rec <- recipe(y ~ ., data = dat)
 
-  expect_snapshot_error(
-    rec %>%
-      step_nzv(x1, x2, x3, x4, options = list(freq_cut = 50, unique_cut = 10))
-  )
-
   filtering <- rec %>%
     step_nzv(x1, x2, x3, x4, freq_cut = 50, unique_cut = 10)
 
@@ -58,6 +53,12 @@ test_that('altered freq_cut and unique_cut', {
       f_ratio >= filtering_trained$steps[[1]]$freq_cut]
 
   expect_equal(filtering_trained$steps[[1]]$removals, removed)
+
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot_error(
+    rec %>%
+      step_nzv(x1, x2, x3, x4, options = list(freq_cut = 50, unique_cut = 10))
+  )
 })
 
 
@@ -111,6 +112,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_nzv(rec)
 

--- a/tests/testthat/test_ordinalscore.R
+++ b/tests/testthat/test_ordinalscore.R
@@ -96,6 +96,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_ordinalscore(rec)
 

--- a/tests/testthat/test_other.R
+++ b/tests/testthat/test_other.R
@@ -318,6 +318,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_other(rec)
 

--- a/tests/testthat/test_pca.R
+++ b/tests/testthat/test_pca.R
@@ -224,6 +224,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_pca(rec)
 

--- a/tests/testthat/test_pls_new.R
+++ b/tests/testthat/test_pls_new.R
@@ -238,6 +238,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_pls(rec, outcome = "mpg")
 

--- a/tests/testthat/test_pls_old.R
+++ b/tests/testthat/test_pls_old.R
@@ -19,6 +19,9 @@ test_that('check old PLS scores from recipes version <= 0.1.12', {
   expect_equal(new_values_tr, old_pls_tr)
 
   # Capture known warning about `keep_original_cols`
-  expect_snapshot(new_values_te <- bake(old_pls, biom_te))
+
+  suppressWarnings(new_values_te <- bake(old_pls, biom_te))
   expect_equal(new_values_te, old_pls_te)
+  skip_if(packageVersion("rlang") < "1.0.0")
+  expect_snapshot(new_values_te <- bake(old_pls, biom_te))
 })

--- a/tests/testthat/test_poly.R
+++ b/tests/testthat/test_poly.R
@@ -128,6 +128,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_poly(rec)
 

--- a/tests/testthat/test_profile.R
+++ b/tests/testthat/test_profile.R
@@ -172,6 +172,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_profile(rec, profile = vars(mpg))
 

--- a/tests/testthat/test_range.R
+++ b/tests/testthat/test_range.R
@@ -145,6 +145,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_range(rec)
 

--- a/tests/testthat/test_range_check.R
+++ b/tests/testthat/test_range_check.R
@@ -35,6 +35,7 @@ test_that("in recipe", {
   expect_error(bake(rec1, test), NA)
   expect_warning(bake(rec1, test), NA)
 
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec2 <- recipe(train) %>% check_range(x, y) %>% prep()
   expect_snapshot(error = TRUE, bake(rec2, test))
 
@@ -79,6 +80,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- check_range(rec)
 

--- a/tests/testthat/test_ratio.R
+++ b/tests/testthat/test_ratio.R
@@ -198,6 +198,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_ratio(rec, denom = vars(mpg))
 

--- a/tests/testthat/test_regex.R
+++ b/tests/testthat/test_regex.R
@@ -72,6 +72,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_regex(rec)
 

--- a/tests/testthat/test_relevel.R
+++ b/tests/testthat/test_relevel.R
@@ -79,6 +79,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_relevel(rec, ref_level = "x")
 

--- a/tests/testthat/test_relu.R
+++ b/tests/testthat/test_relu.R
@@ -129,6 +129,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_relu(rec)
 

--- a/tests/testthat/test_rename.R
+++ b/tests/testthat/test_rename.R
@@ -84,6 +84,7 @@ test_that("rename - empty selection tidy method works", {
 })
 
 test_that("rename - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_rename(rec)
 
@@ -173,6 +174,7 @@ test_that("rename_at - empty selection tidy method works", {
 })
 
 test_that("rename_at - empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_rename_at(rec, fn = identity)
 

--- a/tests/testthat/test_rm.R
+++ b/tests/testthat/test_rm.R
@@ -215,6 +215,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_rm(rec)
 

--- a/tests/testthat/test_roll.R
+++ b/tests/testthat/test_roll.R
@@ -120,6 +120,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_window(rec)
 

--- a/tests/testthat/test_shuffle.R
+++ b/tests/testthat/test_shuffle.R
@@ -101,6 +101,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_shuffle(rec)
 

--- a/tests/testthat/test_slice.R
+++ b/tests/testthat/test_slice.R
@@ -139,6 +139,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_slice(rec)
 

--- a/tests/testthat/test_spatialsign.R
+++ b/tests/testthat/test_spatialsign.R
@@ -80,6 +80,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spatialsign(rec)
 

--- a/tests/testthat/test_sqrt.R
+++ b/tests/testthat/test_sqrt.R
@@ -54,6 +54,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_sqrt(rec)
 

--- a/tests/testthat/test_string2factor.R
+++ b/tests/testthat/test_string2factor.R
@@ -99,6 +99,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_string2factor(rec)
 

--- a/tests/testthat/test_unknown.R
+++ b/tests/testthat/test_unknown.R
@@ -111,6 +111,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_unknown(rec, new_level = "cake")
 

--- a/tests/testthat/test_unorder.R
+++ b/tests/testthat/test_unorder.R
@@ -62,6 +62,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_unorder(rec)
 

--- a/tests/testthat/test_zv.R
+++ b/tests/testthat/test_zv.R
@@ -118,6 +118,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_zv(rec)
 


### PR DESCRIPTION
This PRs makes R cmd check run clear using the CRAN version of {rlang}