### PR TITLE
split up discretize documentation

### DIFF
--- a/R/discretize.R
+++ b/R/discretize.R
@@ -70,13 +70,6 @@ discretize.default <- function(x, ...)
 #'
 #' carbon_no_infs <- discretize(biomass_tr$carbon, infs = FALSE)
 #' predict(carbon_no_infs, c(50, 100))
-#'
-#' rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
-#'               data = biomass_tr)
-#' rec <- rec %>% step_discretize(carbon, hydrogen)
-#' rec <- prep(rec, biomass_tr)
-#' binned_te <- bake(rec, biomass_te)
-#' table(binned_te$carbon)
 
 discretize.numeric <-
   function(x,
@@ -230,6 +223,23 @@ print.discretize <-
 #'  and `value` (the breaks) is returned.
 #' @family discretization steps
 #' @export
+#'
+#' @examples
+#' library(modeldata)
+#' data(biomass)
+#'
+#' biomass_tr <- biomass[biomass$dataset == "Training",]
+#' biomass_te <- biomass[biomass$dataset == "Testing",]
+#'
+#' rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
+#'               data = biomass_tr) %>%
+#'   step_discretize(carbon, hydrogen)
+#'
+#' rec <- prep(rec, biomass_tr)
+#' binned_te <- bake(rec, biomass_te)
+#' table(binned_te$carbon)
+#'
+#' tidy(rec, 1)
 
 step_discretize <- function(recipe,
                             ...,

--- a/man/discretize.Rd
+++ b/man/discretize.Rd
@@ -102,11 +102,4 @@ table(predict(carbon_binned, biomass_tr$carbon))
 
 carbon_no_infs <- discretize(biomass_tr$carbon, infs = FALSE)
 predict(carbon_no_infs, c(50, 100))
-
-rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
-              data = biomass_tr)
-rec <- rec \%>\% step_discretize(carbon, hydrogen)
-rec <- prep(rec, biomass_tr)
-binned_te <- bake(rec, biomass_te)
-table(binned_te$carbon)
 }

--- a/man/step_discretize.Rd
+++ b/man/step_discretize.Rd
@@ -72,6 +72,23 @@ When you \code{\link[=tidy]{tidy()}} this step, a tibble
 with columns \code{terms} (the selectors or variables selected)
 and \code{value} (the breaks) is returned.
 }
+\examples{
+library(modeldata)
+data(biomass)
+
+biomass_tr <- biomass[biomass$dataset == "Training",]
+biomass_te <- biomass[biomass$dataset == "Testing",]
+
+rec <- recipe(HHV ~ carbon + hydrogen + oxygen + nitrogen + sulfur,
+              data = biomass_tr) \%>\%
+  step_discretize(carbon, hydrogen)
+
+rec <- prep(rec, biomass_tr)
+binned_te <- bake(rec, biomass_te)
+table(binned_te$carbon)
+
+tidy(rec, 1)
+}
 \seealso{
 Other discretization steps: 
 \code{\link{step_cut}()}


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/recipes/issues/834.

It simply splits the examples such that the `discretize()` examples are under `discretize()` and `step_discretize()` examples are under `step_discretize()` 