### PR TITLE
Update clarity of r printing for impute_knn()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 
 * `step_time()` has been added that extracts time features such as hour, minute, or second. (#968)
 
+* printing for `step_impute_knn()` now show variables that were imputed instead of variables used for imputing. (#837)
+
 # recipes 0.2.0
 
 ## New Steps

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -282,10 +282,10 @@ bake.step_knnimpute <- bake.step_impute_knn
 #' @export
 print.step_impute_knn <-
   function(x, width = max(20, options()$width - 31), ...) {
-    all_x_vars <- lapply(x$columns, function(x) x$x)
-    all_x_vars <- unique(unlist(all_x_vars))
+    all_y_vars <- lapply(x$columns, function(x) x$y)
+    all_y_vars <- unique(unlist(all_y_vars))
     title <- "K-nearest neighbor imputation for "
-    print_step(all_x_vars, x$terms, x$trained, title, width)
+    print_step(all_y_vars, x$terms, x$trained, title, width)
     invisible(x)
   }
 

--- a/tests/testthat/_snaps/impute_knn.md
+++ b/tests/testthat/_snaps/impute_knn.md
@@ -32,7 +32,7 @@
       
       Operations:
       
-      K-nearest neighbor imputation for hydrogen, oxygen, nitrogen [trained]
+      K-nearest neighbor imputation for carbon, nitrogen [trained]
 
 # options
 


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/837.

Printing now reflects the variable that was imputed, not the variables used for imputing

``` r
library(recipes)

iris <- tibble(iris)
iris[1, 2] <- NA_real_
iris[1, 3] <- NA_real_
iris
#> # A tibble: 150 × 5
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1        NA           NA           0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 140 more rows

base_rec <- recipe(Sepal.Length ~ ., data = iris) %>% 
  step_impute_knn(Petal.Length) 

prep(base_rec)
#> Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          4
#> 
#> Training data contained 150 data points and 1 incomplete row. 
#> 
#> Operations:
#> 
#> K-nearest neighbor imputation for Petal.Length [trained]
prep(base_rec) %>% bake(new_data = NULL)
#> # A tibble: 150 × 5
#>    Sepal.Width Petal.Length Petal.Width Species Sepal.Length
#>          <dbl>        <dbl>       <dbl> <fct>          <dbl>
#>  1        NA           1.44         0.2 setosa           5.1
#>  2         3           1.4          0.2 setosa           4.9
#>  3         3.2         1.3          0.2 setosa           4.7
#>  4         3.1         1.5          0.2 setosa           4.6
#>  5         3.6         1.4          0.2 setosa           5  
#>  6         3.9         1.7          0.4 setosa           5.4
#>  7         3.4         1.4          0.3 setosa           4.6
#>  8         3.4         1.5          0.2 setosa           5  
#>  9         2.9         1.4          0.2 setosa           4.4
#> 10         3.1         1.5          0.1 setosa           4.9
#> # … with 140 more rows
```

<sup>Created on 2022-05-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>