### PR TITLE
Step date locale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@
 
 * `prep()` and `bake()` checks and errors if output of `bake.bake_*()` isn't a tibble.
 
+* `step_date()` now has a locale argument that can be used to control how the `month` and `dow` features are returned. (#1000)
+
 # recipes 0.2.0
 
 ## New Steps

--- a/R/date.R
+++ b/R/date.R
@@ -253,7 +253,7 @@ bake.step_date <- function(object, new_data, ...) {
     tmp <- get_date_features(
       dt = getElement(new_data, object$columns[i]),
       feats = object$features,
-      locale = object$locale,
+      locale = object$locale %||% Sys.getlocale("LC_TIME"),
       abbr = object$abbr,
       label = object$label,
       ord = object$ordinal

--- a/R/date.R
+++ b/R/date.R
@@ -27,6 +27,9 @@
 #'  FALSE`.
 #' @param ordinal A logical: should factors be ordered? Only
 #'  available for features `month` or `dow`.
+#' @param locale locale to be used for `month` and `dow`, see [locales].
+#'  On Linux systems you can use `system("locale -a")` to list all the
+#'  installed locales. Defaults to `Sys.getlocale("LC_TIME")`.
 #' @param columns A character string of variables that will be
 #'  used as inputs. This field is a placeholder and will be
 #'  populated once [prep()] is used.
@@ -77,6 +80,7 @@ step_date <-
            abbr = TRUE,
            label = TRUE,
            ordinal = FALSE,
+           locale = Sys.getlocale("LC_TIME"),
            columns = NULL,
            keep_original_cols = TRUE,
            skip = FALSE,
@@ -110,6 +114,7 @@ step_date <-
         abbr = abbr,
         label = label,
         ordinal = ordinal,
+        locale = locale,
         columns = columns,
         keep_original_cols = keep_original_cols,
         skip = skip,
@@ -119,8 +124,8 @@ step_date <-
   }
 
 step_date_new <-
-  function(terms, role, trained, features, abbr, label, ordinal, columns,
-           keep_original_cols, skip, id) {
+  function(terms, role, trained, features, abbr, label, ordinal, locale,
+           columns, keep_original_cols, skip, id) {
     step(
       subclass = "date",
       terms = terms,
@@ -130,6 +135,7 @@ step_date_new <-
       abbr = abbr,
       label = label,
       ordinal = ordinal,
+      locale = locale,
       columns = columns,
       keep_original_cols = keep_original_cols,
       skip = skip,
@@ -160,6 +166,7 @@ prep.step_date <- function(x, training, info = NULL, ...) {
     abbr = x$abbr,
     label = x$label,
     ordinal = x$ordinal,
+    locale = x$locale,
     columns = col_names,
     keep_original_cols = get_keep_original_cols(x),
     skip = x$skip,
@@ -177,6 +184,7 @@ ord2fac <- function(x, what) {
 get_date_features <-
   function(dt,
            feats,
+           locale,
            abbr = TRUE,
            label = TRUE,
            ord = FALSE) {
@@ -205,7 +213,7 @@ get_date_features <-
     }
     if ("dow" %in% feats) {
       res[, grepl("dow$", names(res))] <-
-        wday(dt, abbr = abbr, label = label)
+        wday(dt, abbr = abbr, label = label, locale = locale)
       if (!ord & label == TRUE) {
         res[, grepl("dow$", names(res))] <-
           ord2fac(res, grep("dow$", names(res), value = TRUE))
@@ -213,7 +221,7 @@ get_date_features <-
     }
     if ("month" %in% feats) {
       res[, grepl("month$", names(res))] <-
-        month(dt, abbr = abbr, label = label)
+        month(dt, abbr = abbr, label = label, locale = locale)
       if (!ord & label == TRUE) {
         res[, grepl("month$", names(res))] <-
           ord2fac(res, grep("month$", names(res), value = TRUE))
@@ -245,6 +253,7 @@ bake.step_date <- function(object, new_data, ...) {
     tmp <- get_date_features(
       dt = getElement(new_data, object$columns[i]),
       feats = object$features,
+      locale = object$locale,
       abbr = object$abbr,
       label = object$label,
       ord = object$ordinal

--- a/R/date.R
+++ b/R/date.R
@@ -27,7 +27,7 @@
 #'  FALSE`.
 #' @param ordinal A logical: should factors be ordered? Only
 #'  available for features `month` or `dow`.
-#' @param locale locale to be used for `month` and `dow`, see [locales].
+#' @param locale Locale to be used for `month` and `dow`, see [locales].
 #'  On Linux systems you can use `system("locale -a")` to list all the
 #'  installed locales. Defaults to `Sys.getlocale("LC_TIME")`.
 #' @param columns A character string of variables that will be

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -13,6 +13,7 @@ step_date(
   abbr = TRUE,
   label = TRUE,
   ordinal = FALSE,
+  locale = Sys.getlocale("LC_TIME"),
   columns = NULL,
   keep_original_cols = TRUE,
   skip = FALSE,
@@ -54,6 +55,10 @@ number.}
 
 \item{ordinal}{A logical: should factors be ordered? Only
 available for features \code{month} or \code{dow}.}
+
+\item{locale}{locale to be used for \code{month} and \code{dow}, see \link{locales}.
+On Linux systems you can use \code{system("locale -a")} to list all the
+installed locales. Defaults to \code{Sys.getlocale("LC_TIME")}.}
 
 \item{columns}{A character string of variables that will be
 used as inputs. This field is a placeholder and will be

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -56,7 +56,7 @@ number.}
 \item{ordinal}{A logical: should factors be ordered? Only
 available for features \code{month} or \code{dow}.}
 
-\item{locale}{locale to be used for \code{month} and \code{dow}, see \link{locales}.
+\item{locale}{Locale to be used for \code{month} and \code{dow}, see \link{locales}.
 On Linux systems you can use \code{system("locale -a")} to list all the
 installed locales. Defaults to \code{Sys.getlocale("LC_TIME")}.}
 

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -149,6 +149,19 @@ test_that("locale argument works when specified", {
   Sys.setlocale("LC_TIME", old_locale)
 })
 
+test_that("can bake and recipes with no locale", {
+  date_rec <- recipe(~ Dan + Stefan, examples) %>%
+    step_date(all_predictors()) %>%
+    prep()
+
+  date_rec$steps[[1]]$locale <- NULL
+
+  expect_error(
+    date_res <- bake(date_rec, new_data = examples, all_predictors()),
+    NA
+  )
+})
+
 test_that("can prep recipes with no keep_original_cols", {
   date_rec <- recipe(~ Dan + Stefan, examples) %>%
     step_date(all_predictors(), features = feats, keep_original_cols = FALSE)

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -112,6 +112,43 @@ test_that("keep_original_cols works", {
   )
 })
 
+test_that("locale argument have recipe work in different locale", {
+  old_locale <- Sys.getlocale("LC_TIME")
+  Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
+
+  date_rec <- recipe(~ Dan + Stefan, examples) %>%
+    step_date(all_predictors()) %>%
+    prep()
+
+  ref_res <- bake(date_rec, new_data = examples)
+
+  Sys.setlocale("LC_TIME", old_locale)
+
+  new_res <- bake(date_rec, new_data = examples)
+
+  expect_equal(ref_res, new_res)
+})
+
+test_that("locale argument works when specified", {
+  old_locale <- Sys.getlocale("LC_TIME")
+  date_rec <- recipe(~ Dan + Stefan, examples) %>%
+    step_date(all_predictors()) %>%
+    prep()
+
+  ref_res <- bake(date_rec, new_data = examples)
+
+  Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
+
+  date_rec <- recipe(~ Dan + Stefan, examples) %>%
+    step_date(all_predictors(), locale = old_locale) %>%
+    prep()
+
+  new_res <- bake(date_rec, new_data = examples)
+
+  expect_equal(ref_res, new_res)
+  Sys.setlocale("LC_TIME", old_locale)
+})
+
 test_that("can prep recipes with no keep_original_cols", {
   date_rec <- recipe(~ Dan + Stefan, examples) %>%
     step_date(all_predictors(), features = feats, keep_original_cols = FALSE)

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -114,6 +114,7 @@ test_that("keep_original_cols works", {
 
 test_that("locale argument have recipe work in different locale", {
   old_locale <- Sys.getlocale("LC_TIME")
+  withr::defer(Sys.setlocale("LC_TIME", old_locale))
   Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
 
   date_rec <- recipe(~ Dan + Stefan, examples) %>%
@@ -131,6 +132,7 @@ test_that("locale argument have recipe work in different locale", {
 
 test_that("locale argument works when specified", {
   old_locale <- Sys.getlocale("LC_TIME")
+  withr::defer(Sys.setlocale("LC_TIME", old_locale))
   date_rec <- recipe(~ Dan + Stefan, examples) %>%
     step_date(all_predictors()) %>%
     prep()
@@ -146,7 +148,6 @@ test_that("locale argument works when specified", {
   new_res <- bake(date_rec, new_data = examples)
 
   expect_equal(ref_res, new_res)
-  Sys.setlocale("LC_TIME", old_locale)
 })
 
 test_that("can bake and recipes with no locale", {


### PR DESCRIPTION
This PR aims to close #1000 by adding a `locale` argument to `step_date()`. This accomplished 2 things; First it removed the buggy behavior shown in #1000 by using the same transformation at `bake()` time as was used at `prep()` time. Secondly it allows you to set the locale up front as an argument so you can specify the locale without setting environment variables. 

``` r
library(recipes)

Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
#> [1] "fr_FR.UTF-8"

examples <- tibble(someday = lubridate::ymd("2000-12-20") + lubridate::days(0:40))
rec <- recipe(~ someday, examples) %>%
  step_date(all_predictors()) %>%
  prep() 

rec %>%
  bake(new_data = examples)
#> # A tibble: 41 × 4
#>    someday    someday_dow someday_month someday_year
#>    <date>     <fct>       <fct>                <dbl>
#>  1 2000-12-20 Mer         déc                   2000
#>  2 2000-12-21 Jeu         déc                   2000
#>  3 2000-12-22 Ven         déc                   2000
#>  4 2000-12-23 Sam         déc                   2000
#>  5 2000-12-24 Dim         déc                   2000
#>  6 2000-12-25 Lun         déc                   2000
#>  7 2000-12-26 Mar         déc                   2000
#>  8 2000-12-27 Mer         déc                   2000
#>  9 2000-12-28 Jeu         déc                   2000
#> 10 2000-12-29 Ven         déc                   2000
#> # … with 31 more rows

Sys.setlocale("LC_TIME", 'en_GB.UTF-8')
#> [1] "en_GB.UTF-8"

rec %>%
  bake(new_data = examples)
#> # A tibble: 41 × 4
#>    someday    someday_dow someday_month someday_year
#>    <date>     <fct>       <fct>                <dbl>
#>  1 2000-12-20 Mer         déc                   2000
#>  2 2000-12-21 Jeu         déc                   2000
#>  3 2000-12-22 Ven         déc                   2000
#>  4 2000-12-23 Sam         déc                   2000
#>  5 2000-12-24 Dim         déc                   2000
#>  6 2000-12-25 Lun         déc                   2000
#>  7 2000-12-26 Mar         déc                   2000
#>  8 2000-12-27 Mer         déc                   2000
#>  9 2000-12-28 Jeu         déc                   2000
#> 10 2000-12-29 Ven         déc                   2000
#> # … with 31 more rows
```

<sup>Created on 2022-06-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



``` r
library(recipes)

Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
#> [1] "fr_FR.UTF-8"

examples <- tibble(someday = lubridate::ymd("2000-12-20") + lubridate::days(0:40))
rec <- recipe(~ someday, examples) %>%
  step_date(all_predictors(), locale = 'en_GB.UTF-8') %>%
  prep() 

rec %>%
  bake(new_data = examples)
#> # A tibble: 41 × 4
#>    someday    someday_dow someday_month someday_year
#>    <date>     <fct>       <fct>                <dbl>
#>  1 2000-12-20 Wed         Dec                   2000
#>  2 2000-12-21 Thu         Dec                   2000
#>  3 2000-12-22 Fri         Dec                   2000
#>  4 2000-12-23 Sat         Dec                   2000
#>  5 2000-12-24 Sun         Dec                   2000
#>  6 2000-12-25 Mon         Dec                   2000
#>  7 2000-12-26 Tue         Dec                   2000
#>  8 2000-12-27 Wed         Dec                   2000
#>  9 2000-12-28 Thu         Dec                   2000
#> 10 2000-12-29 Fri         Dec                   2000
#> # … with 31 more rows
```

<sup>Created on 2022-06-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
