### PR TITLE
use print_step in print.step_percentile

### DIFF
--- a/R/percentile.R
+++ b/R/percentile.R
@@ -126,8 +126,8 @@ pctl_by_approx <- function(x, ref) {
 
 print.step_percentile <-
   function(x, width = max(20, options()$width - 35), ...) {
-    cat("Percentile transformation on ", sep = "")
-    printer(x$terms, names(x$ref_dist), x$trained, width)
+    title <- "Percentile transformation on "
+    print_step(names(x$ref_dist), x$terms, x$trained, title, width)
     invisible(x)
   }
 

--- a/tests/testthat/_snaps/percentile.md
+++ b/tests/testthat/_snaps/percentile.md
@@ -12,7 +12,7 @@
       
       Operations:
       
-      Percentile transformation on <none>
+      Percentile transformation on carbon, sulfur
 
 ---
 
@@ -33,7 +33,7 @@
       
       Operations:
       
-      Percentile transformation on ~carbon, ~sulfur [trained]
+      Percentile transformation on carbon, sulfur [trained]
 
 # empty printing
 


### PR DESCRIPTION
This PR finished the work of using `print_step()` in all print methods.