### PR TITLE
Avoid `map2()` when `wts` aren't used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # recipes (development version)
 
+* Fixed a 0-length recycling bug in `step_dummy_extract()` exposed by the
+  development version of purrr (#1052).
+
 * Types of variables have been made granular. `"nominal"` has been split into `"ordered"` and `"unordered"` and `"numeric"` has been split into `"double"` and `"integer"`. (#993)
 
 * New selectors: `all_double()`, `all_ordered()`, `all_unordered()`, `all_date()` and `all_datetime()`, in addition to the existing `all_numeric()` and `all_nominal()`. All selectors come with a `*_predictors()` variant. (#993)

--- a/R/extract.R
+++ b/R/extract.R
@@ -170,9 +170,15 @@ prep.step_dummy_extract <- function(x, training, info = NULL, ...) {
       )
 
       lvls <- map(elements, unique)
-      wts_tab <- purrr::map2(lvls, as.double(wts), ~rep(.y, length(.x)))
+
+      if (is.null(wts)) {
+        wts_tab <- NULL
+      } else {
+        wts_tab <- purrr::map2(lvls, as.double(wts), ~rep(.y, length(.x)))
+        wts_tab <- unlist(wts_tab)
+      }
+
       lvls <- unlist(lvls)
-      wts_tab <- unlist(wts_tab)
 
       lvls <- sort(weighted_table(lvls, wts = wts_tab), decreasing = TRUE)
 


### PR DESCRIPTION
This is a small bug exposed by purrr 1.0.0 (the dev version). If you install the dev version of purrr and run the tests, then some of the `step_dummy_extract()` ones break because purrr now applies tidyverse recycling rules to its inputs in `map2()` and `pmap()`. The error looks like:

```r
> rlang::last_trace()
<error/vctrs_error_incompatible_size>
Error in `purrr::map2()` at recipes/R/extract.R:173:6:
! Can't recycle `.x` (size 4) to match `.y` (size 0).
---
Backtrace:
    ▆
 1. ├─recipes::prep(dummy)
 2. └─recipes:::prep.recipe(dummy) at recipes/R/recipe.R:278:2
 3.   ├─recipes::prep(x$steps[[i]], training = training, info = x$term_info) at recipes/R/recipe.R:434:8
 4.   └─recipes:::prep.step_dummy_extract(...) at recipes/R/recipe.R:278:2
 5.     └─purrr::map2(lvls, as.double(wts), ~rep(.y, length(.x))) at recipes/R/extract.R:173:6
Run rlang::last_trace(drop = FALSE) to see 6 hidden frames.
```

It would be great if we could get a small recipes release out to make it easier on purrr, otherwise we are going to be forced to do a release when purrr 1.0.0 eventually goes out.

The problem happens when `wts` aren't used, i.e. `wts = NULL`. Then `as.double(wts)` returns `double()`, which isn't tidyverse recyclable against `lvls`, which is typically length >1.