### PR TITLE
delete unused terms.recipe()

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -39,10 +39,6 @@ get_rhs_vars <- function(formula, data, no_lhs = FALSE) {
   predictor_names
 }
 
-terms.recipe <- function(x, ...) {
-  x$term_info
-}
-
 filter_terms.formula <- function(formula, data, ...) {
   get_rhs_vars(formula, data)
 }


### PR DESCRIPTION
What the title says. This function is no longer used, and isn't exported