### PR TITLE
fix formatting for family tag in nnmf_sparse

### DIFF
--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -18,7 +18,7 @@
 #' @param seed An integer that will be used to set the seed in isolation when
 #'  computing the factorization.
 #' @template step-return
-#' @family {multivariate transformation steps}
+#' @family multivariate transformation steps
 #' @export
 #' @details Non-negative matrix factorization computes latent components that
 #'  have non-negative values and take into account that the original data have

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -127,6 +127,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -136,6 +136,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -112,6 +112,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -153,6 +153,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -153,6 +153,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -158,6 +158,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -151,6 +151,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -149,6 +149,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_mutate_at.Rd
+++ b/man/step_mutate_at.Rd
@@ -88,6 +88,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_poly}()},
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -135,6 +135,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},
 \code{\link{step_ratio}()},

--- a/man/step_nnmf_sparse.Rd
+++ b/man/step_nnmf_sparse.Rd
@@ -121,4 +121,21 @@ if (rlang::is_installed("RcppML")) {
     ggplot(aes(x = NNMF2, y = NNMF1, col = HHV)) + geom_point()
 }
 }
-\concept{{multivariate transformation steps}}
+\seealso{
+Other multivariate transformation steps: 
+\code{\link{step_classdist}()},
+\code{\link{step_depth}()},
+\code{\link{step_geodist}()},
+\code{\link{step_ica}()},
+\code{\link{step_isomap}()},
+\code{\link{step_kpca_poly}()},
+\code{\link{step_kpca_rbf}()},
+\code{\link{step_kpca}()},
+\code{\link{step_mutate_at}()},
+\code{\link{step_nnmf}()},
+\code{\link{step_pca}()},
+\code{\link{step_pls}()},
+\code{\link{step_ratio}()},
+\code{\link{step_spatialsign}()}
+}
+\concept{multivariate transformation steps}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -149,6 +149,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pls}()},
 \code{\link{step_ratio}()},

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -182,6 +182,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_ratio}()},

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -112,6 +112,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -110,6 +110,7 @@ Other multivariate transformation steps:
 \code{\link{step_kpca_rbf}()},
 \code{\link{step_kpca}()},
 \code{\link{step_mutate_at}()},
+\code{\link{step_nnmf_sparse}()},
 \code{\link{step_nnmf}()},
 \code{\link{step_pca}()},
 \code{\link{step_pls}()},


### PR DESCRIPTION
Fixes the following issue

```
Found the following \keyword or \concept entries with Rd markup:
  File 'step_nnmf_sparse.Rd':
    \concept{{multivariate transformation steps}}
```