### PR TITLE
reduce use of sweep() in steps

### DIFF
--- a/R/center.R
+++ b/R/center.R
@@ -120,11 +120,11 @@ prep.step_center <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_center <- function(object, new_data, ...) {
-  res <-
-    sweep(as.matrix(new_data[, names(object$means)]), 2, object$means, "-")
-  res <- tibble::as_tibble(res)
-  new_data[, names(object$means)] <- res
-  as_tibble(new_data)
+  for (column in names(object$means)) {
+    mean <- object$means[column]
+    new_data[[column]] <- new_data[[column]] - mean
+  }
+  new_data
 }
 
 print.step_center <-

--- a/R/range.R
+++ b/R/range.R
@@ -113,18 +113,17 @@ prep.step_range <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_range <- function(object, new_data, ...) {
-  tmp <- as.matrix(new_data[, colnames(object$ranges)])
-  tmp <- sweep(tmp, 2, object$ranges[1, ], "-")
-  tmp <- tmp * (object$max - object$min)
-  tmp <- sweep(tmp, 2, object$ranges[2, ] - object$ranges[1, ], "/")
-  tmp <- tmp + object$min
+  for (column in colnames(object$ranges)) {
+    min <- object$ranges["mins", column]
+    max <- object$ranges["maxs", column]
 
-  tmp[tmp < object$min] <- object$min
-  tmp[tmp > object$max] <- object$max
+    new_data[[column]] <- (new_data[[column]] - min) *
+      (object$max - object$min) / (max - min) + object$min
 
-  tmp <- tibble::as_tibble(tmp)
-  new_data[, colnames(object$ranges)] <- tmp
-  as_tibble(new_data)
+    new_data[[column]] <- pmax(new_data[[column]], object$min)
+    new_data[[column]] <- pmin(new_data[[column]], object$max)
+  }
+  new_data
 }
 
 print.step_range <-

--- a/R/scale.R
+++ b/R/scale.R
@@ -124,11 +124,11 @@ prep.step_scale <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_scale <- function(object, new_data, ...) {
-  res <-
-    sweep(as.matrix(new_data[, names(object$sds)]), 2, object$sds, "/")
-  res <- tibble::as_tibble(res)
-  new_data[, names(object$sds)] <- res
-  as_tibble(new_data)
+  for (column in names(object$sds)) {
+    sd <- object$sds[column]
+    new_data[[column]] <- new_data[[column]] / sd
+  }
+  new_data
 }
 
 print.step_scale <-


### PR DESCRIPTION
This PR is very similar to https://github.com/tidymodels/recipes/pull/972.

The `sweep()`s in `pls_project()` and `old_pls_project()` are kept in because the data are already matrices and we don't gain any improvement from removing them since we need to do `%*%`.