### PR TITLE
use skip_if_not_installed() for dials in tests

### DIFF
--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -1,5 +1,7 @@
 
 test_that("extract parameter set from recipe with no steps", {
+  skip_if_not_installed("dials")
+
   bare_rec <- recipe(mpg ~ ., data = mtcars)
 
   bare_info <- extract_parameter_set_dials(bare_rec)
@@ -8,6 +10,8 @@ test_that("extract parameter set from recipe with no steps", {
 })
 
 test_that("extract parameter set from recipe with no tunable parameters", {
+  skip_if_not_installed("dials")
+
   rm_rec <-
     recipe(mpg ~ ., data = mtcars) %>%
     step_rm(hp)
@@ -18,6 +22,8 @@ test_that("extract parameter set from recipe with no tunable parameters", {
 })
 
 test_that("extract parameter set from recipe with tunable parameters", {
+  skip_if_not_installed("dials")
+
   spline_rec <-
     recipe(mpg ~ ., data = mtcars) %>%
     step_impute_knn(all_numeric_predictors(), neighbors = hardhat::tune("imputation")) %>%
@@ -49,6 +55,8 @@ test_that("extract parameter set from recipe with tunable parameters", {
 # -------------------------------------------------------------------------
 
 test_that("extract single parameter from recipe with no steps", {
+  skip_if_not_installed("dials")
+
   bare_rec <- recipe(mpg ~ ., data = mtcars)
 
   expect_snapshot(error = TRUE,
@@ -57,6 +65,8 @@ test_that("extract single parameter from recipe with no steps", {
 })
 
 test_that("extract single parameter from recipe with no tunable parameters", {
+  skip_if_not_installed("dials")
+
   rm_rec <-
     recipe(mpg ~ ., data = mtcars) %>%
     step_rm(hp)
@@ -67,6 +77,8 @@ test_that("extract single parameter from recipe with no tunable parameters", {
 })
 
 test_that("extract single parameter from recipe with tunable parameters", {
+  skip_if_not_installed("dials")
+
   spline_rec <-
     recipe(mpg ~ ., data = mtcars) %>%
     step_impute_knn(all_numeric_predictors(), neighbors = hardhat::tune("imputation")) %>%


### PR DESCRIPTION
This is in the grey area of needed-ness, but since {dials} is in Suggests, I think it will be worth it.