### PR TITLE
Default to using clock locales inside step_date()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Depends:
     R (>= 3.4)
 Imports: 
     cli,
+    clock (>= 0.6.1),
     ellipsis,
     generics (>= 0.1.2),
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Developer focused `.get_data_types()` generic has been added to designate types of columns. Exported for use in extension packages that deal with types not supported in recipes directly. (#993)
 
+* The `step_date()` function now defaults to using the clock package to format day-of-week and month labels. (#1048)
+
 # recipes 1.0.2
 
 * A new set of basis functions were added: `step_spline_b()`, `step_spline_convex()`,  `step_spline_monotone()`, `step_spline_natural()`, `step_spline_nonnegative()`, and 

--- a/R/date.R
+++ b/R/date.R
@@ -80,7 +80,7 @@ step_date <-
            abbr = TRUE,
            label = TRUE,
            ordinal = FALSE,
-           locale = Sys.getlocale("LC_TIME"),
+           locale = clock::clock_locale()$labels,
            columns = NULL,
            keep_original_cols = TRUE,
            skip = FALSE,
@@ -212,16 +212,36 @@ get_date_features <-
       res[, grepl("semester$", names(res))] <- vec_cast(semester(dt), integer())
     }
     if ("dow" %in% feats) {
-      res[, grepl("dow$", names(res))] <-
-        wday(dt, abbr = abbr, label = label, locale = locale)
+      if (inherits(locale, "clock_labels")) {
+        dow <- clock::date_weekday_factor(
+          x = dt, abbreviate = abbr, labels = locale
+        )
+        if (!label) {
+          dow <- as.integer(dow)
+        }
+        res[, grepl("dow$", names(res))] <- dow
+      } else {
+        res[, grepl("dow$", names(res))] <-
+          wday(dt, abbr = abbr, label = label, locale = locale)
+      }
       if (!ord & label == TRUE) {
         res[, grepl("dow$", names(res))] <-
           ord2fac(res, grep("dow$", names(res), value = TRUE))
       }
     }
     if ("month" %in% feats) {
-      res[, grepl("month$", names(res))] <-
-        month(dt, abbr = abbr, label = label, locale = locale)
+      if (inherits(locale, "clock_labels")) {
+        month <- clock::date_month_factor(
+          dt, abbreviate = abbr, labels = locale
+        )
+        if (!label) {
+          month <- as.integer(month)
+        }
+        res[, grepl("month$", names(res))] <- month
+      } else {
+        res[, grepl("month$", names(res))] <-
+          month(dt, abbr = abbr, label = label, locale = locale)
+      }
       if (!ord & label == TRUE) {
         res[, grepl("month$", names(res))] <-
           ord2fac(res, grep("month$", names(res), value = TRUE))

--- a/R/date.R
+++ b/R/date.R
@@ -29,7 +29,8 @@
 #'  available for features `month` or `dow`.
 #' @param locale Locale to be used for `month` and `dow`, see [locales].
 #'  On Linux systems you can use `system("locale -a")` to list all the
-#'  installed locales. Defaults to `Sys.getlocale("LC_TIME")`.
+#'  installed locales. Can be a locales string, or a [clock::clock_labels()]
+#'  object. Defaults to `clock::clock_locale()$labels`.
 #' @param columns A character string of variables that will be
 #'  used as inputs. This field is a placeholder and will be
 #'  populated once [prep()] is used.

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -13,7 +13,7 @@ step_date(
   abbr = TRUE,
   label = TRUE,
   ordinal = FALSE,
-  locale = Sys.getlocale("LC_TIME"),
+  locale = clock::clock_locale()$labels,
   columns = NULL,
   keep_original_cols = TRUE,
   skip = FALSE,

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -58,7 +58,8 @@ available for features \code{month} or \code{dow}.}
 
 \item{locale}{Locale to be used for \code{month} and \code{dow}, see \link{locales}.
 On Linux systems you can use \code{system("locale -a")} to list all the
-installed locales. Defaults to \code{Sys.getlocale("LC_TIME")}.}
+installed locales. Can be a locales string, or a \code{\link[clock:clock_labels]{clock::clock_labels()}}
+object. Defaults to \code{clock::clock_locale()$labels}.}
 
 \item{columns}{A character string of variables that will be
 used as inputs. This field is a placeholder and will be

--- a/tests/testthat/test_date.R
+++ b/tests/testthat/test_date.R
@@ -149,6 +149,33 @@ test_that("locale argument works when specified", {
   expect_equal(ref_res, new_res)
 })
 
+test_that("locale argument works with clock locale", {
+  labels_fr <- clock::clock_locale(labels = "fr")$labels
+
+  date_rec <- recipe(~ Stefan, examples) %>%
+    step_date(all_predictors(), locale = labels_fr, ordinal = TRUE) %>%
+    prep()
+
+  ref_res <- bake(date_rec, new_data = examples)
+
+  expect_identical(
+    ref_res$Stefan_dow,
+    clock::date_weekday_factor(
+      examples$Stefan,
+      labels = labels_fr
+    )
+  )
+
+  expect_identical(
+    ref_res$Stefan_month,
+    clock::date_month_factor(
+      examples$Stefan,
+      labels = labels_fr,
+      abbreviate = TRUE
+    )
+  )
+})
+
 test_that("can bake and recipes with no locale", {
   date_rec <- recipe(~ Dan + Stefan, examples) %>%
     step_date(all_predictors()) %>%
@@ -228,4 +255,3 @@ test_that("bake method errors when needed non-standard role columns are missing"
   expect_error(bake(date_rec, new_data = examples[, 2, drop = FALSE]),
                class = "new_data_missing_column")
 })
-


### PR DESCRIPTION
This PR aims to close #1048. I switches to use `<clock_labels>` internally by default in `step_date()`.

The changes are backwards compatible, e.i. setting `locale = Sys.getlocale("LC_TIME")` still works as before.