### PR TITLE
transition from `map_dfr()` in `tune_args.recipe()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     lubridate (>= 1.8.0),
     magrittr,
     Matrix,
-    purrr (>= 0.2.3),
+    purrr (>= 1.0.0),
     rlang (>= 1.0.3),
     stats,
     tibble,

--- a/R/tune_args.R
+++ b/R/tune_args.R
@@ -6,7 +6,9 @@ tune_args.recipe <- function(object, full = FALSE, ...) {
     return(tune_tbl())
   }
 
-  res <- purrr::map_dfr(object$steps, tune_args, full = full)
+  res <- purrr::map(object$steps, tune_args, full = full)
+  res <- purrr::list_rbind(res)
+
   tune_tbl(
     res$name,
     res$tunable,


### PR DESCRIPTION
Just because this function gets so much traffic, the deprecation machinery for `map_dfr()` ended up causing some slowdowns. :)