### PR TITLE
Fix news for 1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Fixed bug where `step_holiday()` didn't work if it isn't have any missing values. (#1019)
 
-# recipes (1.0.0
+# recipes 1.0.0
 
 ## Improvements and Other Changes
 


### PR DESCRIPTION
The current pkgdown doesn't have a bullet for the news because the version was listed as `(1.0.0` instead of `1.0.0`

![Screen Shot 2022-07-13 at 1 15 14 PM](https://user-images.githubusercontent.com/14034784/178826415-0cd95115-bfb3-4322-aa94-fc47d3df6ed0.png)

This PR should fix it

![Screen Shot 2022-07-13 at 1 15 23 PM](https://user-images.githubusercontent.com/14034784/178826513-125b8d40-f91d-4b2f-b0b6-2274550f6112.png)

