### PR TITLE
Use dials::degree_int() in new spline steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bug in `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, and `spline_nonnegative()` where you weren't able to tune the `degree` argument.
+
 # recipes 1.0.5
 
 * Added `outside` argument to `step_percentile()` to determine different ways of handling values outside the range of the training data.

--- a/R/spline_b.R
+++ b/R/spline_b.R
@@ -214,7 +214,7 @@ tunable.step_spline_b <- function(x, ...) {
     name = c("deg_free", "degree"),
     call_info = list(
       list(pkg = "dials", fun = "spline_degree", range = c(2L, 15L)),
-      list(pkg = "dials", fun = "degree", range = c(1L, 4L))
+      list(pkg = "dials", fun = "degree_int", range = c(1L, 4L))
     ),
     source = "recipe",
     component = "step_spline_b",

--- a/R/spline_convex.R
+++ b/R/spline_convex.R
@@ -205,7 +205,7 @@ tunable.step_spline_convex <- function(x, ...) {
     name = c("deg_free", "degree"),
     call_info = list(
       list(pkg = "dials", fun = "spline_degree", range = c(2L, 15L)),
-      list(pkg = "dials", fun = "degree", range = c(0L, 3L))
+      list(pkg = "dials", fun = "degree_int", range = c(0L, 3L))
     ),
     source = "recipe",
     component = "step_spline_convex",

--- a/R/spline_monotone.R
+++ b/R/spline_monotone.R
@@ -206,7 +206,7 @@ tunable.step_spline_monotone <- function(x, ...) {
     name = c("deg_free", "degree"),
     call_info = list(
       list(pkg = "dials", fun = "spline_degree", range = c(2L, 15L)),
-      list(pkg = "dials", fun = "degree", range = c(0L, 4L))
+      list(pkg = "dials", fun = "degree_int", range = c(0L, 4L))
     ),
     source = "recipe",
     component = "step_spline_monotone",

--- a/R/spline_nonnegative.R
+++ b/R/spline_nonnegative.R
@@ -217,7 +217,7 @@ tunable.step_spline_nonnegative <- function(x, ...) {
     name = c("deg_free", "degree"),
     call_info = list(
       list(pkg = "dials", fun = "spline_degree", range = c(2L, 15L)),
-      list(pkg = "dials", fun = "degree", range = c(0L, 3L))
+      list(pkg = "dials", fun = "degree_int", range = c(0L, 3L))
     ),
     source = "recipe",
     component = "step_spline_nonnegative",


### PR DESCRIPTION
This issue was first brought up on stackoverflow: https://stackoverflow.com/questions/75618633/is-this-a-bug-in-tidy-models. This was a implementation issue in recipes. the non-integer degree was used with integer values range

# Main

``` r
library(tidymodels)

rec <- recipe(mpg ~ disp, data = mtcars) |>
  step_spline_b(disp, degree = tune())

rs <- vfold_cv(mtcars) 

workflow() |>
  add_recipe(rec) |>
  add_model(linear_reg()) |>
  tune_grid(resamples=rs)
#> Error in `mutate()`:
#> ℹ In argument: `object = purrr::map(call_info, eval_call_info)`.
#> Caused by error in `purrr::map()`:
#> ℹ In index: 1.
#> Caused by error in `.f()`:
#> ! Error when calling degree(): Error in new_quant_param(type = "double", range = range, inclusive = c(TRUE,  : 
#>   Since `type = 'double'`, please use that data type for the range.

#> Backtrace:
#>      ▆
#>   1. ├─tune::tune_grid(...)
#>   2. ├─tune:::tune_grid.workflow(...) at tune/R/tune_grid.R:237:2
#>   3. │ └─tune:::tune_grid_workflow(...) at tune/R/tune_grid.R:298:2
#>   4. │   └─tune::check_parameters(...) at tune/R/tune_grid.R:324:2
#>   5. │     ├─hardhat::extract_parameter_set_dials(wflow) at tune/R/checks.R:146:4
#>   6. │     └─workflows:::extract_parameter_set_dials.workflow(wflow)
#>   7. │       ├─hardhat::extract_parameter_set_dials(recipe)
#>   8. │       └─recipes:::extract_parameter_set_dials.recipe(recipe)
#>   9. │         └─... %>% ... at recipes/R/extract_parameter.R:5:2
#>  10. ├─dplyr::mutate(., object = purrr::map(call_info, eval_call_info))
#>  11. ├─dplyr:::mutate.data.frame(., object = purrr::map(call_info, eval_call_info))
#>  12. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
#>  13. │   ├─base::withCallingHandlers(...)
#>  14. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
#>  15. │     └─mask$eval_all_mutate(quo)
#>  16. │       └─dplyr (local) eval()
#>  17. ├─purrr::map(call_info, eval_call_info)
#>  18. │ └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
#>  19. │   ├─purrr:::with_indexed_errors(...)
#>  20. │   │ └─base::withCallingHandlers(...)
#>  21. │   ├─purrr:::call_with_cleanup(...)
#>  22. │   └─recipes (local) .f(.x[[i]], ...)
#>  23. │     └─base::stop(paste0("Error when calling ", x$fun, "(): ", as.character(res))) at recipes/R/extract_parameter.R:34:6
#>  24. └─base::.handleSimpleError(...)
#>  25.   └─purrr (local) h(simpleError(msg, call))
#>  26.     └─cli::cli_abort(...)
#>  27.       └─rlang::abort(...)
```

<sup>Created on 2023-03-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

# This PR

``` r
library(tidymodels)

rec <- recipe(mpg ~ disp, data = mtcars) |>
  step_spline_b(disp, degree = tune())

rs <- vfold_cv(mtcars) 

workflow() |>
  add_recipe(rec) |>
  add_model(linear_reg()) |>
  tune_grid(resamples=rs)
#> → A | warning: Some 'x' values beyond boundary knots may cause ill-conditioned basis
#>                functions.
#> There were issues with some computations   A: x1
#> There were issues with some computations   A: x5
#> There were issues with some computations   A: x8
#> 
#> # Tuning results
#> # 10-fold cross-validation 
#> # A tibble: 10 × 4
#>    splits         id     .metrics         .notes          
#>    <list>         <chr>  <list>           <list>          
#>  1 <split [28/4]> Fold01 <tibble [8 × 5]> <tibble [0 × 3]>
#>  2 <split [28/4]> Fold02 <tibble [8 × 5]> <tibble [0 × 3]>
#>  3 <split [29/3]> Fold03 <tibble [8 × 5]> <tibble [4 × 3]>
#>  4 <split [29/3]> Fold04 <tibble [8 × 5]> <tibble [0 × 3]>
#>  5 <split [29/3]> Fold05 <tibble [8 × 5]> <tibble [0 × 3]>
#>  6 <split [29/3]> Fold06 <tibble [8 × 5]> <tibble [0 × 3]>
#>  7 <split [29/3]> Fold07 <tibble [8 × 5]> <tibble [0 × 3]>
#>  8 <split [29/3]> Fold08 <tibble [8 × 5]> <tibble [0 × 3]>
#>  9 <split [29/3]> Fold09 <tibble [8 × 5]> <tibble [4 × 3]>
#> 10 <split [29/3]> Fold10 <tibble [8 × 5]> <tibble [0 × 3]>
#> 
#> There were issues with some computations:
#> 
#>   - Warning(s) x8: Some 'x' values beyond boundary knots may cause ill-conditioned b...
#> 
#> Run `show_notes(.Last.tune.result)` for more information.
```

<sup>Created on 2023-03-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>