### PR TITLE
use rlang::is_formula()

### DIFF
--- a/R/interactions.R
+++ b/R/interactions.R
@@ -259,7 +259,7 @@ make_new_formula <- function(x) {
 ## term expansion (without `.`s). This returns the factor
 ## names and would not expand dummy variables.
 get_term_names <- function(form, vnames) {
-  if (!is_formula(form)) {
+  if (!rlang::is_formula(form, scoped = TRUE)) {
     form <- as.formula(form)
   }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -2,13 +2,8 @@ filter_terms <- function(x, ...) {
   UseMethod("filter_terms")
 }
 
-## get variables from formulas
-is_formula <- function(x) {
-  isTRUE(inherits(x, "formula"))
-}
-
 get_lhs_vars <- function(formula, data) {
-  if (!is_formula(formula)) {
+  if (!rlang::is_formula(formula)) {
     formula <- as.formula(formula)
   }
   ## Want to make sure that multiple outcomes can be expressed as
@@ -18,7 +13,7 @@ get_lhs_vars <- function(formula, data) {
 }
 
 get_rhs_vars <- function(formula, data, no_lhs = FALSE) {
-  if (!is_formula(formula)) {
+  if (!rlang::is_formula(formula)) {
     formula <- as.formula(formula)
   }
   if (no_lhs) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -214,7 +214,7 @@ recipe.matrix <- function(x, ...) {
 }
 
 form2args <- function(formula, data, ...) {
-  if (!is_formula(formula)) {
+  if (!rlang::is_formula(formula)) {
     formula <- as.formula(formula)
   }
 


### PR DESCRIPTION
this PR switches out the internal helper function `is_formula()` with `rlang::is_formula()`. It is a small complexity reducing PR

It also comes with the tiniest of performance improvements

``` r
library(recipes)
library(rlang)

formula <- ~5

bench::mark(
  is_formula(formula),
  is_formula(formula)
)
#> # A tibble: 2 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 is_formula(formula)    164ns    246ns  3125905.    2.49KB        0
#> 2 is_formula(formula)    205ns    246ns  3037115.        0B        0

not_formula <- 2

bench::mark(
  is_formula(not_formula),
  is_formula(not_formula)
)
#> # A tibble: 2 × 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 is_formula(not_formula)    205ns    246ns  3028618.        0B        0
#> 2 is_formula(not_formula)    205ns    246ns  3055029.        0B        0
```

<sup>Created on 2023-03-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>