### PR TITLE
Avoid depending on the specifics of "object not found" base R errors

### DIFF
--- a/R/roles.R
+++ b/R/roles.R
@@ -307,6 +307,9 @@ update_role <- function(recipe, ..., new_role = "predictor", old_role = NULL) {
 #' @rdname roles
 #' @export
 remove_role <- function(recipe, ..., old_role) {
+  if (rlang::is_missing(old_role)) {
+    rlang::abort('argument "old_role" is missing, with no default.')
+  }
   single_chr(old_role, "old_")
 
   terms <- quos(...)

--- a/R/selections.R
+++ b/R/selections.R
@@ -172,6 +172,10 @@ recipes_eval_select <- function(quos, data, info, ..., allow_rename = FALSE,
                                 check_case_weights = TRUE, call = caller_env()) {
   ellipsis::check_dots_empty()
 
+  if (rlang::is_missing(quos)) {
+    rlang::abort('argument "quos" is missing, with no default.')
+  }
+
   # Maintain ordering between `data` column names and `info$variable` so
   # `eval_select()` and recipes selectors return compatible positions
   data_info <- tibble(variable = names(data))

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -1,14 +1,3 @@
-# quasiquotation
-
-    Code
-      prep(rec_1, training = iris %>% slice(1:75))
-    Condition
-      Error in `step_filter()`:
-      Caused by error in `dplyr::filter()`:
-      i In argument: `Species %in% values`.
-      Caused by error in `Species %in% values`:
-      ! object 'values' not found
-
 # printing
 
     Code

--- a/tests/testthat/_snaps/profile.md
+++ b/tests/testthat/_snaps/profile.md
@@ -10,14 +10,6 @@
 ---
 
     Code
-      sacr_rec %>% step_profile(everything(), profile = age) %>% prep(data = Sacramento)
-    Condition
-      Error in `structure()`:
-      ! object 'age' not found
-
----
-
-    Code
       sacr_rec %>% step_profile(sqft, beds, price, profile = vars(zip, beds)) %>%
         prep(data = Sacramento)
     Condition

--- a/tests/testthat/_snaps/rm.md
+++ b/tests/testthat/_snaps/rm.md
@@ -7,17 +7,6 @@
       Caused by error in `prep()`:
       ! Can't rename variables in this context.
 
-# remove with quasi-quotation
-
-    Code
-      prep(rec_1, training = iris %>% slice(1:75))
-    Condition
-      Error in `step_rm()`:
-      Caused by error in `prep()`:
-      ! Problem while evaluating `all_of(sepal_vars)`.
-      Caused by error in `as_indices_impl()`:
-      ! object 'sepal_vars' not found
-
 # printing
 
     Code

--- a/tests/testthat/_snaps/roles.md
+++ b/tests/testthat/_snaps/roles.md
@@ -67,8 +67,8 @@
     Code
       rec <- remove_role(rec, sample)
     Condition
-      Error in `single_chr()`:
-      ! argument "old_role" is missing, with no default
+      Error in `remove_role()`:
+      ! argument "old_role" is missing, with no default.
 
 ---
 

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -1,14 +1,3 @@
-# quasiquotation
-
-    Code
-      prep(rec_1, training = iris_train)
-    Condition
-      Error in `step_select()`:
-      Caused by error in `prep()`:
-      ! Problem while evaluating `all_of(sepal_vars)`.
-      Caused by error in `as_indices_impl()`:
-      ! object 'sepal_vars' not found
-
 # printing
 
     Code

--- a/tests/testthat/_snaps/selections.md
+++ b/tests/testthat/_snaps/selections.md
@@ -13,6 +13,6 @@
     Code
       recipes_eval_select(data = Sacramento, info = info_sac)
     Condition
-      Error in `enexpr()`:
-      ! argument "quos" is missing, with no default
+      Error in `recipes_eval_select()`:
+      ! argument "quos" is missing, with no default.
 

--- a/tests/testthat/_snaps/terms-select.md
+++ b/tests/testthat/_snaps/terms-select.md
@@ -6,6 +6,9 @@
       Warning:
       `terms_select()` was deprecated in recipes 0.1.17.
       i Please use `recipes_eval_select()` instead.
+      Warning:
+      `with_handlers()` is deprecated as of rlang 1.0.0.
+      i Please use `tryCatch()`, `withCallingHandlers()`, or `try_fetch()`.
     Output
       [1] "city"      "zip"       "beds"      "baths"     "sqft"      "type"     
       [7] "price"     "latitude"  "longitude"
@@ -49,12 +52,4 @@
     Condition
       Error:
       ! No variables or terms were selected.
-
----
-
-    Code
-      terms_select(info = info1)
-    Condition
-      Error in `is_empty()`:
-      ! argument "terms" is missing, with no default
 

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -102,13 +102,6 @@ test_that("quasiquotation", {
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)
 
-  # only rec_2 works when local variable is removed
-  rm(sepal_vars)
-
-  expect_snapshot(error = TRUE,
-    prep(rec_1, training = iris_train)
-  )
-
   prepped_2 <- prep(rec_2, training = iris_train)
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)

--- a/tests/testthat/test-terms-select.R
+++ b/tests/testthat/test-terms-select.R
@@ -102,9 +102,6 @@ test_that("simple name selections", {
   expect_snapshot(error = TRUE,
     terms_select(info = info1, quos(matches("blahblahblah")))
   )
-  expect_snapshot(error = TRUE,
-    terms_select(info = info1)
-  )
 })
 
 

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -84,10 +84,6 @@ test_that("quasiquotation", {
 
   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
 
-  rm(values)
-  expect_snapshot(error = TRUE,
-    prep(rec_1, training = iris %>% slice(1:75))
-  )
   expect_error(
     prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
     regexp = NA

--- a/tests/testthat/test_profile.R
+++ b/tests/testthat/test_profile.R
@@ -77,11 +77,6 @@ test_that("bad values", {
   )
   expect_snapshot(error = TRUE,
     sacr_rec %>%
-      step_profile(everything(), profile = age) %>%
-      prep(data = Sacramento)
-  )
-  expect_snapshot(error = TRUE,
-    sacr_rec %>%
       step_profile(sqft, beds, price, profile = vars(zip, beds)) %>%
       prep(data = Sacramento)
   )

--- a/tests/testthat/test_rm.R
+++ b/tests/testthat/test_rm.R
@@ -161,10 +161,6 @@ test_that("remove with quasi-quotation", {
 
   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
 
-  rm(sepal_vars)
-  expect_snapshot(error = TRUE,
-    prep(rec_1, training = iris %>% slice(1:75))
-  )
   # expect_error(
   #   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
   #   regexp = NA


### PR DESCRIPTION
This PR modifies some functions so that we don't rely on base R errors, and deletes a couple of tests of the same nature where the errors pop up in dplyr functions