### PR TITLE
Add missing skip if not installed

### DIFF
--- a/tests/testthat/test_depth.R
+++ b/tests/testthat/test_depth.R
@@ -1,9 +1,8 @@
 library(testthat)
 library(recipes)
-library(ddalpha)
-
 
 test_that("defaults", {
+  skip_if_not_installed("ddalpha")
   rec <- recipe(Species ~ ., data = iris) %>%
     step_depth(all_predictors(), class = "Species", metric = "spatial", id = "")
   trained <- prep(rec, training = iris, verbose = FALSE)
@@ -41,6 +40,7 @@ test_that("defaults", {
 })
 
 test_that("alt args", {
+  skip_if_not_installed("ddalpha")
   rec <- recipe(Species ~ ., data = iris) %>%
     step_depth(all_predictors(),
       class = "Species",
@@ -54,7 +54,7 @@ test_that("alt args", {
 
   split_up <- split(iris[, 1:4], iris$Species)
   Mahalanobis <- function(x, y) {
-    depth.Mahalanobis(x = y, data = x, mah.estimate = "MCD", mah.parMcd = .75)
+    ddalpha::depth.Mahalanobis(x = y, data = x, mah.estimate = "MCD", mah.parMcd = .75)
   }
 
   exp_res <- lapply(split_up, Mahalanobis, y = iris[, 1:4])
@@ -70,6 +70,7 @@ test_that("alt args", {
 
 
 test_that("printing", {
+  skip_if_not_installed("ddalpha")
   rec <- recipe(Species ~ ., data = iris) %>%
     step_depth(all_predictors(), class = "Species", metric = "spatial")
   expect_snapshot(print(rec))
@@ -77,6 +78,7 @@ test_that("printing", {
 })
 
 test_that("prefix", {
+  skip_if_not_installed("ddalpha")
   rec <- recipe(Species ~ ., data = iris) %>%
     step_depth(all_predictors(),
       class = "Species",
@@ -89,6 +91,7 @@ test_that("prefix", {
 })
 
 test_that("empty selection prep/bake adds NA columns", {
+  skip_if_not_installed("ddalpha")
   rec1 <- recipe(Species ~ ., iris)
   rec2 <- step_depth(rec1, class = "Species")
 
@@ -102,6 +105,7 @@ test_that("empty selection prep/bake adds NA columns", {
 })
 
 test_that("empty selection tidy method works", {
+  skip_if_not_installed("ddalpha")
   rec <- recipe(Species ~ ., iris)
   rec <- step_depth(rec, class = "Species")
 
@@ -115,6 +119,7 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("empty printing", {
+  skip_if_not_installed("ddalpha")
   skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(Species ~ ., iris)
   rec <- step_depth(rec, class = "Species")

--- a/tests/testthat/test_roll.R
+++ b/tests/testthat/test_roll.R
@@ -54,6 +54,7 @@ test_that("error checks", {
 })
 
 test_that("basic moving average", {
+  skip_if_not_installed("RcppRoll")
   simple_ma <- rec %>%
     step_window(starts_with("y"))
   simple_ma <- prep(simple_ma, training = sim_dat)
@@ -71,6 +72,7 @@ test_that("basic moving average", {
 })
 
 test_that("creating new variables", {
+  skip_if_not_installed("RcppRoll")
   new_names <- rec %>%
     step_window(starts_with("y"), names = paste0("new", 1:2), role = "predictor")
   new_names <- prep(new_names, training = sim_dat)
@@ -86,6 +88,7 @@ test_that("creating new variables", {
 })
 
 test_that("na_rm argument works for step_window", {
+  skip_if_not_installed("RcppRoll")
 
   sim_dat_na <- sim_dat
   sim_dat_na[7, 2:3] <- NA
@@ -113,6 +116,7 @@ test_that("na_rm argument works for step_window", {
 })
 
 test_that("printing", {
+  skip_if_not_installed("RcppRoll")
   new_names <- rec %>%
     step_window(starts_with("y"), names = paste0("new", 1:2), role = "predictor")
   expect_snapshot(print(new_names))


### PR DESCRIPTION
This PR adds `skip_if_not_installed()` to a couple of test files that didn't have them for steps that uses suggested packages.