### PR TITLE
Fix failing step_holiday() test on r-devel

### DIFF
--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -89,10 +89,8 @@ test_that("works with no missing values - Date class", {
 })
 
 test_that("POSIXct class", {
-  test_data$day <- as.POSIXct(test_data$day)
-  exp_dates$date <- as.POSIXct(exp_dates$date)
-  lubridate::tz(test_data$day) <- ""
-  lubridate::tz(exp_dates$date) <- ""
+  test_data$day <- lubridate::as_datetime(test_data$day, tz = "UTC")
+  exp_dates$date <- lubridate::as_datetime(exp_dates$date, tz = "UTC")
 
   holiday_rec <- recipe(~day, test_data) %>%
     step_holiday(all_predictors(), holidays = exp_dates$holiday)
@@ -114,7 +112,7 @@ test_that("POSIXct class", {
   )
   expect_equal(
     holiday_ind$day[is.na(test_data$day)],
-    as.POSIXct(NA, tz = "")
+    as.POSIXct(NA, tz = "UTC")
   )
   expect_equal(
     holiday_ind$day_ChristmasDay[is.na(test_data$day)],

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -111,6 +111,7 @@ test_that("POSIXct class", {
     exp_dates$date[exp_dates$holiday == "Easter"]
   )
 
+  # https://developer.r-project.org/blosxom.cgi/R-devel/2022/10/05#n2022-10-05
   if (getRversion() > "4.2.1") {
     na_posixct <- as.POSIXct(NA)
   } else {

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -113,7 +113,7 @@ test_that("POSIXct class", {
 
   # https://developer.r-project.org/blosxom.cgi/R-devel/2022/10/05#n2022-10-05
   if (getRversion() > "4.2.1") {
-    na_posixct <- as.POSIXct(NA, tz = "")
+    na_posixct <- as.POSIXct(NA, tz = "UTC")
   } else {
     na_posixct <- as.POSIXct(NA, tz = NULL)
   }

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -91,6 +91,8 @@ test_that("works with no missing values - Date class", {
 test_that("POSIXct class", {
   test_data$day <- as.POSIXct(test_data$day)
   exp_dates$date <- as.POSIXct(exp_dates$date)
+  lubridate::tz(test_data$day) <- ""
+  lubridate::tz(exp_dates$date) <- ""
 
   holiday_rec <- recipe(~day, test_data) %>%
     step_holiday(all_predictors(), holidays = exp_dates$holiday)
@@ -110,16 +112,9 @@ test_that("POSIXct class", {
     holiday_ind$day[is_equal_1(holiday_ind$day_Easter)],
     exp_dates$date[exp_dates$holiday == "Easter"]
   )
-
-  # https://developer.r-project.org/blosxom.cgi/R-devel/2022/10/05#n2022-10-05
-  if (getRversion() > "4.2.1") {
-    na_posixct <- as.POSIXct(NA, tz = "UTC")
-  } else {
-    na_posixct <- as.POSIXct(NA, tz = NULL)
-  }
   expect_equal(
     holiday_ind$day[is.na(test_data$day)],
-    na_posixct
+    as.POSIXct(NA, tz = "")
   )
   expect_equal(
     holiday_ind$day_ChristmasDay[is.na(test_data$day)],

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -113,7 +113,7 @@ test_that("POSIXct class", {
 
   # https://developer.r-project.org/blosxom.cgi/R-devel/2022/10/05#n2022-10-05
   if (getRversion() > "4.2.1") {
-    na_posixct <- as.POSIXct(NA)
+    na_posixct <- as.POSIXct(NA, tz = "")
   } else {
     na_posixct <- as.POSIXct(NA, tz = NULL)
   }

--- a/tests/testthat/test_holiday.R
+++ b/tests/testthat/test_holiday.R
@@ -110,9 +110,15 @@ test_that("POSIXct class", {
     holiday_ind$day[is_equal_1(holiday_ind$day_Easter)],
     exp_dates$date[exp_dates$holiday == "Easter"]
   )
+
+  if (getRversion() > "4.2.1") {
+    na_posixct <- as.POSIXct(NA)
+  } else {
+    na_posixct <- as.POSIXct(NA, tz = NULL)
+  }
   expect_equal(
     holiday_ind$day[is.na(test_data$day)],
-    as.POSIXct(NA, tz = NULL)
+    na_posixct
   )
   expect_equal(
     holiday_ind$day_ChristmasDay[is.na(test_data$day)],


### PR DESCRIPTION
This PR fixes the test that now fails, was first discovered https://github.com/tidymodels/recipes/actions/runs/3192498090/jobs/5210042479#step:6:234 and happened because of a change in r-devel https://developer.r-project.org/blosxom.cgi/R-devel/2022/10/05#n2022-10-05