### PR TITLE
add missing tibble conversion in prep.recipe

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -418,6 +418,9 @@ prep.recipe <-
             info = x$term_info
           )
         training <- bake(x$steps[[i]], new_data = training)
+        if (!is_tibble(training)) {
+          training <- as_tibble(training)
+        }
         x$term_info <-
           merge_term_info(get_types(training), x$term_info)
 


### PR DESCRIPTION
We saw an error in https://github.com/tidymodels/extratests/actions/runs/2375665870. This error didn't have anything to do with parallel processing or themis in particular. The error surfaced because `bake.step_smote()` returns a data.frame instead of a tibble.

What happened was the changes in https://github.com/tidymodels/recipes/pull/979 and https://github.com/tidymodels/themis/pull/96 was done incompletely. 

We convert to tibble after each `bake.step_*` inside `bake.recipe()`

https://github.com/tidymodels/recipes/blob/77fa788b3fed542c7832fc00a8b9725a165e6a46/R/recipe.R#L580

But I forgot to add the same check after each `bake.step_*` inside `prep.recipe()`. This PR fixes that.
