### PR TITLE
`check_new_data_columns`: Only check the required variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,7 @@
 
 * `step_kpca*()` now directly use the `kernlab` package. Recipe objects from previous versions will error when applied to new data. 
 
-* `bake()` will now error if `new_data` doesn't contain all the required columns. (#491)
+* `bake()` will now error if `new_data` doesn't contain all the required columns. (#491, #1009)
 
 ## Developer
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -715,7 +715,7 @@ check_new_data_columns <-
   function(object, new_data, exclusions = c("case_weights", "outcome")) {
 
     original_var_data <- object$var_info %>%
-      dplyr::filter(source == "original", is.na(role) | !(role %in% exclusions))
+      dplyr::filter(source == "original", !is.na(role), !(role %in% exclusions))
     original_vars <- original_var_data %>%  dplyr::pull(variable)
 
     if (!is.null(new_data) && !all(original_vars %in% colnames(new_data))) {

--- a/tests/testthat/test_bake.R
+++ b/tests/testthat/test_bake.R
@@ -43,7 +43,8 @@ test_that("bake errors if predictor cols are missing from new_data", {
   expect_error(rec2 %>% prep() %>% bake(mtcars_mat[, -(2:6)]), error26)
 
   mtcars_mat <- as.matrix(mtcars)
-  rec3 <- recipe(x = mtcars_mat)
+  rec3 <- recipe(x = mtcars_mat) %>%
+    update_role(mpg, cyl, disp, hp, drat, wt, new_role = "predictor")
 
   expect_error(rec3 %>% prep() %>% bake(mtcars_mat), NA)
   expect_error(rec3 %>% prep() %>% bake(mtcars_mat[, -1]), error1)


### PR DESCRIPTION
This fixes #1008 by excluding the variables that have no role in the recipe.