### PR TITLE
Don't link to dimRed and fastICA in documentation

### DIFF
--- a/R/ica.R
+++ b/R/ica.R
@@ -11,12 +11,12 @@
 #'  or the number of possible components, a smaller value will be
 #'  used.
 #' @param options A list of options to
-#'  [fastICA::fastICA()]. No defaults are set here.
+#'  `fastICA::fastICA()`. No defaults are set here.
 #'  **Note** that the arguments `X` and `n.comp` should
 #'  not be passed here.
 #' @param seed A single integer to set the random number stream prior to
 #'  running ICA.
-#' @param res The [fastICA::fastICA()] object is stored
+#' @param res The `fastICA::fastICA()` object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @param columns A character string of variable names that will

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -11,8 +11,8 @@
 #'  or the number of possible dimensions, a smaller value will be
 #'  used.
 #' @param neighbors The number of neighbors.
-#' @param options A list of options to [dimRed::Isomap()].
-#' @param res The [dimRed::Isomap()] object is stored
+#' @param options A list of options to `dimRed::Isomap()`.
+#' @param res The `dimRed::Isomap()` object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep.recipe()].
 #' @param columns A character string of variable names that will

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -40,14 +40,14 @@ or the number of possible components, a smaller value will be
 used.}
 
 \item{options}{A list of options to
-\code{\link[fastICA:fastICA]{fastICA::fastICA()}}. No defaults are set here.
+\code{fastICA::fastICA()}. No defaults are set here.
 \strong{Note} that the arguments \code{X} and \code{n.comp} should
 not be passed here.}
 
 \item{seed}{A single integer to set the random number stream prior to
 running ICA.}
 
-\item{res}{The \code{\link[fastICA:fastICA]{fastICA::fastICA()}} object is stored
+\item{res}{The \code{fastICA::fastICA()} object is stored
 here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -41,9 +41,9 @@ used.}
 
 \item{neighbors}{The number of neighbors.}
 
-\item{options}{A list of options to \code{\link[dimRed:Isomap-class]{dimRed::Isomap()}}.}
+\item{options}{A list of options to \code{dimRed::Isomap()}.}
 
-\item{res}{The \code{\link[dimRed:Isomap-class]{dimRed::Isomap()}} object is stored
+\item{res}{The \code{dimRed::Isomap()} object is stored
 here once this preprocessing step has be trained by
 \code{\link[=prep.recipe]{prep.recipe()}}.}
 


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/recipes/issues/823 by removing direct links to packages.

All other uses of the packages were removed in this PR
https://github.com/tidymodels/recipes/pull/829/files