### PR TITLE
properly Supersede juice

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -56,8 +56,7 @@
 #' recipe(~ city + price + beds, data = Sacramento) %>%
 #'   step_profile(-beds, profile = vars(beds)) %>%
 #'   prep(training = Sacramento) %>%
-#'   juice()
-#'
+#'   bake(new_data = NULL)
 #'
 #' ##########
 #'

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -789,6 +789,9 @@ bake_req_tibble <- function(x) {
 
 #' Extract transformed training set
 #'
+#' @description
+#' `r lifecycle::badge('superseded')`
+#'
 #' As of `recipes` version 0.1.14, **`juice()` is superseded** in favor of
 #' `bake(object, new_data = NULL)`.
 #'

--- a/man/juice.Rd
+++ b/man/juice.Rd
@@ -23,15 +23,17 @@ called \strong{after} any selectors and the selectors should only
 resolve to numeric columns (otherwise an error is thrown).}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+
 As of \code{recipes} version 0.1.14, \strong{\code{juice()} is superseded} in favor of
 \code{bake(object, new_data = NULL)}.
-}
-\details{
+
 As steps are estimated by \code{prep}, these operations are
 applied to the training set. Rather than running \code{\link[=bake]{bake()}}
 to duplicate this processing, this function will return
 variables from the processed training set.
-
+}
+\details{
 When preparing a recipe, if the training data set is
 retained using \code{retain = TRUE}, there is no need to \code{\link[=bake]{bake()}} the
 recipe to get the preprocessed training set.

--- a/man/step_profile.Rd
+++ b/man/step_profile.Rd
@@ -109,8 +109,7 @@ data(Sacramento, package = "modeldata")
 recipe(~ city + price + beds, data = Sacramento) \%>\%
   step_profile(-beds, profile = vars(beds)) \%>\%
   prep(training = Sacramento) \%>\%
-  juice()
-
+  bake(new_data = NULL)
 
 ##########
 

--- a/tests/testthat/test-update-role-requirements.R
+++ b/tests/testthat/test-update-role-requirements.R
@@ -95,7 +95,7 @@ test_that("can `bake()` without roles that set `bake = FALSE`", {
 
   df$x <- NULL
 
-  expect <- juice(rec)
+  expect <- bake(rec, new_data = NULL)
   expect$x <- NULL
 
   expect_identical(
@@ -117,7 +117,7 @@ test_that("can update `bake` requirements after prepping", {
     bake(rec, df)
   })
 
-  expect <- juice(rec)
+  expect <- bake(rec, new_data = NULL)
   expect$x <- NULL
 
   rec <- update_role_requirements(rec, "id", bake = FALSE)
@@ -149,7 +149,7 @@ test_that("doesn't error on missing case weights by default", {
 
   df$w <- NULL
 
-  expect <- juice(rec)
+  expect <- bake(rec, new_data = NULL)
   expect$w <- NULL
 
   expect_identical(

--- a/tests/testthat/test_arrange.R
+++ b/tests/testthat/test_arrange.R
@@ -21,7 +21,7 @@ test_that("basic usage", {
     slice(1:75) %>%
     dplyr::arrange(desc(Sepal.Length), 1 / Petal.Length)
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -48,7 +48,7 @@ test_that("quasiquotation", {
     slice(1:75) %>%
     arrange(Sepal.Length, Petal.Length)
 
-  rec_1_train <- juice(prepped_1)
+  rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 })
 
@@ -57,7 +57,7 @@ test_that("no input", {
     iris_rec %>%
     step_arrange() %>%
     prep(training = iris) %>%
-    juice(composition = "data.frame")
+    bake(new_data = NULL, composition = "data.frame")
   expect_equal(no_inputs, iris)
 })
 

--- a/tests/testthat/test_bake.R
+++ b/tests/testthat/test_bake.R
@@ -6,7 +6,10 @@ test_that("order of columns after juice and bake", {
     step_center(all_predictors()) %>%
     step_scale(all_predictors())
   car_preped <- prep(car_rec, training = mtcars)
-  expect_equal(colnames(juice(car_preped)), colnames(bake(car_preped, new_data = mtcars)))
+  expect_equal(
+    colnames(juice(car_preped)),
+    colnames(bake(car_preped, new_data = mtcars))
+  )
 })
 
 test_that("can use tidyselect ops in bake() and juice() column selection", {

--- a/tests/testthat/test_column_order.R
+++ b/tests/testthat/test_column_order.R
@@ -19,7 +19,7 @@ test_that("basic steps", {
   cols_1 <- c("hydrogen", "nitrogen", "sulfur", "HHV", "oxygen_o_carbon")
 
   expect_equal(
-    names(juice(rec_1)),
+    names(bake(rec_1, new_data = NULL)),
     cols_1
   )
   expect_equal(
@@ -28,7 +28,7 @@ test_that("basic steps", {
   )
 
   expect_equal(
-    names(juice(rec_1, all_predictors())),
+    names(bake(rec_1, new_data = NULL, all_predictors())),
     cols_1[cols_1 != "HHV"]
   )
   expect_equal(
@@ -72,7 +72,7 @@ test_that("skipped steps", {
   )
 
   expect_equal(
-    names(juice(rec_2)),
+    names(bake(rec_2, new_data = NULL)),
     cols_1
   )
   expect_equal(
@@ -81,7 +81,7 @@ test_that("skipped steps", {
   )
 
   expect_equal(
-    names(juice(rec_2, all_predictors())),
+    names(bake(rec_2, new_data = NULL, all_predictors())),
     cols_1[cols_1 != "HHV"]
   )
   expect_equal(
@@ -105,7 +105,7 @@ test_that("remove and add a column", {
   cols_3 <- c("hydrogen", "nitrogen", "sulfur", "oxygen_o_carbon", "HHV")
 
   expect_equal(
-    names(juice(rec_3)),
+    names(bake(rec_3, new_data = NULL)),
     cols_3
   )
   expect_equal(
@@ -114,7 +114,7 @@ test_that("remove and add a column", {
   )
 
   expect_equal(
-    names(juice(rec_3, all_predictors())),
+    names(bake(rec_3, new_data = NULL, all_predictors())),
     cols_3[cols_3 != "HHV"]
   )
   expect_equal(
@@ -138,7 +138,7 @@ test_that("extra roles", {
   cols_3 <- c("hydrogen", "nitrogen", "sulfur", "oxygen_o_carbon", "HHV")
 
   expect_equal(
-    names(juice(rec_4)),
+    names(bake(rec_4, new_data = NULL)),
     cols_3
   )
   expect_equal(
@@ -147,7 +147,7 @@ test_that("extra roles", {
   )
 
   expect_equal(
-    names(juice(rec_4, all_predictors())),
+    names(bake(rec_4, new_data = NULL, all_predictors())),
     cols_3[cols_3 != "HHV"]
   )
   expect_equal(

--- a/tests/testthat/test_dummies.R
+++ b/tests/testthat/test_dummies.R
@@ -161,7 +161,7 @@ test_that("tests for NA values in factor", {
     factors <- prep(factors, training = sacr_missing)
   )
 
-  factors_data_0 <- juice(factors)
+  factors_data_0 <- bake(factors, new_data = NULL)
   expect_snapshot(
     factors_data_1 <- bake(factors, new_data = sacr_missing)
   )
@@ -183,7 +183,7 @@ test_that("tests for NA values in ordered factor", {
     factors <- prep(factors, training = sacr_ordered)
   )
 
-  factors_data_0 <- juice(factors)
+  factors_data_0 <- bake(factors, new_data = NULL)
   expect_snapshot(
     factors_data_1 <- bake(factors, new_data = sacr_ordered)
   )

--- a/tests/testthat/test_factors2strings.R
+++ b/tests/testthat/test_factors2strings.R
@@ -19,7 +19,7 @@ test_that("basic functionality", {
   ex_1 <- rec %>%
     step_factor2string(y, z) %>%
     prep(ex_dat, strings_as_factors = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
   expect_equal(class(ex_1$w), "character")
   expect_equal(class(ex_1$x), "character")
 })

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -21,7 +21,7 @@ test_that("basic usage - skip = FALSE", {
     slice(1:75) %>%
     dplyr::filter(Sepal.Length > 4.5, Species == "setosa")
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -49,7 +49,7 @@ test_that("skip = FALSE", {
     slice(1:75) %>%
     dplyr::filter(Sepal.Length > 4.5, Species == "setosa")
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -75,7 +75,7 @@ test_that("quasiquotation", {
     slice(1:75) %>%
     filter(Sepal.Length > 4.5, Species %in% values)
 
-  rec_1_train <- juice(prepped_1)
+  rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 
   rec_2 <-
@@ -92,7 +92,7 @@ test_that("quasiquotation", {
     prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
     regexp = NA
   )
-  rec_2_train <- juice(prepped_2)
+  rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)
 })
 
@@ -101,7 +101,7 @@ test_that("no input", {
     iris_rec %>%
     step_filter() %>%
     prep(training = iris) %>%
-    juice(composition = "data.frame")
+    bake(new_data = NULL, composition = "data.frame")
   expect_equal(no_inputs, iris)
 })
 

--- a/tests/testthat/test_geodist.R
+++ b/tests/testthat/test_geodist.R
@@ -23,7 +23,7 @@ test_that("basic functionality", {
     )
   rec_trained <- prep(rec, traning = rand_data)
 
-  tr_int <- juice(rec_trained, all_predictors())
+  tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
   te_int <- bake(rec_trained, rand_data, all_predictors())
 
   expect_equal(tr_int[["geo_dist"]], dists)
@@ -36,7 +36,7 @@ test_that("basic functionality", {
     )
   rec_log_trained <- prep(rec_log, traning = rand_data)
 
-  tr_log_int <- juice(rec_log_trained, all_predictors())
+  tr_log_int <- bake(rec_log_trained, new_data = NULL, all_predictors())
   te_log_int <- bake(rec_log_trained, rand_data, all_predictors())
 
   expect_equal(tr_log_int[["geo_dist"]], log(dists))

--- a/tests/testthat/test_ica.R
+++ b/tests/testthat/test_ica.R
@@ -45,7 +45,7 @@ test_that("correct ICA values", {
   set.seed(12)
   ica_extract_trained <- prep(ica_extract, training = biomass_tr, verbose = FALSE)
 
-  ica_pred <- juice(ica_extract_trained, all_predictors())
+  ica_pred <- bake(ica_extract_trained, new_data = NULL, all_predictors())
   ica_pred <- head(as.matrix(ica_pred))
 
   rownames(ica_pred) <- NULL
@@ -96,7 +96,7 @@ test_that("No ICA comps", {
 
   ica_extract_trained <- prep(ica_extract, training = biomass_tr)
   expect_equal(
-    names(juice(ica_extract_trained)),
+    names(bake(ica_extract_trained, new_data = NULL)),
     names(biomass_tr)[-(1:2)]
   )
   expect_true(all(names(ica_extract_trained$steps[[1]]$res) == "x_vars"))

--- a/tests/testthat/test_impute_linear.R
+++ b/tests/testthat/test_impute_linear.R
@@ -18,7 +18,7 @@ test_that("Does the imputation (no NAs), and does it correctly.", {
   imputed <- recipe(head(ames_dat)) %>%
     step_impute_linear(Lot_Frontage, impute_with = c("Lot_Area")) %>%
     prep(ames_dat) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     pull(Lot_Frontage) %>%
     .[missing_ind]
 
@@ -141,7 +141,7 @@ test_that("case weights", {
     prep(ames_dat_cw)
 
   imputed <- rec_prepped %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     pull(Lot_Frontage) %>%
     .[missing_ind]
 
@@ -167,7 +167,7 @@ test_that("case weights", {
     prep(ames_dat_cw)
 
   imputed <- rec_prepped %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     pull(Lot_Frontage) %>%
     .[missing_ind]
 

--- a/tests/testthat/test_impute_lower.R
+++ b/tests/testthat/test_impute_lower.R
@@ -44,7 +44,7 @@ test_that("basic usage", {
     rec1$steps[[1]]$threshold
   )
 
-  processed <- juice(rec1)
+  processed <- bake(rec1, new_data = NULL)
   for (i in names(rec1$steps[[1]]$threshold)) {
     affected <- biomass_tr[[i]] <= rec1$steps[[1]]$threshold[[i]]
     is_less <- processed[affected, i] < biomass_tr[affected, i]

--- a/tests/testthat/test_impute_roll.R
+++ b/tests/testthat/test_impute_roll.R
@@ -32,7 +32,7 @@ test_that("imputation values with 7-pt median", {
   seven_pt_exp$x2[4] <- median(seven_pt_exp$x2[1:7], na.rm = TRUE)
   seven_pt_exp$x2[10] <- median(seven_pt_exp$x2[6:12], na.rm = TRUE)
 
-  expect_equal(seven_pt_exp, juice(seven_pt))
+  expect_equal(seven_pt_exp, bake(seven_pt, new_data = NULL))
 
   seven_pt_tidy_tr <-
     tibble(
@@ -60,7 +60,7 @@ test_that("imputation values with 3-pt mean", {
   three_pt_exp$x2[4] <- mean(three_pt_exp$x2[3:5], na.rm = TRUE)
   three_pt_exp$x2[10] <- mean(three_pt_exp$x2[9:11], na.rm = TRUE)
 
-  expect_equal(three_pt_exp, juice(three_pt))
+  expect_equal(three_pt_exp, bake(three_pt, new_data = NULL))
 
   three_pt_tidy_tr <-
     tibble(

--- a/tests/testthat/test_integer.R
+++ b/tests/testthat/test_integer.R
@@ -28,7 +28,7 @@ test_that("basic functionality", {
     step_integer(all_predictors())
   rec_trained <- prep(rec, traning = tr_dat)
 
-  tr_int <- juice(rec_trained, all_predictors())
+  tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
   te_int <- bake(rec_trained, te_dat, all_predictors())
 
   exp_x <- c(NA, 2, 2, 1, 0)
@@ -48,7 +48,7 @@ test_that("zero-based", {
     step_integer(all_predictors(), zero_based = TRUE)
   rec_trained <- prep(rec, traning = tr_dat)
 
-  tr_int <- juice(rec_trained, all_predictors())
+  tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
   te_int <- bake(rec_trained, te_dat, all_predictors())
 
   exp_x <- c(NA, 1, 1, 0, 3)
@@ -67,7 +67,7 @@ test_that("not integers", {
     step_integer(all_predictors(), strict = FALSE)
   rec_trained <- prep(rec, traning = tr_dat)
 
-  tr_int <- juice(rec_trained, all_predictors())
+  tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
   te_int <- bake(rec_trained, te_dat, all_predictors())
 
   expect_true(all(vapply(te_int, is.numeric, logical(1))))
@@ -128,7 +128,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   rec_trained <- prep(rec, traning = tr_dat)
 
-  tr_int <- juice(rec_trained, all_predictors())
+  tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
 
   expect_error(bake(rec_trained, te_dat[, 2:3], all_predictors()),
                class = "new_data_missing_column")

--- a/tests/testthat/test_interact.R
+++ b/tests/testthat/test_interact.R
@@ -234,7 +234,7 @@ test_that("missing columns", {
     step_rm(x1) %>%
     step_interact(~ x1:x2)
   expect_snapshot(no_fail_rec <- prep(no_fail, dat_tr))
-  no_fail_res <- juice(no_fail_rec) %>% names()
+  no_fail_res <- bake(no_fail_rec, new_data = NULL) %>% names()
   expect_true(!any(grepl("_x_", no_fail_res)))
 
   one_int <-
@@ -243,7 +243,7 @@ test_that("missing columns", {
     step_interact(~ x1:x2) %>%
     step_interact(~ x3:x2)
   expect_snapshot(one_int_rec <- prep(one_int, dat_tr))
-  one_int_res <- juice(one_int_rec) %>% names()
+  one_int_res <- bake(one_int_rec, new_data = NULL) %>% names()
   expect_true(sum(grepl("_x_", one_int_res)) == 1)
 
   with_selectors <-

--- a/tests/testthat/test_isomap.R
+++ b/tests/testthat/test_isomap.R
@@ -92,7 +92,7 @@ test_that("No ISOmap", {
     prep()
 
   expect_equal(
-    names(juice(im_rec)),
+    names(bake(im_rec, new_data = NULL)),
     colnames(dat1)
   )
   expect_null(im_rec$steps[[1]]$res)

--- a/tests/testthat/test_kpca.R
+++ b/tests/testthat/test_kpca.R
@@ -63,7 +63,7 @@ test_that("No kPCA comps", {
   )
 
   expect_equal(
-    names(juice(pca_extract)),
+    names(bake(pca_extract, new_data = NULL)),
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)

--- a/tests/testthat/test_kpca_poly.R
+++ b/tests/testthat/test_kpca_poly.R
@@ -57,7 +57,7 @@ test_that("No kPCA comps", {
     prep()
 
   expect_equal(
-    names(juice(pca_extract)),
+    names(bake(pca_extract, new_data = NULL)),
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)

--- a/tests/testthat/test_kpca_rbf.R
+++ b/tests/testthat/test_kpca_rbf.R
@@ -57,7 +57,7 @@ test_that("No kPCA comps", {
     prep()
 
   expect_equal(
-    names(juice(pca_extract)),
+    names(bake(pca_extract, new_data = NULL)),
     paste0("X", c(2:6, 1))
   )
   expect_null(pca_extract$steps[[1]]$res)

--- a/tests/testthat/test_mutate.R
+++ b/tests/testthat/test_mutate.R
@@ -27,7 +27,7 @@ test_that("basic usage", {
       half_length = Sepal.Length / 2
     )
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -56,7 +56,7 @@ test_that("quasiquotation", {
     slice(1:75) %>%
     mutate(new_var = Sepal.Width * const)
 
-  rec_1_train <- juice(prepped_1)
+  rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 
   rec_2 <-
@@ -73,7 +73,7 @@ test_that("quasiquotation", {
     prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
     regexp = NA
   )
-  rec_2_train <- juice(prepped_2)
+  rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)
 })
 
@@ -102,7 +102,7 @@ test_that("no input", {
     iris_rec %>%
     step_mutate() %>%
     prep(training = iris) %>%
-    juice(composition = "data.frame")
+    bake(new_data = NULL, composition = "data.frame")
   expect_equal(no_inputs, iris)
 })
 
@@ -146,7 +146,7 @@ test_that("basic usage", {
       Petal.Length = log(Petal.Length)
     )
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -179,7 +179,7 @@ test_that("mulitple functions", {
       Petal.Length_b = sqrt(Petal.Length)
     )
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -203,7 +203,7 @@ test_that("no input", {
     iris_rec %>%
       step_mutate_at() %>%
       prep(training = iris) %>%
-      juice(composition = "data.frame")
+      bake(new_data = NULL, composition = "data.frame")
   )
 })
 

--- a/tests/testthat/test_naindicate.R
+++ b/tests/testthat/test_naindicate.R
@@ -46,7 +46,7 @@ test_that("step_indicate_na on all columns", {
   baked <- recipe(Ozone ~ ., data = airquality) %>%
     step_indicate_na(everything()) %>%
     prep(airquality, verbose = FALSE, retain = TRUE) %>%
-    juice()
+    bake(new_data = NULL)
 
   expect_named(
     baked,
@@ -62,7 +62,7 @@ test_that("step_indicate_na on subset of columns", {
   baked <- recipe(Ozone ~ ., data = airquality) %>%
     step_indicate_na(Ozone, Solar.R) %>%
     prep(airquality, verbose = FALSE, retain = TRUE) %>%
-    juice()
+    bake(new_data = NULL)
 
   expect_named(
     baked,
@@ -75,7 +75,7 @@ test_that("step_indicate_na on subset of columns", {
   baked2 <- recipe(Ozone ~ ., data = airquality) %>%
     step_indicate_na(Solar.R) %>%
     prep(airquality, verbose = FALSE, retain = TRUE) %>%
-    juice()
+    bake(new_data = NULL)
 
   expect_named(
     baked2,

--- a/tests/testthat/test_naomit.R
+++ b/tests/testthat/test_naomit.R
@@ -6,7 +6,7 @@ test_that("step_naomit on all columns", {
   baked <- recipe(Ozone ~ ., data = airquality) %>%
     step_naomit(everything()) %>%
     prep(airquality, verbose = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
 
   na_res <- tibble(na.omit(airquality))
   attributes(na_res)$na.action <- NULL
@@ -18,7 +18,7 @@ test_that("step_naomit on subset of columns", {
   baked <- recipe(Ozone ~ ., data = airquality) %>%
     step_naomit(Ozone, Solar.R) %>%
     prep(airquality, verbose = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
 
   na_res <- tibble(tidyr::drop_na(airquality, Ozone, Solar.R))
 
@@ -27,7 +27,7 @@ test_that("step_naomit on subset of columns", {
   baked2 <- recipe(Ozone ~ ., data = airquality) %>%
     step_naomit(Solar.R) %>%
     prep(airquality, verbose = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
 
   na_res2 <- tibble(tidyr::drop_na(airquality, Solar.R))
 

--- a/tests/testthat/test_num2factor.R
+++ b/tests/testthat/test_num2factor.R
@@ -18,7 +18,7 @@ test_that("basic functionality", {
   ex_1 <- rec %>%
     step_num2factor(z, levels = rev(LETTERS[1:10])) %>%
     prep(ex_dat) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(inherits(ex_1$w, "factor"))
   expect_true(inherits(ex_1$x, "numeric"))
   expect_true(inherits(ex_1$z, "factor"))
@@ -27,7 +27,7 @@ test_that("basic functionality", {
   ex_2 <- rec %>%
     step_num2factor(z, ordered = TRUE, levels = rev(LETTERS[1:10])) %>%
     prep(ex_dat) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(inherits(ex_2$w, "factor"))
   expect_true(inherits(ex_2$x, "numeric"))
   expect_true(inherits(ex_2$z, "ordered"))

--- a/tests/testthat/test_pca.R
+++ b/tests/testthat/test_pca.R
@@ -133,7 +133,7 @@ test_that("No PCA comps", {
 
   pca_extract_trained <- prep(pca_extract, training = biomass_tr)
   expect_equal(
-    names(juice(pca_extract_trained)),
+    names(bake(pca_extract_trained, new_data = NULL)),
     names(biomass_tr)[-(1:2)]
   )
   expect_true(all(is.na(pca_extract_trained$steps[[1]]$res$rotation)))

--- a/tests/testthat/test_pls_new.R
+++ b/tests/testthat/test_pls_new.R
@@ -40,7 +40,7 @@ test_that("PLS, dense loadings", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, bm_pls_tr)
   te_new <- bake(rec, biom_te)
   expect_equal(te_new, bm_pls_te)
@@ -59,7 +59,7 @@ test_that("PLS, dense loadings, multiple outcomes", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, bm_pls_multi_tr)
   te_new <- bake(rec, biom_te %>% select(-carbon))
   expect_equal(te_new, bm_pls_multi_te)
@@ -79,7 +79,7 @@ test_that("PLS, sparse loadings", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, bm_spls_tr)
   te_new <- bake(rec, biom_te)
   expect_equal(te_new, bm_spls_te)
@@ -99,7 +99,7 @@ test_that("PLS, dense loadings, multiple outcomes", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, bm_spls_multi_tr)
   te_new <- bake(rec, biom_te %>% select(-carbon))
   expect_equal(te_new, bm_spls_multi_te)
@@ -119,7 +119,7 @@ test_that("PLS-DA, dense loadings", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, cell_plsda_tr)
   te_new <- bake(rec, cell_te)
   expect_equal(te_new, cell_plsda_te)
@@ -148,7 +148,7 @@ test_that("PLS-DA, sparse loadings", {
     c("mu", "sd", "coefs", "col_norms")
   )
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(tr_new, cell_splsda_tr)
   te_new <- bake(rec, cell_te)
   expect_equal(te_new, cell_splsda_te)
@@ -178,7 +178,7 @@ test_that("No PLS", {
   )
   pred_names <- summary(rec)$variable[summary(rec)$role == "predictor"]
 
-  tr_new <- juice(rec, all_predictors())
+  tr_new <- bake(rec, new_data = NULL, all_predictors())
   expect_equal(names(tr_new), pred_names)
   te_new <- bake(rec, cell_te, all_predictors())
   expect_equal(names(te_new), pred_names)

--- a/tests/testthat/test_pls_old.R
+++ b/tests/testthat/test_pls_old.R
@@ -19,7 +19,7 @@ load(test_path("test_pls_old.RData"))
 ## -----------------------------------------------------------------------------
 
 test_that("check old PLS scores from recipes version <= 0.1.12", {
-  new_values_tr <- juice(old_pls, all_predictors())
+  new_values_tr <- bake(old_pls, new_data = NULL, all_predictors())
   expect_equal(new_values_tr, old_pls_tr)
 
   # Capture known warning about `keep_original_cols`

--- a/tests/testthat/test_poly.R
+++ b/tests/testthat/test_poly.R
@@ -93,7 +93,7 @@ test_that("old option argument", {
       recipe(~., data = iris) %>%
       step_poly(Sepal.Width, options = list(degree = 3)) %>%
       prep() %>%
-      juice(),
+      bake(new_data = NULL),
     "The `degree` argument is now a main argument"
   )
   exp_names <- c(

--- a/tests/testthat/test_profile.R
+++ b/tests/testthat/test_profile.R
@@ -14,7 +14,7 @@ test_that("numeric profile", {
   num_rec <- sacr_rec %>%
     step_profile(-sqft, profile = vars(sqft)) %>%
     prep(Sacramento) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(is_unq(num_rec$city))
   expect_true(is_unq(num_rec$price))
   expect_true(is_unq(num_rec$zip))
@@ -35,7 +35,7 @@ test_that("factor profile", {
   fact_rec <- sacr_rec %>%
     step_profile(-city, profile = vars(city)) %>%
     prep(Sacramento) %>%
-    juice()
+    bake(new_data = NULL)
   expect_false(is_unq(fact_rec$city))
   expect_true(is_unq(fact_rec$price))
   expect_true(is_unq(fact_rec$zip))
@@ -48,7 +48,7 @@ test_that("beds profile", {
   beds_rec <- sacr_rec %>%
     step_profile(-beds, profile = vars(beds)) %>%
     prep(Sacramento) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(is_unq(beds_rec$city))
   expect_true(is_unq(beds_rec$price))
   expect_true(is_unq(beds_rec$zip))
@@ -60,7 +60,7 @@ test_that("character profile", {
   chr_rec <- sacr_rec %>%
     step_profile(-zip, profile = vars(zip)) %>%
     prep(Sacramento, strings_as_factors = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(is_unq(chr_rec$city))
   expect_true(is_unq(chr_rec$price))
   expect_false(is_unq(chr_rec$zip))

--- a/tests/testthat/test_relevel.R
+++ b/tests/testthat/test_relevel.R
@@ -14,7 +14,7 @@ test_that("basic functionality", {
     step_relevel(zip, ref_level = "z95838") %>%
     prep()
 
-  tr_1 <- juice(rec_1)
+  tr_1 <- bake(rec_1, new_data = NULL)
   expect_equal(levels(tr_1$zip)[[1]], "z95838")
 
   te_1 <- bake(rec_1, sacr_te)

--- a/tests/testthat/test_rename.R
+++ b/tests/testthat/test_rename.R
@@ -27,7 +27,7 @@ test_that("basic usage", {
       plum = Sepal.Length
     )
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -47,7 +47,7 @@ test_that("no input", {
     iris_rec %>%
     step_rename() %>%
     prep(training = iris) %>%
-    juice(composition = "data.frame")
+    bake(new_data = NULL, composition = "data.frame")
   expect_equal(no_inputs, iris)
 })
 
@@ -110,7 +110,7 @@ test_that("basic usage", {
     slice(1:75) %>%
     rename_at(vars(contains("Length")), ~ tolower(.))
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -139,7 +139,7 @@ test_that("no input", {
     iris_rec %>%
       step_rename_at() %>%
       prep(training = iris) %>%
-      juice(composition = "data.frame")
+      bake(new_data = NULL, composition = "data.frame")
   )
 })
 

--- a/tests/testthat/test_rm.R
+++ b/tests/testthat/test_rm.R
@@ -32,7 +32,7 @@ test_that("basics", {
 #     step_rm(x1, skip = TRUE)
 #
 #   rec_trained <- prep(rec, training = ex_dat)
-#   tr_res <- juice(rec_trained)
+#   tr_res <- bake(rec_trained, new_data = NULL)
 #   te_res <- bake(rec_trained, new_data = ex_dat)
 #
 #   expect_equal(colnames(tr_res), "x2")
@@ -53,7 +53,7 @@ test_that("basic usage", {
     slice(1:75) %>%
     select(-Species, -starts_with("Sepal"))
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   iris_test <- iris %>%
@@ -92,7 +92,7 @@ test_that("remove via type", {
     slice(1:75) %>%
     select_if(~ !is.numeric(.))
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   iris_test <- iris %>%
@@ -121,7 +121,7 @@ test_that("remove via role", {
     slice(1:75) %>%
     select(Species)
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   iris_test <- iris %>%
@@ -152,7 +152,7 @@ test_that("remove with quasi-quotation", {
     slice(1:75) %>%
     select(-all_of(sepal_vars))
 
-  rec_1_train <- juice(prepped_1)
+  rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 
   rec_2 <-
@@ -169,7 +169,7 @@ test_that("remove with quasi-quotation", {
   #   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
   #   regexp = NA
   # )
-  rec_2_train <- juice(prepped_2)
+  rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)
 })
 

--- a/tests/testthat/test_roles.R
+++ b/tests/testthat/test_roles.R
@@ -401,7 +401,7 @@ test_that("adding multiple roles/types does not duplicate prepped columns", {
     rec %>%
       add_role(carbon, new_role = "carb") %>%
       prep(training = biomass) %>%
-      juice() %>%
+      bake(new_data = NULL) %>%
       ncol(),
     8
   )
@@ -411,7 +411,7 @@ test_that("adding multiple roles/types does not duplicate prepped columns", {
     rec %>%
       add_role(carbon, new_type = "carb") %>%
       prep(training = biomass) %>%
-      juice() %>%
+      bake(new_data = NULL) %>%
       ncol(),
     8
   )
@@ -476,7 +476,7 @@ test_that("Existing `NA` roles are not modified in prep() when new columns are g
 
   # Juicing with all predictors should only give these two columns
   expect_equal(
-    colnames(juice(prepped_rec_dummy, all_predictors())),
+    colnames(bake(prepped_rec_dummy, new_data = NULL, all_predictors())),
     c("Species_versicolor", "Species_virginica")
   )
 })

--- a/tests/testthat/test_sample.R
+++ b/tests/testthat/test_sample.R
@@ -14,7 +14,7 @@ test_that("basic usage", {
     iris_rec %>%
     step_sample(size = 1) %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     nrow()
   expect_equal(single_sample, 1)
 
@@ -22,7 +22,7 @@ test_that("basic usage", {
     iris_rec %>%
     step_sample(size = 0.99999) %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     nrow()
   expect_equal(full_sample, 150)
 
@@ -30,7 +30,7 @@ test_that("basic usage", {
     iris_rec %>%
     step_sample(size = 0.5) %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     nrow()
   expect_equal(half_sample, 75)
 
@@ -38,7 +38,7 @@ test_that("basic usage", {
     iris_rec %>%
     step_sample(size = 50) %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     nrow()
   expect_equal(third_sample, 50)
 
@@ -46,7 +46,7 @@ test_that("basic usage", {
     iris_rec %>%
     step_sample() %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     nrow()
   expect_equal(whole_sample, 150)
 
@@ -55,14 +55,14 @@ test_that("basic usage", {
     step_sample() %>%
     prep(training = iris2 %>% slice(1:120))
 
-  expect_equal(juice(smaller_iris) %>% nrow(), 120)
+  expect_equal(bake(smaller_iris, new_data = NULL) %>% nrow(), 120)
   expect_equal(bake(smaller_iris, iris2 %>% slice(121:150)) %>% nrow(), 30)
 
   boot_sample <-
     iris_rec %>%
     step_sample(replace = TRUE) %>%
     prep(training = iris2) %>%
-    juice() %>%
+    bake(new_data = NULL) %>%
     pull(row) %>%
     table()
   expect_true(max(boot_sample) > 1)

--- a/tests/testthat/test_slice.R
+++ b/tests/testthat/test_slice.R
@@ -21,7 +21,7 @@ test_that("basic usage", {
     slice(1:75) %>%
     slice(1:5)
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -47,7 +47,7 @@ test_that("skip = FALSE", {
     slice(1:75) %>%
     slice(1:5)
 
-  rec_train <- juice(prepped)
+  rec_train <- bake(prepped, new_data = NULL)
   expect_equal(dplyr_train, rec_train)
 
   dplyr_test <-
@@ -73,7 +73,7 @@ test_that("quasiquotation", {
     slice(1:75) %>%
     slice(values)
 
-  rec_1_train <- juice(prepped_1)
+  rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 
   expect_error(
@@ -93,7 +93,7 @@ test_that("quasiquotation", {
     prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
     regexp = NA
   )
-  rec_2_train <- juice(prepped_2)
+  rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)
 })
 
@@ -103,7 +103,7 @@ test_that("no input", {
     iris_rec %>%
     step_slice() %>%
     prep(training = iris) %>%
-    juice(composition = "data.frame")
+    bake(new_data = NULL, composition = "data.frame")
   expect_equal(no_inputs, iris)
 })
 

--- a/tests/testthat/test_string2factor.R
+++ b/tests/testthat/test_string2factor.R
@@ -19,7 +19,7 @@ test_that("basic functionality", {
   ex_1 <- rec %>%
     step_string2factor(w, x) %>%
     prep(ex_dat, strings_as_factors = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
   expect_equal(class(ex_1$w), "factor")
   expect_equal(class(ex_1$x), "factor")
   expect_equal(levels(ex_1$w), letters[1:3])
@@ -28,7 +28,7 @@ test_that("basic functionality", {
   ex_2 <- rec %>%
     step_string2factor(w, x, ordered = TRUE) %>%
     prep(ex_dat, strings_as_factors = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
   expect_equal(class(ex_2$w), c("ordered", "factor"))
   expect_equal(class(ex_2$x), c("ordered", "factor"))
   expect_equal(levels(ex_2$w), letters[1:3])
@@ -61,7 +61,7 @@ test_that("pre-made factors", {
   ex_1 <- rec %>%
     step_string2factor(w, x, y, z) %>%
     prep(ex_dat, strings_as_factors = FALSE) %>%
-    juice()
+    bake(new_data = NULL)
   expect_true(inherits(ex_1$w, "factor"))
   expect_true(inherits(ex_1$x, "factor"))
   expect_true(inherits(ex_1$y, "factor"))

--- a/tests/testthat/test_unknown.R
+++ b/tests/testthat/test_unknown.R
@@ -16,7 +16,7 @@ test_that("basic functionality", {
     step_unknown(city, zip) %>%
     prep()
 
-  tr_1 <- juice(rec_1)
+  tr_1 <- bake(rec_1, new_data = NULL)
   tr_city <- tr_1$city[is.na(sacr_tr$city)]
   tr_city <- unique(as.character(tr_city))
   expect_true(all(tr_city == "unknown"))
@@ -47,7 +47,7 @@ test_that("basic functionality", {
   rec_2 <- rec %>%
     step_unknown(city, new_level = "potato-based") %>%
     prep()
-  tr_2 <- juice(rec_2)
+  tr_2 <- bake(rec_2, new_data = NULL)
   tr_city <- tr_2$city[is.na(sacr_tr$city)]
   tr_city <- unique(as.character(tr_city))
   expect_true(all(tr_city == "potato-based"))


### PR DESCRIPTION
This PR finishes the superseding of `juice()` by

- Add supersede badge
- No longer use `juice()` in examples
- No longer use `juice()` in non-juice related tests

to close https://github.com/tidymodels/recipes/issues/953