### PR TITLE
Convert all examples to use exampleIf

### DIFF
--- a/R/ica.R
+++ b/R/ica.R
@@ -57,7 +57,7 @@
 #'  component analysis: algorithms and applications. *Neural
 #'  Networks*, 13(4-5), 411-430.
 #'
-#' @examples
+#' @examplesIf FALSE
 #' # from fastICA::fastICA
 #' set.seed(131)
 #' S <- matrix(runif(400), 200, 2)
@@ -73,16 +73,14 @@
 #' ica_trans <- step_scale(ica_trans, V1, V2)
 #' ica_trans <- step_ica(ica_trans, V1, V2, num_comp = 2)
 #'
-#' if (FALSE) {
-#'   ica_estimates <- prep(ica_trans, training = tr)
-#'   ica_data <- bake(ica_estimates, te)
+#' ica_estimates <- prep(ica_trans, training = tr)
+#' ica_data <- bake(ica_estimates, te)
 #'
-#'   plot(te$V1, te$V2)
-#'   plot(ica_data$IC1, ica_data$IC2)
+#' plot(te$V1, te$V2)
+#' plot(ica_data$IC1, ica_data$IC2)
 #'
-#'   tidy(ica_trans, number = 3)
-#'   tidy(ica_estimates, number = 3)
-#' }
+#' tidy(ica_trans, number = 3)
+#' tidy(ica_estimates, number = 3)
 step_ica <-
   function(recipe,
            ...,

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -60,8 +60,7 @@
 #' \pkg{dimRed}, a framework for dimensionality reduction,
 #'   https://github.com/gdkrmr
 #'
-#' @examplesIf rlang::is_installed("modeldata")
-#' \donttest{
+#' @examplesIf FALSE
 #' data(biomass, package = "modeldata")
 #'
 #' biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -77,20 +76,17 @@
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_isomap(all_numeric_predictors(), neighbors = 100, num_terms = 2)
 #'
-#' if (FALSE) {
-#'   im_estimates <- prep(im_trans, training = biomass_tr)
+#' im_estimates <- prep(im_trans, training = biomass_tr)
 #'
-#'   im_te <- bake(im_estimates, biomass_te)
+#' im_te <- bake(im_estimates, biomass_te)
 #'
-#'   rng <- extendrange(c(im_te$Isomap1, im_te$Isomap2))
-#'   plot(im_te$Isomap1, im_te$Isomap2,
-#'     xlim = rng, ylim = rng
-#'   )
+#' rng <- extendrange(c(im_te$Isomap1, im_te$Isomap2))
+#' plot(im_te$Isomap1, im_te$Isomap2,
+#'   xlim = rng, ylim = rng
+#' )
 #'
-#'   tidy(im_trans, number = 3)
-#'   tidy(im_estimates, number = 3)
-#' }
-#' }
+#' tidy(im_trans, number = 3)
+#' tidy(im_estimates, number = 3)
 step_isomap <-
   function(recipe,
            ...,

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -31,6 +31,7 @@
 #' @template case-weights-not-supported
 #'
 #' @examplesIf rlang::is_installed(c("modeldata", "ggplot2", "kernlab"))
+#' library(ggplot2)
 #' data(biomass, package = "modeldata")
 #'
 #' biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -46,18 +47,16 @@
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_kpca(all_numeric_predictors())
 #'
-#' if (require(kernlab) & require(ggplot2)) {
-#'   kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+#' kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 #'
-#'   kpca_te <- bake(kpca_estimates, biomass_te)
+#' kpca_te <- bake(kpca_estimates, biomass_te)
 #'
-#'   ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-#'     geom_point() +
-#'     coord_equal()
+#' ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+#'   geom_point() +
+#'   coord_equal()
 #'
-#'   tidy(kpca_trans, number = 3)
-#'   tidy(kpca_estimates, number = 3)
-#' }
+#' tidy(kpca_trans, number = 3)
+#' tidy(kpca_estimates, number = 3)
 step_kpca <-
   function(recipe,
            ...,

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -20,6 +20,7 @@
 #' @template case-weights-not-supported
 #'
 #' @examplesIf rlang::is_installed(c("modeldata", "ggplot2","kernlab"))
+#' library(ggplot2)
 #' data(biomass, package = "modeldata")
 #'
 #' biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -35,18 +36,16 @@
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_kpca_poly(all_numeric_predictors())
 #'
-#' if (require(ggplot2) & require(kernlab)) {
-#'   kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+#' kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 #'
-#'   kpca_te <- bake(kpca_estimates, biomass_te)
+#' kpca_te <- bake(kpca_estimates, biomass_te)
 #'
-#'   ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-#'     geom_point() +
-#'     coord_equal()
+#' ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+#'   geom_point() +
+#'   coord_equal()
 #'
-#'   tidy(kpca_trans, number = 3)
-#'   tidy(kpca_estimates, number = 3)
-#' }
+#' tidy(kpca_trans, number = 3)
+#' tidy(kpca_estimates, number = 3)
 step_kpca_poly <-
   function(recipe,
            ...,

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -20,6 +20,7 @@
 #' @template case-weights-not-supported
 #'
 #' @examplesIf rlang::is_installed(c("modeldata", "ggplot2", "kernlab"))
+#' library(ggplot2)
 #' data(biomass, package = "modeldata")
 #'
 #' biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -35,18 +36,16 @@
 #'   step_normalize(all_numeric_predictors()) %>%
 #'   step_kpca_rbf(all_numeric_predictors())
 #'
-#' if (require(ggplot2) & require(kernlab)) {
-#'   kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+#' kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 #'
-#'   kpca_te <- bake(kpca_estimates, biomass_te)
+#' kpca_te <- bake(kpca_estimates, biomass_te)
 #'
-#'   ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-#'     geom_point() +
-#'     coord_equal()
+#' ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+#'   geom_point() +
+#'   coord_equal()
 #'
-#'   tidy(kpca_trans, number = 3)
-#'   tidy(kpca_estimates, number = 3)
-#' }
+#' tidy(kpca_trans, number = 3)
+#' tidy(kpca_estimates, number = 3)
 step_kpca_rbf <-
   function(recipe,
            ...,

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -118,6 +118,7 @@ The underlying operation does not allow for case weights.
 }
 
 \examples{
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # from fastICA::fastICA
 set.seed(131)
 S <- matrix(runif(400), 200, 2)
@@ -133,16 +134,15 @@ ica_trans <- step_center(rec, V1, V2)
 ica_trans <- step_scale(ica_trans, V1, V2)
 ica_trans <- step_ica(ica_trans, V1, V2, num_comp = 2)
 
-if (FALSE) {
-  ica_estimates <- prep(ica_trans, training = tr)
-  ica_data <- bake(ica_estimates, te)
+ica_estimates <- prep(ica_trans, training = tr)
+ica_data <- bake(ica_estimates, te)
 
-  plot(te$V1, te$V2)
-  plot(ica_data$IC1, ica_data$IC2)
+plot(te$V1, te$V2)
+plot(ica_data$IC1, ica_data$IC2)
 
-  tidy(ica_trans, number = 3)
-  tidy(ica_estimates, number = 3)
-}
+tidy(ica_trans, number = 3)
+tidy(ica_estimates, number = 3)
+\dontshow{\}) # examplesIf}
 }
 \references{
 Hyvarinen, A., and Oja, E. (2000). Independent

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -111,8 +111,7 @@ The underlying operation does not allow for case weights.
 }
 
 \examples{
-\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-\donttest{
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data(biomass, package = "modeldata")
 
 biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -128,20 +127,17 @@ im_trans <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_isomap(all_numeric_predictors(), neighbors = 100, num_terms = 2)
 
-if (FALSE) {
-  im_estimates <- prep(im_trans, training = biomass_tr)
+im_estimates <- prep(im_trans, training = biomass_tr)
 
-  im_te <- bake(im_estimates, biomass_te)
+im_te <- bake(im_estimates, biomass_te)
 
-  rng <- extendrange(c(im_te$Isomap1, im_te$Isomap2))
-  plot(im_te$Isomap1, im_te$Isomap2,
-    xlim = rng, ylim = rng
-  )
+rng <- extendrange(c(im_te$Isomap1, im_te$Isomap2))
+plot(im_te$Isomap1, im_te$Isomap2,
+  xlim = rng, ylim = rng
+)
 
-  tidy(im_trans, number = 3)
-  tidy(im_estimates, number = 3)
-}
-}
+tidy(im_trans, number = 3)
+tidy(im_estimates, number = 3)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -119,6 +119,7 @@ The underlying operation does not allow for case weights.
 
 \examples{
 \dontshow{if (rlang::is_installed(c("modeldata", "ggplot2", "kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
 data(biomass, package = "modeldata")
 
 biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -134,18 +135,16 @@ kpca_trans <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_kpca(all_numeric_predictors())
 
-if (require(kernlab) & require(ggplot2)) {
-  kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 
-  kpca_te <- bake(kpca_estimates, biomass_te)
+kpca_te <- bake(kpca_estimates, biomass_te)
 
-  ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-    geom_point() +
-    coord_equal()
+ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+  geom_point() +
+  coord_equal()
 
-  tidy(kpca_trans, number = 3)
-  tidy(kpca_estimates, number = 3)
-}
+tidy(kpca_trans, number = 3)
+tidy(kpca_estimates, number = 3)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -111,6 +111,7 @@ The underlying operation does not allow for case weights.
 
 \examples{
 \dontshow{if (rlang::is_installed(c("modeldata", "ggplot2","kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
 data(biomass, package = "modeldata")
 
 biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -126,18 +127,16 @@ kpca_trans <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_kpca_poly(all_numeric_predictors())
 
-if (require(ggplot2) & require(kernlab)) {
-  kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 
-  kpca_te <- bake(kpca_estimates, biomass_te)
+kpca_te <- bake(kpca_estimates, biomass_te)
 
-  ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-    geom_point() +
-    coord_equal()
+ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+  geom_point() +
+  coord_equal()
 
-  tidy(kpca_trans, number = 3)
-  tidy(kpca_estimates, number = 3)
-}
+tidy(kpca_trans, number = 3)
+tidy(kpca_estimates, number = 3)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -109,6 +109,7 @@ The underlying operation does not allow for case weights.
 
 \examples{
 \dontshow{if (rlang::is_installed(c("modeldata", "ggplot2", "kernlab"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(ggplot2)
 data(biomass, package = "modeldata")
 
 biomass_tr <- biomass[biomass$dataset == "Training", ]
@@ -124,18 +125,16 @@ kpca_trans <- rec \%>\%
   step_normalize(all_numeric_predictors()) \%>\%
   step_kpca_rbf(all_numeric_predictors())
 
-if (require(ggplot2) & require(kernlab)) {
-  kpca_estimates <- prep(kpca_trans, training = biomass_tr)
+kpca_estimates <- prep(kpca_trans, training = biomass_tr)
 
-  kpca_te <- bake(kpca_estimates, biomass_te)
+kpca_te <- bake(kpca_estimates, biomass_te)
 
-  ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
-    geom_point() +
-    coord_equal()
+ggplot(kpca_te, aes(x = kPC1, y = kPC2)) +
+  geom_point() +
+  coord_equal()
 
-  tidy(kpca_trans, number = 3)
-  tidy(kpca_estimates, number = 3)
-}
+tidy(kpca_trans, number = 3)
+tidy(kpca_estimates, number = 3)
 \dontshow{\}) # examplesIf}
 }
 \references{


### PR DESCRIPTION
A handful of examples didn't properly use `@exampleIf`

`kpca`, `kpca_poly`, and `kpca_rbf` used `@exampleIf` but the `if(require)` calls were not removed

`ica` and `isomap` used a `if (FALSE)` which is now converted to `@exampleIf FALSE`