### PR TITLE
Have steps return integers when appropriate 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed bug where `step_holiday()` didn't work if it isn't have any missing values. (#1019)
 
+* `step_date()`, `step_dummy()`, `step_dummy_extract()`, `step_holiday()`, `step_ordinalscore()`, and `step_regex()` now returns integer results when appropriate. (#766)
+
 * `step_integer()` has a new default `strict = TRUE` returning integers by default. (#766)
 
 * `step_intercept()` has a new default `value = 1L` returning an integer intercept by default. (#766)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Fixed bug where `step_holiday()` didn't work if it isn't have any missing values. (#1019)
 
+* `step_integer()` has a new default `strict = TRUE` returning integers by default. (#766)
+
+* `step_intercept()` has a new default `value = 1L` returning an integer intercept by default. (#766)
+
 # recipes 1.0.0
 
 ## Improvements and Other Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,9 @@
 
 * `step_date()`, `step_dummy()`, `step_dummy_extract()`, `step_holiday()`, `step_ordinalscore()`, and `step_regex()` now returns integer results when appropriate. (#766)
 
-* `step_integer()` has a new default `strict = TRUE` returning integers by default. (#766)
+* The default for the `strict` argument in `step_integer()` has been changed from `FALSE` to `TRUE`. The function will thus return integers, rather than whole-number numerics, by default. (#766)
 
-* `step_intercept()` has a new default `value = 1L` returning an integer intercept by default. (#766)
+* The default for the `value` argument in `step_intercept()` has been changed from `1` to `1L`. (#766)
 
 # recipes 1.0.0
 

--- a/R/date.R
+++ b/R/date.R
@@ -189,27 +189,27 @@ get_date_features <-
            label = TRUE,
            ord = FALSE) {
     ## pre-allocate values
-    res <- matrix(NA, nrow = length(dt), ncol = length(feats))
+    res <- matrix(NA_integer_, nrow = length(dt), ncol = length(feats))
     colnames(res) <- feats
     res <- as_tibble(res)
 
     if ("year" %in% feats) {
-      res[, grepl("year$", names(res))] <- year(dt)
+      res[, grepl("year$", names(res))] <- vec_cast(year(dt), integer())
     }
     if ("doy" %in% feats) {
-      res[, grepl("doy$", names(res))] <- yday(dt)
+      res[, grepl("doy$", names(res))] <- vec_cast(yday(dt), integer())
     }
     if ("week" %in% feats) {
-      res[, grepl("week$", names(res))] <- week(dt)
+      res[, grepl("week$", names(res))] <- vec_cast(week(dt), integer())
     }
     if ("decimal" %in% feats) {
       res[, grepl("decimal$", names(res))] <- decimal_date(dt)
     }
     if ("quarter" %in% feats) {
-      res[, grepl("quarter$", names(res))] <- quarter(dt)
+      res[, grepl("quarter$", names(res))] <- vec_cast( quarter(dt), integer())
     }
     if ("semester" %in% feats) {
-      res[, grepl("semester$", names(res))] <- semester(dt)
+      res[, grepl("semester$", names(res))] <- vec_cast(semester(dt), integer())
     }
     if ("dow" %in% feats) {
       res[, grepl("dow$", names(res))] <-

--- a/R/date.R
+++ b/R/date.R
@@ -206,7 +206,7 @@ get_date_features <-
       res[, grepl("decimal$", names(res))] <- decimal_date(dt)
     }
     if ("quarter" %in% feats) {
-      res[, grepl("quarter$", names(res))] <- vec_cast( quarter(dt), integer())
+      res[, grepl("quarter$", names(res))] <- vec_cast(quarter(dt), integer())
     }
     if ("semester" %in% feats) {
       res[, grepl("semester$", names(res))] <- vec_cast(semester(dt), integer())

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -314,6 +314,9 @@ bake.step_dummy <- function(object, new_data, ...) {
         data = indicators
       )
     indicators <- as_tibble(indicators)
+    if (fac_type != "ordered") {
+      indicators <- purrr::map_dfc(indicators, vec_cast, integer())
+    }
 
     options(na.action = old_opt)
     on.exit(expr = NULL)

--- a/R/extract.R
+++ b/R/extract.R
@@ -233,6 +233,7 @@ bake.step_dummy_extract <- function(object, new_data, ...) {
     )
 
     indicators <- list_to_dummies(elements, sort(object$levels[[i]]), object$other)
+    indicators <- purrr::map_dfc(indicators, vec_cast, integer())
 
     ## use backticks for nonstandard factor levels here
     used_lvl <- gsub(paste0("^", col_names[i]), "", colnames(indicators))

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -148,6 +148,8 @@ bake.step_holiday <- function(object, new_data, ...) {
     )
 
     names(tmp) <- paste(object$columns[i], names(tmp), sep = "_")
+    tmp <- purrr::map_dfc(tmp, vec_cast, integer())
+
     new_data <- bind_cols(new_data, tmp)
   }
 

--- a/R/integer.R
+++ b/R/integer.R
@@ -60,7 +60,7 @@ step_integer <-
            ...,
            role = "predictor",
            trained = FALSE,
-           strict = FALSE,
+           strict = TRUE,
            zero_based = FALSE,
            key = NULL,
            skip = FALSE,

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -14,7 +14,8 @@
 #' @param trained A logical to indicate if the quantities for preprocessing
 #'   have been estimated. Again included only for consistency.
 #' @param name Character name for newly added column
-#' @param value A numeric constant to fill the intercept column. Defaults to 1.
+#' @param value A numeric constant to fill the intercept column. Defaults to
+#'   `1L`.
 #' @template step-return
 #' @export
 #'

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -40,7 +40,7 @@
 #' with_intercept
 step_intercept <- function(recipe, ..., role = "predictor",
                            trained = FALSE, name = "intercept",
-                           value = 1,
+                           value = 1L,
                            skip = FALSE, id = rand_id("intercept")) {
   if (length(list(...)) > 0) {
     rlang::warn("Selectors are not used for this step.")

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -133,6 +133,8 @@ bake.step_ordinalscore <- function(object, new_data, ...) {
   check_new_data(object$columns, object, new_data)
 
   scores <- lapply(new_data[, object$columns], object$convert)
+  scores <- lapply(scores, vec_cast, integer())
+
   for (i in object$columns) {
     new_data[, i] <- scores[[i]]
   }

--- a/R/regex.R
+++ b/R/regex.R
@@ -157,7 +157,7 @@ bake.step_regex <- function(object, new_data, ...) {
     regex <- mod_call_args(regex, args = object$options)
   }
 
-  new_data[, object$result] <- ifelse(eval(regex), 1, 0)
+  new_data[, object$result] <- ifelse(eval(regex), 1L, 0L)
   new_data
 }
 

--- a/man/step_integer.Rd
+++ b/man/step_integer.Rd
@@ -9,7 +9,7 @@ step_integer(
   ...,
   role = "predictor",
   trained = FALSE,
-  strict = FALSE,
+  strict = TRUE,
   zero_based = FALSE,
   key = NULL,
   skip = FALSE,

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -10,7 +10,7 @@ step_intercept(
   role = "predictor",
   trained = FALSE,
   name = "intercept",
-  value = 1,
+  value = 1L,
   skip = FALSE,
   id = rand_id("intercept")
 )

--- a/man/step_intercept.Rd
+++ b/man/step_intercept.Rd
@@ -31,7 +31,8 @@ have been estimated. Again included only for consistency.}
 
 \item{name}{Character name for newly added column}
 
-\item{value}{A numeric constant to fill the intercept column. Defaults to 1.}
+\item{value}{A numeric constant to fill the intercept column. Defaults to
+\code{1L}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/tests/testthat/_snaps/dummies.md
+++ b/tests/testthat/_snaps/dummies.md
@@ -81,7 +81,7 @@
     Output
       # A tibble: 10 x 2
          y      x1_B
-         <fct> <dbl>
+         <fct> <int>
        1 0         0
        2 0         1
        3 1         0

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -28,6 +28,23 @@ test_that("default option", {
   expect_equal(date_res, date_exp)
 })
 
+test_that("returns integers", {
+  examples <- data.frame(
+    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
+      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
+  )
+
+  feats <- c("hour", "hour12", "minute")
+
+  date_rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors(), features = feats, keep_original_cols = FALSE)
+
+  date_rec <- prep(date_rec, training = examples)
+  date_res <- bake(date_rec, new_data = examples)
+
+  expect_true(all(vapply(date_res, is.integer, logical(1))))
+})
+
 
 test_that("nondefault options", {
   examples <- data.frame(

--- a/tests/testthat/test_count.R
+++ b/tests/testthat/test_count.R
@@ -12,7 +12,6 @@ counts <- gregexpr(pattern = "(rock|stony)", text = covers$description)
 counts <- vapply(counts, function(x) length(x[x > 0]), integer(1))
 chars <- nchar(covers$description)
 
-
 test_that("default options", {
   rec1 <- rec %>%
     step_count(description, pattern = "(rock|stony)") %>%
@@ -26,6 +25,10 @@ test_that("default options", {
   expect_equal(res1$X.rock.stony., counts)
   expect_equal(res1$`every thing`, chars)
   expect_equal(res1$pct, counts / chars)
+
+  expect_true(is.integer(res1$X.rock.stony.))
+  expect_true(is.integer(res1$`every thing`))
+  expect_false(is.integer(res1$pct))
 })
 
 

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -3,7 +3,6 @@ library(recipes)
 library(lubridate)
 library(tibble)
 
-
 examples <- data.frame(
   Dan = ymd("2002-03-04") + days(1:10),
   Stefan = ymd("2006-01-13") + days(1:10)
@@ -26,20 +25,20 @@ test_that("default option", {
   date_exp <- tibble(
     Dan = examples$Dan,
     Stefan = examples$Stefan,
-    Dan_year = year(examples$Dan),
-    Dan_doy = yday(examples$Dan),
-    Dan_week = week(examples$Dan),
+    Dan_year = vec_cast(year(examples$Dan), integer()),
+    Dan_doy = vec_cast(yday(examples$Dan), integer()),
+    Dan_week = vec_cast(week(examples$Dan), integer()),
     Dan_decimal = decimal_date(examples$Dan),
-    Dan_semester = semester(examples$Dan),
-    Dan_quarter = quarter(examples$Dan),
+    Dan_semester = vec_cast(semester(examples$Dan), integer()),
+    Dan_quarter = vec_cast(quarter(examples$Dan), integer()),
     Dan_dow = wday(examples$Dan, label = TRUE, abbr = TRUE),
     Dan_month = month(examples$Dan, label = TRUE, abbr = TRUE),
-    Stefan_year = year(examples$Stefan),
-    Stefan_doy = yday(examples$Stefan),
-    Stefan_week = week(examples$Stefan),
+    Stefan_year = vec_cast(year(examples$Stefan), integer()),
+    Stefan_doy = vec_cast(yday(examples$Stefan), integer()),
+    Stefan_week = vec_cast(week(examples$Stefan), integer()),
     Stefan_decimal = decimal_date(examples$Stefan),
-    Stefan_semester = semester(examples$Stefan),
-    Stefan_quarter = quarter(examples$Stefan),
+    Stefan_semester = vec_cast(semester(examples$Stefan), integer()),
+    Stefan_quarter = vec_cast(quarter(examples$Stefan), integer()),
     Stefan_dow = wday(examples$Stefan, label = TRUE, abbr = TRUE),
     Stefan_month = month(examples$Stefan, label = TRUE, abbr = TRUE)
   )
@@ -48,7 +47,7 @@ test_that("default option", {
   date_exp$Stefan_dow <- factor(as.character(date_exp$Stefan_dow), levels = levels(date_exp$Stefan_dow))
   date_exp$Stefan_month <- factor(as.character(date_exp$Stefan_month), levels = levels(date_exp$Stefan_month))
 
-  expect_equal(date_res, date_exp)
+  expect_identical(date_res, date_exp)
 })
 
 

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -84,6 +84,14 @@ test_that("dummy variables with non-factor inputs", {
   )
 })
 
+test_that("create integer dummy variables", {
+  rec <- recipe(sqft ~ zip + city, data = sacr_fac)
+  dummy <- rec %>% step_dummy(city, zip, id = "")
+  dummy_trained <- prep(dummy, training = sacr_fac, verbose = FALSE, strings_as_factors = FALSE)
+  dummy_pred <- bake(dummy_trained, new_data = sacr_fac, all_predictors())
+  expect_true(all(vapply(dummy_pred, is.integer, logical(1))))
+})
+
 test_that("create all dummy variables", {
   rec <- recipe(sqft ~ zip + city + price, data = sacr_fac)
   dummy <- rec %>% step_dummy(city, zip, one_hot = TRUE, id = "")

--- a/tests/testthat/test_dummies_extract.R
+++ b/tests/testthat/test_dummies_extract.R
@@ -14,20 +14,20 @@ color_examples <- tibble(
 
 color_result <- tribble(
   ~colors_blue, ~colors_red, ~colors_white, ~colors_other,
-  1,            1,           0,             0,
-  1,            1,           1,             0,
-  3,            0,           0,             0
+  1L,            1L,           0L,             0L,
+  1L,            1L,           1L,             0L,
+  3L,            0L,           0L,             0L
 )
 
 mini_tate <- tate_text[c(101, 102, 105, 108), ]
 
 mini_tate_result <- tibble(
-  medium_Charcoal = c(0, 0, 0, 1),
-  medium_Etching =  c(1, 1, 1, 0),
-  medium_aquatint = c(1, 0, 0, 0),
-  medium_gouache =  c(0, 0, 0, 1),
-  medium_paper =    c(1, 1, 1, 1),
-  medium_other =    c(0, 0, 0, 0)
+  medium_Charcoal = c(0L, 0L, 0L, 1L),
+  medium_Etching =  c(1L, 1L, 1L, 0L),
+  medium_aquatint = c(1L, 0L, 0L, 0L),
+  medium_gouache =  c(0L, 0L, 0L, 1L),
+  medium_paper =    c(1L, 1L, 1L, 1L),
+  medium_other =    c(0L, 0L, 0L, 0L)
 )
 
 test_that("dummy variables", {
@@ -285,8 +285,8 @@ test_that("case weights", {
   dummy_pred <- bake(dummy_prepped, new_data = mini_tate)
 
   exp_results <- tibble(
-    medium_paper = c(1, 1, 1, 1),
-    medium_other = c(2, 1, 1, 2)
+    medium_paper = c(1L, 1L, 1L, 1L),
+    medium_other = c(2L, 1L, 1L, 2L)
   )
 
   expect_identical(dummy_pred, exp_results)
@@ -312,7 +312,7 @@ test_that("case weights", {
   dummy_pred <- bake(dummy_prepped, new_data = mini_tate)
 
   exp_results <- tibble(
-    medium_other = c(3, 2, 2, 3)
+    medium_other = c(3L, 2L, 2L, 3L)
   )
 
   expect_identical(dummy_pred, exp_results)

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -53,6 +53,18 @@ test_that("Date class", {
   )
 })
 
+test_that("Date class", {
+  holiday_rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(),
+                 holidays = exp_dates$holiday,
+                 keep_original_cols = FALSE)
+
+  holiday_rec <- prep(holiday_rec, training = test_data)
+  holiday_ind <- bake(holiday_rec, test_data, all_predictors())
+
+  expect_true(all(vapply(holiday_ind, is.integer, logical(1))))
+})
+
 test_that("works with no missing values - Date class", {
   test_data <- na.omit(test_data)
 
@@ -115,6 +127,22 @@ test_that("POSIXct class", {
     NA_integer_
   )
 })
+
+test_that("Date class", {
+  test_data$day <- as.POSIXct(test_data$day)
+  exp_dates$date <- as.POSIXct(exp_dates$date)
+
+  holiday_rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(),
+                 holidays = exp_dates$holiday,
+                 keep_original_cols = FALSE)
+
+  holiday_rec <- prep(holiday_rec, training = test_data)
+  holiday_ind <- bake(holiday_rec, test_data, all_predictors())
+
+  expect_true(all(vapply(holiday_ind, is.integer, logical(1))))
+})
+
 
 test_that("works with no missing values - POSIXct class", {
   test_data <- na.omit(test_data)

--- a/tests/testthat/test_integer.R
+++ b/tests/testthat/test_integer.R
@@ -39,7 +39,7 @@ test_that("basic functionality", {
   expect_equal(te_int$y, exp_y)
   expect_equal(te_int$z, exp_z)
   expect_true(all(vapply(te_int, is.numeric, logical(1))))
-  expect_true(all(!vapply(te_int, is.integer, logical(1))))
+  expect_true(all(vapply(te_int, is.integer, logical(1))))
 })
 
 
@@ -59,21 +59,21 @@ test_that("zero-based", {
   expect_equal(te_int$y, exp_y)
   expect_equal(te_int$z, exp_z)
   expect_true(all(vapply(te_int, is.numeric, logical(1))))
-  expect_true(all(!vapply(te_int, is.integer, logical(1))))
+  expect_true(all(vapply(te_int, is.integer, logical(1))))
 })
 
-test_that("integers", {
+test_that("not integers", {
   rec <- recipe(~ x + y + z, data = tr_dat) %>%
-    step_integer(all_predictors(), strict = TRUE)
+    step_integer(all_predictors(), strict = FALSE)
   rec_trained <- prep(rec, traning = tr_dat)
 
   tr_int <- juice(rec_trained, all_predictors())
   te_int <- bake(rec_trained, te_dat, all_predictors())
 
   expect_true(all(vapply(te_int, is.numeric, logical(1))))
-  expect_true(all(vapply(te_int, is.integer, logical(1))))
+  expect_true(!all(vapply(te_int, is.integer, logical(1))))
   expect_true(all(vapply(tr_int, is.numeric, logical(1))))
-  expect_true(all(vapply(tr_int, is.integer, logical(1))))
+  expect_true(!all(vapply(tr_int, is.integer, logical(1))))
 })
 
 test_that("printing", {

--- a/tests/testthat/test_intercept.R
+++ b/tests/testthat/test_intercept.R
@@ -14,9 +14,9 @@ test_that("add appropriate column with default settings", {
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
   rec_trans <- bake(rec_trained, new_data = ex_dat)
 
-  exp_res <- tibble::add_column(ex_dat, "intercept" = 1, .before = TRUE)
+  exp_res <- tibble::add_column(ex_dat, "intercept" = 1L, .before = TRUE)
 
-  expect_equal(rec_trans, exp_res)
+  expect_identical(rec_trans, exp_res)
 })
 
 test_that("adds arbitrary numeric column", {
@@ -28,7 +28,7 @@ test_that("adds arbitrary numeric column", {
 
   exp_res <- tibble::add_column(ex_dat, "(Intercept)" = 2.5, .before = TRUE)
 
-  expect_equal(rec_trans, exp_res)
+  expect_identical(rec_trans, exp_res)
 })
 
 

--- a/tests/testthat/test_naindicate.R
+++ b/tests/testthat/test_naindicate.R
@@ -21,14 +21,14 @@ test_that("step_indicate_na populates binaries correctly", {
     step_indicate_na(col1) %>%
     prep(train, verbose = FALSE, retain = TRUE)
 
-  expect_equal(
+  expect_identical(
     bake(rec1, train)$na_ind_col1,
-    c(0, 0, 0)
+    c(0L, 0L, 0L)
   )
 
-  expect_equal(
+  expect_identical(
     bake(rec1, test)$na_ind_col1,
-    c(1, 1, 1)
+    c(1L, 1L, 1L)
   )
 
   rec2 <- recipe(train) %>%

--- a/tests/testthat/test_ordinalscore.R
+++ b/tests/testthat/test_ordinalscore.R
@@ -35,12 +35,12 @@ test_that("linear scores", {
   rec1_scores <- bake(rec1, new_data = ex_dat)
   rec1_scores_NA <- bake(rec1, new_data = ex_miss)
 
-  expect_equal(as.numeric(ex_dat$ord1), rec1_scores$ord1)
-  expect_equal(as.numeric(ex_dat$ord2), rec1_scores$ord2)
-  expect_equal(as.numeric(ex_dat$ord3), rec1_scores$ord3)
+  expect_identical(as.integer(ex_dat$ord1), rec1_scores$ord1)
+  expect_identical(as.integer(ex_dat$ord2), rec1_scores$ord2)
+  expect_identical(as.integer(ex_dat$ord3), rec1_scores$ord3)
 
-  expect_equal(as.numeric(ex_miss$ord1), rec1_scores_NA$ord1)
-  expect_equal(as.numeric(ex_miss$ord3), rec1_scores_NA$ord3)
+  expect_identical(as.integer(ex_miss$ord1), rec1_scores_NA$ord1)
+  expect_identical(as.integer(ex_miss$ord3), rec1_scores_NA$ord3)
 })
 
 test_that("nonlinear scores", {

--- a/tests/testthat/test_regex.R
+++ b/tests/testthat/test_regex.R
@@ -19,6 +19,8 @@ test_that("default options", {
     as.numeric(grepl("(rock|stony)", covers$description))
   )
   expect_equal(res1$`all ones`, rep(1, nrow(covers)))
+  expect_true(is.integer(res1$X.rock.stony.))
+  expect_true(is.integer(res1$`all ones`))
 })
 
 


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/766.

To be closed before #993 to in according to: https://github.com/tidymodels/recipes/issues/993#issuecomment-1140453797.

This PR looks at the following steps:

These steps have their `bake.step_*()` modified to return integers when it could

- `step_date()`
- `step_dummy()`
- `step_dummy_extract()`
- `step_holiday()`
- `step_ordinalscore()`
- `step_regex()`

These steps have had their argument defaults changed to produce integers by default

- `step_intercept()`
- `step_integer()`

These steps already returned integers when needed, got tests to verify

- `step_indicate_na()`
- `step_count()`
- `step_time()`

Nothing changed, included for completeness

- `step_dummy_multi_choice()`
