### PR TITLE
reset term_info if fresh = TRUE in prep()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
  
 * Finally removed `step_upsample()` and `step_downsample()` in recipes as they are now available in the themis package.
 
+* Fixed a bug where setting `fresh = TRUE` in `prep()` wouldn't result in re-prepping the recipe. (#492)
+
 # recipes 0.2.0
 
 # New Steps

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -367,8 +367,12 @@ prep.recipe <-
       )
     }
 
+    if (fresh) {
+      x$term_info <- x$var_info
+    }
 
     running_info <- x$term_info %>% mutate(number = 0, skip = FALSE)
+
     for (i in seq(along.with = x$steps)) {
       needs_tuning <- map_lgl(x$steps[[i]], is_tune)
       if (any(needs_tuning)) {

--- a/tests/testthat/test_basics.R
+++ b/tests/testthat/test_basics.R
@@ -122,6 +122,32 @@ test_that("bake without prep", {
   )
 })
 
+test_that("prep with fresh = TRUE", {
+  test_data <- data.frame(x = factor(c(1, 2)), y = c(1, 2))
+
+  rec <-
+    recipe(y ~ ., data = test_data) %>%
+    step_dummy(x, id = "") %>%
+    prep()
+
+  new_rec <- prep(rec, training = test_data, fresh = TRUE)
+
+  expect_identical(rec, new_rec)
+
+  expect_equal(
+    tidy(new_rec, 1),
+    tibble(terms = "x", columns = "2", id = "")
+  )
+
+  test_data2 <- data.frame(x = factor(c(1, 3)), y = c(1, 2))
+
+  new_rec2 <- prep(rec, training = test_data2, fresh = TRUE)
+
+  expect_equal(
+    tidy(new_rec2, 1),
+    tibble(terms = "x", columns = "3", id = "")
+  )
+})
 
 test_that("bake without newdata", {
   rec <- recipe(HHV ~ ., data = biomass) %>%
@@ -207,3 +233,4 @@ test_that("`retain flag in prep should return data when TRUE and zero rows when 
   prec_4 <- prep(rec, training = mtcars %>% tail(12), retain = FALSE)
   expect_equal(nrow(prec_4$template), 0)
 })
+


### PR DESCRIPTION
This PR should close https://github.com/tidymodels/recipes/issues/492 and close https://github.com/tidymodels/recipes/issues/564.

It was almost doing the right thing, but it was using the `x$term_info` from the prepped recipe. This PR resets the term info if `fresh = TRUE`.

``` r
library(recipes)

test_data <- data.frame(x = factor(c(1,2)), y = c(1,2))

rec <- 
  recipe(y~., data = test_data) %>% 
  step_dummy(all_nominal()) %>% 
  prep()

new_rec <- prep(rec, training = test_data, fresh = TRUE)

identical(rec, new_rec)
#> [1] TRUE
```
