### PR TITLE
No more mod call args

### DIFF
--- a/R/count.R
+++ b/R/count.R
@@ -158,7 +158,7 @@ bake.step_count <- function(object, new_data, ...) {
     )
   )
   if (length(object$options) > 0) {
-    regex <- mod_call_args(regex, args = object$options)
+    regex <- rlang::call_modify(regex, !!!object$options)
   }
 
   new_data[, object$result] <- vapply(eval(regex), counter, integer(1))

--- a/R/misc.R
+++ b/R/misc.R
@@ -61,19 +61,6 @@ sub_args <- function(func, options, removals = NULL) {
   }
   args
 }
-## Same as above but starts with a call object
-mod_call_args <- function(cl, args, removals = NULL) {
-  if (!is.null(removals)) {
-    for (i in removals) {
-      cl[[i]] <- NULL
-    }
-  }
-  arg_names <- names(args)
-  for (i in arg_names) {
-    cl[[i]] <- args[[i]]
-  }
-  cl
-}
 
 #' Naming Tools
 #'

--- a/R/misc.R
+++ b/R/misc.R
@@ -47,21 +47,6 @@ filter_terms.formula <- function(formula, data, ...) {
   get_rhs_vars(formula, data)
 }
 
-
-## This function takes the default arguments of `func` and
-## replaces them with the matching ones in `options` and
-## remove any in `removals`
-sub_args <- function(func, options, removals = NULL) {
-  args <- formals(func)
-  for (i in seq_along(options)) {
-    args[[names(options)[i]]] <- options[[i]]
-  }
-  if (!is.null(removals)) {
-    args[removals] <- NULL
-  }
-  args
-}
-
 #' Naming Tools
 #'
 #' `names0` creates a series of `num` names with a common prefix.

--- a/R/pca.R
+++ b/R/pca.R
@@ -173,7 +173,7 @@ prep.step_pca <- function(x, training, info = NULL, ...) {
           tol = NULL
         ))
       if (length(x$options) > 0) {
-        prc_call <- mod_call_args(prc_call, args = x$options)
+        prc_call <- rlang::call_modify(prc_call, !!!x$options)
       }
 
       prc_call$x <- expr(training[, col_names, drop = FALSE])

--- a/R/regex.R
+++ b/R/regex.R
@@ -152,7 +152,7 @@ bake.step_regex <- function(object, new_data, ...) {
     )
   )
   if (length(object$options) > 0) {
-    regex <- mod_call_args(regex, args = object$options)
+    regex <- rlang::call_modify(regex, !!!object$options)
   }
 
   new_data[, object$result] <- ifelse(eval(regex), 1L, 0L)


### PR DESCRIPTION
We used to use `mod_call_args()`, but now we can use `rlang::call_modify()`. To close https://github.com/tidymodels/recipes/issues/266