### PR TITLE
outside argument for step_percentile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Added `outside` argument to `step_percentile()` to determine different ways of handling values outside the range of the training data.
+
 * Added missing tidy method for `step_intercept()` and `step_lag()`. (#730)
 
 * Errors in `prep()` and `bake()` will now indicate which step caused the error. (#420)

--- a/man/step_percentile.Rd
+++ b/man/step_percentile.Rd
@@ -11,6 +11,7 @@ step_percentile(
   trained = FALSE,
   ref_dist = NULL,
   options = list(probs = (0:100)/100),
+  outside = "none",
   skip = FALSE,
   id = rand_id("percentile")
 )
@@ -34,6 +35,13 @@ preprocessing step has be trained by \code{\link[=prep]{prep()}}.}
 
 \item{options}{A named list of options to pass to \code{\link[stats:quantile]{stats::quantile()}}.
 See Details for more information.}
+
+\item{outside}{A character, describing how interpolation is to take place
+outside the interval \verb{[min(x), max(x)]}. \code{none} means nothing will happen
+and values outside the range will be \code{NA}. \code{lower} means that new values
+less than \code{min(x)} will be given the value \code{0}. \code{upper} means that new
+values larger than \code{max(x)} will be given the value \code{1}. \code{both} will handle
+both cases. Defaults to \code{none}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/tests/testthat/_snaps/percentile.md
+++ b/tests/testthat/_snaps/percentile.md
@@ -1,3 +1,12 @@
+# outside argument
+
+    Code
+      recipe(~a, data = train_df) %>% step_percentile(a, outside = "left") %>% prep() %>%
+        bake(new_data = new_df)
+    Condition
+      Error in `step_percentile()`:
+      ! `outside` must be one of "none", "both", "upper", or "lower", not "left".
+
 # printing
 
     Code

--- a/tests/testthat/test_percentile.R
+++ b/tests/testthat/test_percentile.R
@@ -103,6 +103,52 @@ test_that("passing new probs works", {
   )
 })
 
+test_that("outside argument", {
+  train_df <- tibble(a = 1:9)
+
+  new_df <- tibble(a = c(0.99, 5, 9.01))
+
+  expect_identical(
+    recipe(~ a, data = train_df) %>%
+      step_percentile(a, outside = "none") %>%
+      prep() %>%
+      bake(new_data = new_df),
+    tibble(a = c(NA, 0.5, NA))
+  )
+
+  expect_identical(
+    recipe(~ a, data = train_df) %>%
+      step_percentile(a, outside = "lower") %>%
+      prep() %>%
+      bake(new_data = new_df),
+    tibble(a = c(0, 0.5, NA))
+  )
+
+  expect_identical(
+    recipe(~ a, data = train_df) %>%
+      step_percentile(a, outside = "upper") %>%
+      prep() %>%
+      bake(new_data = new_df),
+    tibble(a = c(NA, 0.5, 1))
+  )
+
+  expect_identical(
+    recipe(~ a, data = train_df) %>%
+      step_percentile(a, outside = "both") %>%
+      prep() %>%
+      bake(new_data = new_df),
+    tibble(a = c(0, 0.5, 1))
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~ a, data = train_df) %>%
+      step_percentile(a, outside = "left") %>%
+      prep() %>%
+      bake(new_data = new_df)
+  )
+})
+
 test_that("printing", {
   rec <- recipe(~., data = biomass_tr) %>%
     step_percentile(carbon, sulfur)


### PR DESCRIPTION
This PR is here to make this problem easier to handle https://community.rstudio.com/t/step-percentile-new-data-outside-range-of-training-data/156694. now you have a way to determine how values outside the range in `step_percentile()` is handled

``` r
library(dplyr)
library(recipes)

train_df <- tibble(
  a = 1:10,
  b = 10:1
)

new_df <- tibble(a = c(1, 4, 5), b = c(0.99, 5, 10.01))

# Defaults to `outside = "none"`
train_df %>%
  recipe(a ~ b) %>%
  step_percentile(b, outside = "none") %>%
  prep() %>%
  bake(new_data = new_df)
#> # A tibble: 3 × 2
#>        b     a
#>    <dbl> <dbl>
#> 1 NA         1
#> 2  0.444     4
#> 3 NA         5

train_df %>%
  recipe(a ~ b) %>%
  step_percentile(b, outside = "both") %>%
  prep() %>%
  bake(new_data = new_df)
#> # A tibble: 3 × 2
#>       b     a
#>   <dbl> <dbl>
#> 1 0         1
#> 2 0.444     4
#> 3 1         5

train_df %>%
  recipe(a ~ b) %>%
  step_percentile(b, outside = "lower") %>%
  prep() %>%
  bake(new_data = new_df)
#> # A tibble: 3 × 2
#>        b     a
#>    <dbl> <dbl>
#> 1  0         1
#> 2  0.444     4
#> 3 NA         5

train_df %>%
  recipe(a ~ b) %>%
  step_percentile(b, outside = "upper") %>%
  prep() %>%
  bake(new_data = new_df)
#> # A tibble: 3 × 2
#>        b     a
#>    <dbl> <dbl>
#> 1 NA         1
#> 2  0.444     4
#> 3  1         5
```

<sup>Created on 2023-01-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>