### PR TITLE
Add a version requirement for modeldata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     igraph,
     kernlab,
     knitr,
-    modeldata,
+    modeldata (>= 0.1.1),
     parsnip (>= 0.1.7),
     RANN,
     RcppRoll,


### PR DESCRIPTION
Since `tate_text` is new to that version & used several times in tests/examples