### PR TITLE
correctly avoid turning dummies into integers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bug where `step_dummy()` would error if the contrast for unordered factors was set to `contr.poly`.
+
 * Fixed a 0-length recycling bug in `step_dummy_extract()` exposed by the
   development version of purrr (#1052).
 

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -314,7 +314,9 @@ bake.step_dummy <- function(object, new_data, ...) {
         data = indicators
       )
     indicators <- as_tibble(indicators)
-    if (fac_type != "ordered") {
+    fac_type <- dplyr::if_else(fac_type != "ordered", "unordered", "ordered")
+    contrast <- options("contrasts")$contrasts[[fac_type]]
+    if (contrast != "contr.poly") {
       indicators <- purrr::map_dfc(indicators, vec_cast, integer())
     }
 

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -92,6 +92,17 @@ test_that("create integer dummy variables", {
   expect_true(all(vapply(dummy_pred, is.integer, logical(1))))
 })
 
+test_that("doesn't turn dummies into integers when contrasts is poly", {
+  rlang::local_options(
+    contrasts = c(unordered = "contr.poly", ordered = "contr.poly")
+  )
+  rec <- recipe(sqft ~ zip + city, data = sacr_fac)
+  dummy <- rec %>% step_dummy(city, zip, id = "")
+  dummy_trained <- prep(dummy, training = sacr_fac, verbose = FALSE, strings_as_factors = FALSE)
+  dummy_pred <- bake(dummy_trained, new_data = sacr_fac, all_predictors())
+  expect_true(all(vapply(dummy_pred, is.double, logical(1))))
+})
+
 test_that("create all dummy variables", {
   rec <- recipe(sqft ~ zip + city + price, data = sacr_fac)
   dummy <- rec %>% step_dummy(city, zip, one_hot = TRUE, id = "")
@@ -408,4 +419,3 @@ test_that("bake method errors when needed non-standard role columns are missing"
   expect_error(bake(dummy_trained, new_data = sacr_fac[, 3:4], all_predictors()),
                class = "new_data_missing_column")
 })
-


### PR DESCRIPTION
I made a mistake in https://github.com/tidymodels/recipes/pull/1039. This PR should fix it.

`step_dummy()` didn't correctly determine when to avoid turning dummies into integers

# Main

``` r
library(recipes)

options(contrasts = c(unordered = "contr.poly", ordered = "contr.poly"))

recipe(~Species, data = iris) |>
  step_dummy(Species) |>
  prep() |>
  bake(new_data = NULL)
#> Error in `map()`:
#> ! Can't convert from `.x[[i]]` <double> to <integer> due to loss of precision.
#> • Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,...

#> Backtrace:
#>      ▆
#>   1. ├─recipes::bake(...)
#>   2. ├─recipes::prep(step_dummy(recipe(~Species, data = iris), Species))
#>   3. └─recipes:::prep.recipe(...)
#>   4.   ├─recipes::bake(x$steps[[i]], new_data = training)
#>   5.   └─recipes:::bake.step_dummy(x$steps[[i]], new_data = training)
#>   6.     └─purrr::map_dfc(indicators, vec_cast, integer())
#>   7.       └─purrr::map(.x, .f, ...)
#>   8.         └─vctrs (local) .f(.x[[i]], ...)
#>   9.           └─vctrs (local) `<fn>`()
#>  10.             └─vctrs:::vec_cast.integer.double(...)
#>  11.               └─vctrs::maybe_lossy_cast(...)
#>  12.                 ├─base::withRestarts(...)
#>  13.                 │ └─base (local) withOneRestart(expr, restarts[[1L]])
#>  14.                 │   └─base (local) doWithOneRestart(return(expr), restart)
#>  15.                 └─vctrs:::stop_lossy_cast(...)
#>  16.                   └─vctrs::stop_incompatible_cast(...)
#>  17.                     └─vctrs::stop_incompatible_type(...)
#>  18.                       └─vctrs:::stop_incompatible(...)
#>  19.                         └─vctrs:::stop_vctrs(...)
#>  20.                           └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = vctrs_error_call(call))
```

# PR

``` r
library(recipes)

options(contrasts = c(unordered = "contr.poly", ordered = "contr.poly"))

recipe(~Species, data = iris) |>
  step_dummy(Species) |>
  prep() |>
  bake(new_data = NULL)
#> # A tibble: 150 × 2
#>    Species_.L Species_.Q
#>         <dbl>      <dbl>
#>  1     -0.707      0.408
#>  2     -0.707      0.408
#>  3     -0.707      0.408
#>  4     -0.707      0.408
#>  5     -0.707      0.408
#>  6     -0.707      0.408
#>  7     -0.707      0.408
#>  8     -0.707      0.408
#>  9     -0.707      0.408
#> 10     -0.707      0.408
#> # … with 140 more rows
```
