### PR TITLE
make step_holiday with with no missing data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bug where `step_holiday()` didn't work if it isn't have any missing values. (#1019)
+
 # recipes (1.0.0
 
 ## Improvements and Other Changes

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -115,7 +115,9 @@ prep.step_holiday <- function(x, training, info = NULL, ...) {
 is_holiday <- function(hol, dt) {
   years <- unique(year(dt))
   na_year <- which(is.na(years))
-  years <- years[-na_year]
+  if (length(na_year) > 0) {
+    years <- years[-na_year]
+  }
   hdate <- holiday(year = years, Holiday = hol)
   hdate <- as.Date(hdate)
   out <- rep(0, length(dt))

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -53,6 +53,28 @@ test_that("Date class", {
   )
 })
 
+test_that("works with no missing values - Date class", {
+  test_data <- na.omit(test_data)
+
+  holiday_rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday)
+
+  holiday_rec <- prep(holiday_rec, training = test_data)
+  holiday_ind <- bake(holiday_rec, test_data)
+
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_USMemorialDay)],
+    exp_dates$date[exp_dates$holiday == "USMemorialDay"]
+  )
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_ChristmasDay)],
+    exp_dates$date[exp_dates$holiday == "ChristmasDay"]
+  )
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_Easter)],
+    exp_dates$date[exp_dates$holiday == "Easter"]
+  )
+})
 
 test_that("POSIXct class", {
   test_data$day <- as.POSIXct(test_data$day)
@@ -94,6 +116,31 @@ test_that("POSIXct class", {
   )
 })
 
+test_that("works with no missing values - POSIXct class", {
+  test_data <- na.omit(test_data)
+
+  test_data$day <- as.POSIXct(test_data$day)
+  exp_dates$date <- as.POSIXct(exp_dates$date)
+
+  holiday_rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday)
+
+  holiday_rec <- prep(holiday_rec, training = test_data)
+  holiday_ind <- bake(holiday_rec, test_data)
+
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_USMemorialDay)],
+    exp_dates$date[exp_dates$holiday == "USMemorialDay"]
+  )
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_ChristmasDay)],
+    exp_dates$date[exp_dates$holiday == "ChristmasDay"]
+  )
+  expect_equal(
+    holiday_ind$day[is_equal_1(holiday_ind$day_Easter)],
+    exp_dates$date[exp_dates$holiday == "Easter"]
+  )
+})
 
 test_that("printing", {
   holiday_rec <- recipe(~day, test_data) %>%


### PR DESCRIPTION
An bug was introduced in `step_holiday()` when used without missing data. This wasn't detected because all the tests included missing data.

This PR fixes that bug and will close https://github.com/tidymodels/recipes/issues/1019