### PR TITLE
make sure composition returns a tibble if composition is set to tibble

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -802,6 +802,8 @@ juice <- function(object, ..., composition = "tibble") {
     new_data <- convert_matrix(new_data, sparse = FALSE)
   } else if (composition == "data.frame") {
     new_data <- base::as.data.frame(new_data)
+  } else if (composition == "tibble") {
+    new_data <- tibble::as_tibble(new_data)
   }
 
   new_data


### PR DESCRIPTION
With the advent of https://github.com/tidymodels/recipes/pull/979, and the changes in other packages I found a small use-case where we don't have type consistency. `juice()` doesn't do any enforcement to make sure that a tibble is returned if `composition == "tibble"`. This PR fixes that.

Reprex of what went wrong in https://github.com/tidymodels/themis/pull/96

``` r
library(recipes)
library(themis)

recipe(class ~ x + y, data = circle_example) %>%
  step_smotenc(class) %>%
  prep() %>%
  bake(new_data = NULL) %>%
  str()
#> 'data.frame':    684 obs. of  3 variables:
#>  $ x    : num  2.59 9.71 9.53 9.73 13.05 ...
#>  $ y    : num  10.61 6.83 11.6 11.86 9.03 ...
#>  $ class: Factor w/ 2 levels "Circle","Rest": 2 1 2 2 2 2 2 2 1 1 ...

recipe(class ~ x + y, data = circle_example) %>%
  step_smotenc(class) %>%
  prep() %>%
  bake(new_data = circle_example)
#> # A tibble: 400 × 3
#>        x     y class 
#>    <dbl> <dbl> <fct> 
#>  1  2.59 10.6  Rest  
#>  2  9.71  6.83 Circle
#>  3  9.53 11.6  Rest  
#>  4  9.73 11.9  Rest  
#>  5 13.1   9.03 Rest  
#>  6  9.96  3.64 Rest  
#>  7  1.13 11.6  Rest  
#>  8  4.26  2.30 Rest  
#>  9 10.3   9.71 Circle
#> 10  8.20  6.82 Circle
#> # … with 390 more rows
```

<sup>Created on 2022-05-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>