### PR TITLE
fix indentation for 0.2.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
 
 # recipes 0.2.0
 
-# New Steps
+## New Steps
 
 * `step_nnmf_sparse()` uses a different implementation of non-negative matrix factorization that is much faster and enables regularized estimation. (#790)
 
@@ -63,7 +63,6 @@
 * `step_ica()` now indirectly uses the `fastICA` package since that package has increased their R version requirement. Recipe objects from previous versions will error when applied to new data. (#823)
 
 * `step_kpca*()` now directly use the `kernlab` package. Recipe objects from previous versions will error when applied to new data. 
-
 
 ## Developer
 


### PR DESCRIPTION
Last release had slightly wrong indentation, leaving the entire changelog of the release to be missing. This PR should fix the problem

# Before

<img width="1161" alt="Screen Shot 2022-04-19 at 2 06 09 PM" src="https://user-images.githubusercontent.com/14034784/164099113-bda41466-a99a-43af-8a59-755a1238ff82.png">

# After

<img width="1094" alt="Screen Shot 2022-04-19 at 2 07 30 PM" src="https://user-images.githubusercontent.com/14034784/164099962-971e7b62-0a77-4e75-bca9-dd3a81ee7a59.png">


