### PR TITLE
Have recipe.formula have better error when data is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `recipes_extension_check()` have been added. This developer focused function checks that steps have all the required S3 methods.
 
+* `recipe()` now error more informatively when `data` is missing. (#1042)
+
 # recipes 1.0.3
 
 * `step_dummy()` no longer returns integer columns as there are a number of contrast methods that return fractional values. (#1053)

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -191,6 +191,9 @@ recipe.formula <- function(formula, data, ...) {
     rlang::abort("`-` is not allowed in a recipe formula. Use `step_rm()` instead.")
   }
 
+  if (rlang::is_missing(data)) {
+    cli::cli_abort("Argument {.var data} is missing, with no default.")
+  }
   # Check for other in-line functions
   args <- form2args(formula, data, ...)
   obj <- recipe.data.frame(

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -138,3 +138,11 @@
       Error in `prep()`:
       ! bake() methods should always return tibbles
 
+# recipe() errors if `data` is missing
+
+    Code
+      recipe(mpg ~ .)
+    Condition
+      Error in `recipe()`:
+      ! Argument `data` is missing, with no default.
+

--- a/tests/testthat/test_basics.R
+++ b/tests/testthat/test_basics.R
@@ -332,3 +332,7 @@ test_that("`internal data is kept as tibbles when prepping", {
 
   expect_snapshot(error = TRUE, prep(rec_spec))
 })
+
+test_that("recipe() errors if `data` is missing", {
+  expect_snapshot(error = TRUE, recipe(mpg ~ .))
+})


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1042

``` r
library(tidymodels)

recipe(mpg ~ .)
#> Error in `recipe()`:
#> ! Argument `data` is missing, with no default.

#> Backtrace:
#>     ▆
#>  1. ├─recipes::recipe(mpg ~ .)
#>  2. └─recipes:::recipe.formula(mpg ~ .) at recipes/R/recipe.R:9:2
#>  3.   └─rlang::abort("Argument `data` is missing, with no default.") at recipes/R/recipe.R:195:4

tune_bayes(
linear_reg(engine = "glmnet", penalty = tune(), mixture = tune()),
recipe(mpg ~ .) %>% step_ns(hp, deg_free = tune()),
bootstraps(mtcars, 2)
)
#> Error in `recipe()` at recipes/R/ns.R:62:4:
#> ! Argument `data` is missing, with no default.

#> Backtrace:
#>     ▆
#>  1. ├─tune::tune_bayes(...)
#>  2. ├─tune:::tune_bayes.model_spec(...)
#>  3. │ └─rlang::is_missing(preprocessor)
#>  4. ├─recipe(mpg ~ .) %>% step_ns(hp, deg_free = tune())
#>  5. ├─recipes::step_ns(., hp, deg_free = tune())
#>  6. │ └─recipes::add_step(...) at recipes/R/ns.R:62:4
#>  7. ├─recipes::recipe(mpg ~ .) at recipes/R/ns.R:62:4
#>  8. └─recipes:::recipe.formula(mpg ~ .) at recipes/R/recipe.R:9:2
#>  9.   └─rlang::abort("Argument `data` is missing, with no default.") at recipes/R/recipe.R:195:4
```

<sup>Created on 2022-12-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>