### PR TITLE
don't use ellipse_check()

### DIFF
--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -80,7 +80,7 @@ step_nnmf_sparse <-
     add_step(
       recipe,
       step_nnmf_sparse_new(
-        terms = ellipse_check(...),
+        terms = enquos(...),
         role = role,
         trained = trained,
         num_comp = num_comp,


### PR DESCRIPTION
ellipse_check() is deprecated and it appears like we forgot to stop using it in `step_nnmf_sparse()`

https://github.com/tidymodels/recipes/blob/f8f02691c977ee0039122661d4e3d48b0dbd29ea/R/misc.R#L275-L279