### PR TITLE
use list_unchop instead of vec_unchop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     tidyselect (>= 1.2.0),
     timeDate,
     utils,
-    vctrs,
+    vctrs (>= 0.5.0),
     withr
 Suggests: 
     covr,

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -397,7 +397,7 @@ tidy.step_discretize <- function(x, ...) {
 
     brks <- unname(brks)
     brks <- lapply(brks, unname)
-    values <- vctrs::vec_unchop(brks, ptype = double())
+    values <- vctrs::list_unchop(brks, ptype = double())
 
     res <- tibble(terms = brk_vars, value = values)
   } else {

--- a/R/dummy_multi_choice.R
+++ b/R/dummy_multi_choice.R
@@ -118,7 +118,7 @@ prep.step_dummy_multi_choice <- function(x, training, info = NULL, ...) {
   multi_dummy_check_type(training[, col_names])
 
   levels <- purrr::map(training[, col_names], levels)
-  levels <- vctrs::vec_unchop(levels, ptype = character(), name_spec = rlang::zap())
+  levels <- vctrs::list_unchop(levels, ptype = character(), name_spec = rlang::zap())
   levels <- levels[!is.na(levels)]
   levels <- keep_levels(levels, x$threshold, other = x$other)
 
@@ -185,7 +185,7 @@ bake.step_dummy_multi_choice <- function(object, new_data, ...) {
 
 multi_dummy <- function(x, y) {
   row_id <- rep(seq_len(nrow(x)), times = ncol(x))
-  values <- vctrs::vec_unchop(
+  values <- vctrs::list_unchop(
     purrr::map(x, as.character),
     ptype = character(),
     name_spec = rlang::zap()

--- a/R/format.R
+++ b/R/format.R
@@ -24,6 +24,6 @@ format_selectors <- function(x, width = options()$width - 9) {
     expr_deparse(quo_get_expr(x))
   })
 
-  x_items <- vctrs::vec_unchop(x_items, ptype = character())
+  x_items <- vctrs::list_unchop(x_items, ptype = character())
   format_ch_vec(x_items, width = width, sep = ", ")
 }

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -214,7 +214,7 @@ tidy.step_impute_mean <- function(x, ...) {
   if (is_trained(x)) {
     res <- tibble(
       terms = names(x$means),
-      model = vctrs::vec_unchop(unname(x$means), ptype = double())
+      model = vctrs::list_unchop(unname(x$means), ptype = double())
     )
   } else {
     term_names <- sel2char(x$terms)

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -180,7 +180,7 @@ tidy.step_impute_median <- function(x, ...) {
   if (is_trained(x)) {
     res <- tibble(
       terms = names(x$medians),
-      model = vctrs::vec_unchop(unname(x$medians), ptype = double())
+      model = vctrs::list_unchop(unname(x$medians), ptype = double())
     )
   } else {
     term_names <- sel2char(x$terms)

--- a/R/other.R
+++ b/R/other.R
@@ -265,7 +265,7 @@ tidy.step_other <- function(x, ...) {
   if (is_trained(x)) {
     values <- purrr::map(x$objects, function(x) x$keep)
     n <- vapply(values, length, integer(1))
-    values <- vctrs::vec_unchop(values, ptype = character(), name_spec = rlang::zap())
+    values <- vctrs::list_unchop(values, ptype = character(), name_spec = rlang::zap())
     res <- tibble(
       terms = rep(names(n), n),
       retained = values


### PR DESCRIPTION
> [vec_unchop()](https://vctrs.r-lib.org/reference/vec_unchop.html) has been renamed to [list_unchop()](https://vctrs.r-lib.org/reference/vec_chop.html) to better indicate that it requires list input. [vec_unchop()](https://vctrs.r-lib.org/reference/vec_unchop.html) will stick around for a few minor versions, but has been formally soft-deprecated ([#1209](https://github.com/r-lib/vctrs/issues/1209)).