### PR TITLE
`cli` formatting of prompt to install missing package

### DIFF
--- a/R/pkg_check.R
+++ b/R/pkg_check.R
@@ -27,7 +27,8 @@ recipes_pkg_check <- function(pkg = NULL, ...) {
     n_install_pkgs <- sum(!good)
 
     cli::cli_text(
-      "{n_install_pkgs} package{?s} ({.pkg {install_pkg}}) {?is/are} needed for this step but {?is/are} not installed."
+      "{n_install_pkgs} package{?s} ({.pkg {install_pkg}}) {?is/are} needed ",
+      "for this step but {?is/are} not installed."
     )
 
     if (length(install_pkg) > 1) {

--- a/R/pkg_check.R
+++ b/R/pkg_check.R
@@ -22,21 +22,14 @@ recipes_pkg_check <- function(pkg = NULL, ...) {
     }
   }
   if (any(!good)) {
-    pkList <- paste(pkg[!good], collapse = ", ")
-    msg <- paste0(
-      sum(!good),
-      ifelse(sum(!good) > 1, " packages are", " package is"),
-      " needed for this step and",
-      ifelse(sum(!good) > 1, " are", " is"),
-      " not installed. (",
-      pkList,
-      "). ",
-      "Start a clean R session then run: "
-    )
-    cat(msg)
-
     install_opt <- quos(...)
     install_pkg <- pkg[!good]
+    n_install_pkgs <- sum(!good)
+
+    cli::cli_text(
+      "{n_install_pkgs} package{?s} ({.pkg {install_pkg}}) {?is/are} needed for this step but {?is/are} not installed."
+    )
+
     if (length(install_pkg) > 1) {
       inst_expr <-
         quo(install.packages(c(!!!install_pkg), !!!install_opt))
@@ -45,7 +38,7 @@ recipes_pkg_check <- function(pkg = NULL, ...) {
         quo(install.packages(!!install_pkg, !!!install_opt))
     }
     pkg_str <- deparse(quo_squash(inst_expr))
-    cat(pkg_str)
+    cli::cli_text("Start a clean R session then run: ", pkg_str)
   }
 
   invisible()

--- a/R/pkg_check.R
+++ b/R/pkg_check.R
@@ -39,7 +39,7 @@ recipes_pkg_check <- function(pkg = NULL, ...) {
         quo(install.packages(!!install_pkg, !!!install_opt))
     }
     pkg_str <- deparse(quo_squash(inst_expr))
-    cli::cli_text("Start a clean R session then run: ", pkg_str)
+    cli::cli_text("To install run: {.run ", pkg_str, "}")
   }
 
   invisible()

--- a/tests/testthat/_snaps/pkg_check.md
+++ b/tests/testthat/_snaps/pkg_check.md
@@ -4,8 +4,7 @@
       recipes_pkg_check(pkg = "missing_pkg", dependencies = NA)
     Message
       1 package (missing_pkg) is needed for this step but is not installed.
-      Start a clean R session then run: install.packages("missing_pkg", dependencies
-      = NA)
+      To install run: `install.packages("missing_pkg", dependencies = NA)`
 
 ---
 
@@ -14,8 +13,7 @@
     Message
       2 packages (missing_pkg_1 and missing_pkg_2) are needed for this step but are
       not installed.
-      Start a clean R session then run: install.packages(c("missing_pkg_1",
-      "missing_pkg_2"))
+      To install run: `install.packages(c("missing_pkg_1", "missing_pkg_2"))`
 
 ---
 

--- a/tests/testthat/_snaps/pkg_check.md
+++ b/tests/testthat/_snaps/pkg_check.md
@@ -1,0 +1,24 @@
+# recipes_pkg_check() works
+
+    Code
+      recipes_pkg_check(pkg = "missing_pkg", dependencies = NA)
+    Message
+      1 package (missing_pkg) is needed for this step but is not installed.
+      Start a clean R session then run: install.packages("missing_pkg", dependencies
+      = NA)
+
+---
+
+    Code
+      recipes_pkg_check(pkg = c("missing_pkg_1", "missing_pkg_2"))
+    Message
+      2 packages (missing_pkg_1 and missing_pkg_2) are needed for this step but are
+      not installed.
+      Start a clean R session then run: install.packages(c("missing_pkg_1",
+      "missing_pkg_2"))
+
+---
+
+    Code
+      recipes_pkg_check(pkg = NULL)
+

--- a/tests/testthat/test-pkg_check.R
+++ b/tests/testthat/test-pkg_check.R
@@ -1,0 +1,11 @@
+test_that("recipes_pkg_check() works", {
+  expect_snapshot(
+    recipes_pkg_check(pkg = "missing_pkg", dependencies = NA)
+  )
+  expect_snapshot(
+    recipes_pkg_check(pkg = c("missing_pkg_1", "missing_pkg_2"))
+  )
+  expect_snapshot(
+    recipes_pkg_check(pkg = NULL)
+  )
+})


### PR DESCRIPTION
closes #1060

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
data(ames, package = "modeldata")

ames_rec <-
  recipe(Sale_Price ~ ., data = ames) %>%
  step_spline_natural(Longitude, deg_free = 2) %>%
  step_spline_natural(Latitude, deg_free = 2)
#> 1 package (splines2) is needed for this step but is not installed.
#> Start a clean R session then run: install.packages("splines2")
#> 1 package (splines2) is needed for this step but is not installed.
#> Start a clean R session then run: install.packages("splines2")
```

<sup>Created on 2022-11-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>