### PR TITLE
remove unused filter_terms()

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1,7 +1,3 @@
-filter_terms <- function(x, ...) {
-  UseMethod("filter_terms")
-}
-
 ## get variables from formulas
 is_formula <- function(x) {
   isTRUE(inherits(x, "formula"))
@@ -41,10 +37,6 @@ get_rhs_vars <- function(formula, data, no_lhs = FALSE) {
 
 terms.recipe <- function(x, ...) {
   x$term_info
-}
-
-filter_terms.formula <- function(formula, data, ...) {
-  get_rhs_vars(formula, data)
 }
 
 #' Naming Tools


### PR DESCRIPTION
What the title says. This function is no longer used, and isn't exported