### PR TITLE
Fixes for dev dplyr

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -861,3 +861,8 @@ recipes_error_context <- function(expr, step_name) {
     }
   )
 }
+
+vec_paste0 <- function(..., collapse = NULL) {
+  args <- vctrs::vec_recycle_common(...)
+  rlang::inject(paste0(!!!args, collapse = collapse))
+}

--- a/R/naindicate.R
+++ b/R/naindicate.R
@@ -109,7 +109,7 @@ bake.step_indicate_na <- function(object, new_data, ...) {
   )
 
   cols <- tibble::new_tibble(cols, nrow = nrow(new_data))
-  cols <- dplyr::rename_with(cols, ~ paste0(object$prefix, "_", .x))
+  cols <- dplyr::rename_with(cols, ~ vec_paste0(object$prefix, "_", .x))
 
   new_data <- dplyr::bind_cols(new_data, cols)
   new_data

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -66,7 +66,9 @@ prep.step_naomit <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_naomit <- function(object, new_data, ...) {
-  tibble::as_tibble(tidyr::drop_na(new_data, object$columns))
+  columns <- object$columns
+  columns <- unname(columns)
+  tibble::as_tibble(tidyr::drop_na(new_data, tidyselect::all_of(columns)))
 }
 
 print.step_naomit <-

--- a/tests/testthat/test_slice.R
+++ b/tests/testthat/test_slice.R
@@ -97,17 +97,6 @@ test_that("quasiquotation", {
   expect_equal(dplyr_train, rec_2_train)
 })
 
-
-test_that("no input", {
-  no_inputs <-
-    iris_rec %>%
-    step_slice() %>%
-    prep(training = iris) %>%
-    bake(new_data = NULL, composition = "data.frame")
-  expect_equal(no_inputs, iris)
-})
-
-
 test_that("printing", {
   rec <- iris_rec %>% step_slice(1:2)
   expect_snapshot(print(rec))


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `rename_with()` now checks that the result of the function is the right length. `paste0()` has bad recycling behavior when there are length 0 inputs so we typically use a `vec_paste0()` helper for this instead
- `slice()` with no inputs now drops all rows. We were testing this but i dont think we should test this edge case dplyr behavior so i just removed the test
- I also fixed a dev tidyr issue where we now assert that tidyselection in `drop_na()` shouldn't rename (because that isn't meaningful). And I used the more appropriate `all_of()` selector.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!