### PR TITLE
Properly specify ptype argument for tidyr::unchop

### DIFF
--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -291,7 +291,7 @@ tidy.step_impute_knn <- function(x, ...) {
     res <- tidyr::unchop(
       data = res,
       cols = tidyselect::all_of(c("terms", "predictors")),
-      ptype = tibble(terms = character(), predictors = character())
+      ptype = list(terms = character(), predictors = character())
     )
     res$neighbors <- rep(x$neighbors, nrow(res))
   } else {


### PR DESCRIPTION
This change should be backwards compatible with tidyr < 1.2.0 so we don't need to touch the DESCRIPTION.