### PR TITLE
Add tests for recipes_eval_select

### DIFF
--- a/tests/testthat/_snaps/R4.1/selections.md
+++ b/tests/testthat/_snaps/R4.1/selections.md
@@ -1,0 +1,9 @@
+# simple name selections
+
+    Code
+      recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1)
+    Error <rlang_error>
+      object 'age' not found
+      Caused by error in `unique.default()`:
+      ! object 'age' not found
+

--- a/tests/testthat/_snaps/selections.md
+++ b/tests/testthat/_snaps/selections.md
@@ -1,0 +1,25 @@
+# simple name selections
+
+    Code
+      recipes_eval_select(quos = quos(log(date)), data = okc, info = info1)
+    Error <rlang_error>
+      non-numeric argument to mathematical function
+      Caused by error in `log()`:
+      ! non-numeric argument to mathematical function
+
+---
+
+    Code
+      recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1)
+    Error <rlang_error>
+      object 'age' not found
+      Caused by error in `unique.default()`:
+      ! object 'age' not found
+
+---
+
+    Code
+      recipes_eval_select(data = okc, info = info1)
+    Error <simpleError>
+      argument "quos" is missing, with no default
+

--- a/tests/testthat/_snaps/selections.md
+++ b/tests/testthat/_snaps/selections.md
@@ -10,15 +10,6 @@
 ---
 
     Code
-      recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1)
-    Error <rlang_error>
-      object 'age' not found
-      Caused by error in `unique.default()`:
-      ! object 'age' not found
-
----
-
-    Code
       recipes_eval_select(data = okc, info = info1)
     Error <simpleError>
       argument "quos" is missing, with no default

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -1,3 +1,5 @@
+r_version <- function() paste0("R", getRversion()[, 1:2])
+
 data("okc", package = "modeldata")
 rec1 <- recipe(~ ., data = okc)
 info1 <- summary(rec1)
@@ -95,7 +97,8 @@ test_that('simple name selections', {
   )
   expect_snapshot(
     recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1),
-    error = TRUE
+    error = TRUE,
+    variant = r_version()
   )
   expect_snapshot(
     recipes_eval_select(data = okc, info = info1),

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -9,15 +9,21 @@ data(okc)
 rec1 <- recipe(~ ., data = okc)
 info1 <- summary(rec1)
 
+rec2 <- recipe(age ~ ., data = okc)
+info2 <- summary(rec2)
+
+rec3 <- recipe(diet ~ ., data = okc)
+info3 <- summary(rec3)
+
 library(modeldata)
 data(biomass)
-rec2 <- recipe(biomass) %>%
+rec4 <- recipe(biomass) %>%
   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,
               new_role = "predictor") %>%
   update_role(HHV, new_role = "outcome") %>%
   update_role(sample, new_role = "id variable") %>%
   update_role(dataset, new_role = "splitting indicator")
-info2 <- summary(rec2)
+info4 <- summary(rec4)
 
 test_that('simple role selections', {
   expect_equal(
@@ -29,14 +35,14 @@ test_that('simple role selections', {
     setNames(nm = character())
   )
   expect_equal(
-    recipes_eval_select(quos = quos(all_outcomes()), data = biomass, info = info2),
+    recipes_eval_select(quos = quos(all_outcomes()), data = biomass, info = info4),
     setNames(nm = "HHV")
   )
   expect_equal(
     recipes_eval_select(
       quos = quos(has_role("splitting indicator")),
       data = biomass,
-      info = info2
+      info = info4
     ),
     setNames(nm = "dataset")
   )
@@ -63,11 +69,11 @@ test_that('simple name selections', {
     setNames(nm = c("age", "date"))
   )
   expect_equal(
-    recipes_eval_select(quos = quos(contains("gen")), data = biomass, info = info2),
+    recipes_eval_select(quos = quos(contains("gen")), data = biomass, info = info4),
     setNames(nm = c("hydrogen", "oxygen", "nitrogen"))
   )
   expect_equal(
-    recipes_eval_select(quos = quos(contains("gen"), -nitrogen), data = biomass, info = info2),
+    recipes_eval_select(quos = quos(contains("gen"), -nitrogen), data = biomass, info = info4),
     setNames(nm = c("hydrogen", "oxygen"))
   )
   expect_equal(
@@ -110,7 +116,7 @@ test_that('combinations', {
     recipes_eval_select(
       quos = quos(matches("[hH]"), -all_outcomes()),
       data = biomass,
-      info = info2
+      info = info4
     ),
     setNames(nm = "hydrogen")
   )
@@ -118,7 +124,7 @@ test_that('combinations', {
     recipes_eval_select(
       quos = quos(all_numeric(), -all_predictors()),
       data = biomass,
-      info = info2
+      info = info4
     ),
     setNames(nm = "HHV")
   )
@@ -126,7 +132,7 @@ test_that('combinations', {
     recipes_eval_select(
       quos = quos(all_numeric(), -all_predictors(), dataset),
       data = biomass,
-      info = info2
+      info = info4
     ),
     setNames(nm = c("HHV", "dataset"))
   )
@@ -134,7 +140,7 @@ test_that('combinations', {
     recipes_eval_select(
       quos = quos(all_numeric(), -all_predictors(), dataset, -dataset),
       data = biomass,
-      info = info2
+      info = info4
     ),
     setNames(nm = "HHV")
   )
@@ -192,4 +198,16 @@ test_that('new dplyr selectors', {
     regex = NA
   )
   expect_equal(names(rec_4$steps[[1]]$means), c("hydrogen", "carbon"))
+})
+
+test_that('predictor specific role selections', {
+  expect_equal(
+    recipes_eval_select(quos = quos(all_numeric_predictors()), data = okc, info = info2),
+    setNames(nm = "height")
+  )
+
+  expect_equal(
+    recipes_eval_select(quos = quos(all_nominal_predictors()), data = okc, info = info3),
+    setNames(nm = c("location", "Class"))
+  )
 })

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -1,11 +1,4 @@
-library(testthat)
-library(recipes)
-library(tibble)
-library(tidyselect)
-library(rlang)
-
-library(modeldata)
-data(okc)
+data("okc", package = "modeldata")
 rec1 <- recipe(~ ., data = okc)
 info1 <- summary(rec1)
 
@@ -15,8 +8,7 @@ info2 <- summary(rec2)
 rec3 <- recipe(diet ~ ., data = okc)
 info3 <- summary(rec3)
 
-library(modeldata)
-data(biomass)
+data("biomass", package = "modeldata")
 rec4 <- recipe(biomass) %>%
   update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,
               new_role = "predictor") %>%

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -89,17 +89,17 @@ test_that('simple name selections', {
     setNames(nm = character())
   )
 
-  expect_error(
+  expect_snapshot(
     recipes_eval_select(quos = quos(log(date)), data = okc, info = info1),
-    "non-numeric argument to mathematical function"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1),
-    "object 'age' not found"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     recipes_eval_select(data = okc, info = info1),
-    'argument "quos" is missing, with no default'
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -1,0 +1,195 @@
+library(testthat)
+library(recipes)
+library(tibble)
+library(tidyselect)
+library(rlang)
+
+library(modeldata)
+data(okc)
+rec1 <- recipe(~ ., data = okc)
+info1 <- summary(rec1)
+
+library(modeldata)
+data(biomass)
+rec2 <- recipe(biomass) %>%
+  update_role(carbon, hydrogen, oxygen, nitrogen, sulfur,
+              new_role = "predictor") %>%
+  update_role(HHV, new_role = "outcome") %>%
+  update_role(sample, new_role = "id variable") %>%
+  update_role(dataset, new_role = "splitting indicator")
+info2 <- summary(rec2)
+
+test_that('simple role selections', {
+  expect_equal(
+    recipes_eval_select(quos = quos(all_predictors()), data = okc, info = info1),
+    setNames(nm = info1$variable)
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(all_outcomes()), data = okc, info = info1),
+    setNames(nm = character())
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(all_outcomes()), data = biomass, info = info2),
+    setNames(nm = "HHV")
+  )
+  expect_equal(
+    recipes_eval_select(
+      quos = quos(has_role("splitting indicator")),
+      data = biomass,
+      info = info2
+    ),
+    setNames(nm = "dataset")
+  )
+})
+
+test_that('simple type selections', {
+  expect_equal(
+    recipes_eval_select(quos = quos(all_numeric()), data = okc, info = info1),
+    setNames(nm = c("age", "height"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(has_type("date")), data = okc, info = info1),
+    setNames(nm = "date")
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(all_nominal()), data = okc, info = info1),
+    setNames(nm = c("diet", "location", "Class"))
+  )
+})
+
+test_that('simple name selections', {
+  expect_equal(
+    recipes_eval_select(quos = quos(matches("e$")), data = okc, info = info1),
+    setNames(nm = c("age", "date"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(contains("gen")), data = biomass, info = info2),
+    setNames(nm = c("hydrogen", "oxygen", "nitrogen"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(contains("gen"), -nitrogen), data = biomass, info = info2),
+    setNames(nm = c("hydrogen", "oxygen"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(date, age), data = okc, info = info1),
+    setNames(nm = c("date", "age"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(-age, date), data = okc, info = info1),
+    setNames(nm = c("diet", "height", "location", "date", "Class"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(date, -age), data = okc, info = info1),
+    setNames(nm = "date")
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(date:age), data = okc, info = info1),
+    setNames(nm = c("date", "location", "height", "diet", "age"))
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(matches("blahblahblah")), data = okc, info = info1),
+    setNames(nm = character())
+  )
+
+  expect_error(
+    recipes_eval_select(quos = quos(log(date)), data = okc, info = info1),
+    "non-numeric argument to mathematical function"
+  )
+  expect_error(
+    recipes_eval_select(quos = quos(I(date:age)), data = okc, info = info1),
+    "object 'age' not found"
+  )
+  expect_error(
+    recipes_eval_select(data = okc, info = info1),
+    'argument "quos" is missing, with no default'
+  )
+})
+
+test_that('combinations', {
+  expect_equal(
+    recipes_eval_select(
+      quos = quos(matches("[hH]"), -all_outcomes()),
+      data = biomass,
+      info = info2
+    ),
+    setNames(nm = "hydrogen")
+  )
+  expect_equal(
+    recipes_eval_select(
+      quos = quos(all_numeric(), -all_predictors()),
+      data = biomass,
+      info = info2
+    ),
+    setNames(nm = "HHV")
+  )
+  expect_equal(
+    recipes_eval_select(
+      quos = quos(all_numeric(), -all_predictors(), dataset),
+      data = biomass,
+      info = info2
+    ),
+    setNames(nm = c("HHV", "dataset"))
+  )
+  expect_equal(
+    recipes_eval_select(
+      quos = quos(all_numeric(), -all_predictors(), dataset, -dataset),
+      data = biomass,
+      info = info2
+    ),
+    setNames(nm = "HHV")
+  )
+})
+
+test_that('namespaced selectors', {
+  expect_equal(
+    recipes_eval_select(quos = quos(tidyselect::matches("e$")), data = okc, info = info1),
+    recipes_eval_select(quos = quos(matches("e$")), data = okc, info = info1)
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(dplyr::matches("e$")), data = okc, info = info1),
+    recipes_eval_select(quos(matches("e$")), data = okc, info = info1)
+  )
+  expect_equal(
+    recipes_eval_select(quos = quos(recipes::all_predictors()), data = okc, info = info1),
+    recipes_eval_select(quos = quos(all_predictors()), data = okc, info = info1)
+  )
+})
+
+test_that('new dplyr selectors', {
+  vnames <- c("hydrogen", "carbon")
+  expect_error(
+    rec_1 <-
+      recipe(HHV ~ ., data = biomass) %>%
+      step_normalize(all_of(c("hydrogen", "carbon"))) %>%
+      prep(),
+    regex = NA
+  )
+  expect_equal(names(rec_1$steps[[1]]$means), c("hydrogen", "carbon"))
+
+  expect_error(
+    rec_2 <-
+      recipe(HHV ~ ., data = biomass) %>%
+      step_normalize(all_of(!!vnames)) %>%
+      prep(),
+    regex = NA
+  )
+  expect_equal(names(rec_2$steps[[1]]$means), c("hydrogen", "carbon"))
+
+  expect_error(
+    rec_3 <-
+      recipe(HHV ~ ., data = biomass) %>%
+      step_normalize(any_of(c("hydrogen", "carbon"))) %>%
+      prep(),
+    regex = NA
+  )
+  expect_equal(names(rec_3$steps[[1]]$means), c("hydrogen", "carbon"))
+
+  expect_error(
+    rec_4 <-
+      recipe(HHV ~ ., data = biomass) %>%
+      step_normalize(any_of(c("hydrogen", "carbon", "bourbon"))) %>%
+      prep(),
+    regex = NA
+  )
+  expect_equal(names(rec_4$steps[[1]]$means), c("hydrogen", "carbon"))
+})


### PR DESCRIPTION
This PR adds a suite of tests for `recipes_eval_select()`. These are slightly modified from the `terms_select()` tests. They additionally adds tests for `for all_numeric_predictors()` and `all_nominal_predictors()` which would close https://github.com/tidymodels/recipes/issues/841.