### PR TITLE
don't use colon programatically

### DIFF
--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -234,7 +234,7 @@ prep.step_harmonic <- function(x, training, info = NULL, ...) {
 
   frequencies <- sort(unique(na.omit(x$frequency)))
 
-  names(frequencies) <- as.character(1:length(frequencies))
+  names(frequencies) <- as.character(seq_along(frequencies))
   names(starting_vals) <- col_names
   names(cycle_sizes) <- col_names
 
@@ -303,7 +303,7 @@ bake.step_harmonic <- function(object, new_data, ...) {
     colnames(res) <- paste0(
       col_name,
       rep(c("_sin_", "_cos_"), each = n_frequency),
-      1:n_frequency
+      seq_len(n_frequency)
     )
     res <- as_tibble(res)
     new_data <- bind_cols(new_data, res)

--- a/R/ica.R
+++ b/R/ica.R
@@ -191,7 +191,7 @@ bake.step_ica <- function(object, new_data, ...) {
       center = object$res$means, scale = FALSE
     )
     comps <- comps %*% object$res$K %*% object$res$W
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     colnames(comps) <- names0(ncol(comps), object$prefix)
     new_data <- bind_cols(new_data, as_tibble(comps))
     keep_original_cols <- get_keep_original_cols(object)

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -197,7 +197,7 @@ bake.step_isomap <- function(object, new_data, ...) {
         dimred_data(new_data[, isomap_vars, drop = FALSE])
       )@data
     })
-    comps <- comps[, 1:object$num_terms, drop = FALSE]
+    comps <- comps[, seq_len(object$num_terms), drop = FALSE]
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))
     keep_original_cols <- get_keep_original_cols(object)

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -164,7 +164,7 @@ bake.step_kpca <- function(object, new_data, ...) {
         rlang::expr(as.matrix(new_data[, object$columns]))
       )
     comps <- rlang::eval_tidy(cl)
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     colnames(comps) <- names0(ncol(comps), object$prefix)
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -162,7 +162,7 @@ bake.step_kpca_poly <- function(object, new_data, ...) {
         rlang::expr(as.matrix(new_data[, object$columns]))
       )
     comps <- rlang::eval_tidy(cl)
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     colnames(comps) <- names0(ncol(comps), object$prefix)
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -150,7 +150,7 @@ bake.step_kpca_rbf <- function(object, new_data, ...) {
         rlang::expr(as.matrix(new_data[, object$columns]))
       )
     comps <- rlang::eval_tidy(cl)
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     colnames(comps) <- names0(ncol(comps), object$prefix)
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))

--- a/R/lincombo.R
+++ b/R/lincombo.R
@@ -150,7 +150,7 @@ recommend_rm <- function(x, eps = 1e-6, ...) {
   if (is.null(num_cols) || rank == num_cols) {
     rm_list <- character(0) # there are no linear combinations
   } else {
-    p1 <- 1:rank
+    p1 <- seq_len(rank)
     X <- qr_decomp_R[p1, p1] # extract the independent columns
     Y <- qr_decomp_R[p1, -p1, drop = FALSE] # extract the dependent columns
     b <- qr(X) # factor the independent columns
@@ -160,7 +160,7 @@ recommend_rm <- function(x, eps = 1e-6, ...) {
 
     # generate a list with one element for each dependent column
     combos <- lapply(
-      1:ncol(Y),
+      seq_len(ncol(Y)),
       function(i) {
         c(pivot[rank + i], pivot[which(b[, i] != 0)])
       }
@@ -197,7 +197,7 @@ iter_lc_rm <- function(x,
     stringsAsFactors = FALSE
   )
 
-  for (i in 1:max_steps) {
+  for (i in seq_len(max_steps)) {
     if (verbose) {
       cat(i)
     }

--- a/R/misc.R
+++ b/R/misc.R
@@ -81,9 +81,9 @@ get_rhs_vars <- function(formula, data, no_lhs = FALSE) {
 
 names0 <- function(num, prefix = "x") {
   if (num < 1) {
-    rlang::abort("`num` should be > 0")
+    rlang::abort("`num` should be > 0.")
   }
-  ind <- format(1:num)
+  ind <- format(seq_len(num))
   ind <- gsub(" ", "0", ind)
   paste0(prefix, ind)
 }

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -180,7 +180,7 @@ bake.step_nnmf <- function(object, new_data, ...) {
     nnmf_vars <- rownames(object$res@other.data$w)
     comps <-
       object$res@apply(dimred_data(new_data[, nnmf_vars, drop = FALSE]))@data
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     colnames(comps) <- names0(ncol(comps), object$prefix)
     new_data <- bind_cols(new_data, as_tibble(comps))
     keep_original_cols <- get_keep_original_cols(object)

--- a/R/pca.R
+++ b/R/pca.R
@@ -228,7 +228,7 @@ bake.step_pca <- function(object, new_data, ...) {
     pca_vars <- rownames(object$res$rotation)
     comps <- scale(new_data[, pca_vars], object$res$center, object$res$scale) %*%
       object$res$rotation
-    comps <- comps[, 1:object$num_comp, drop = FALSE]
+    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
     comps <- check_name(comps, new_data, object)
     new_data <- bind_cols(new_data, as_tibble(comps))
     keep_original_cols <- get_keep_original_cols(object)
@@ -305,7 +305,7 @@ pca_variances <- function(x) {
     res <- tibble::tibble(
       terms = x,
       value = y,
-      component = rep(1:p, 4)
+      component = rep(seq_len(p), 4)
     )
   } else {
     res <- tibble::tibble(

--- a/R/pls.R
+++ b/R/pls.R
@@ -285,7 +285,7 @@ old_pls_project <- function(object, x) {
   }
   input_data <- sweep(input_data, 2, object$Xmeans, "-")
   comps <- input_data %*% object$projection
-  colnames(comps) <- paste0("pls", 1:ncol(comps))
+  colnames(comps) <- paste0("pls", seq_len(ncol(comps)))
   tibble::as_tibble(comps)
 }
 

--- a/R/poly.R
+++ b/R/poly.R
@@ -147,7 +147,7 @@ prep.step_poly <- function(x, training, info = NULL, ...) {
 bake.step_poly <- function(object, new_data, ...) {
   col_names <- names(object$objects)
   check_new_data(col_names, object, new_data)
-  new_names <- purrr::map(object$objects, ~ paste(attr(.x, "var"), "poly", 1:ncol(.x), sep = "_"))
+  new_names <- purrr::map(object$objects, ~ paste(attr(.x, "var"), "poly", seq_len(ncol(.x)), sep = "_"))
 
   # Start with n-row, 0-col tibble for the empty selection case
   new_tbl <- tibble::new_tibble(x = list(), nrow = nrow(new_data))

--- a/R/roles.R
+++ b/R/roles.R
@@ -333,7 +333,7 @@ remove_role <- function(recipe, ..., old_role) {
   }
 
   info <- info %>%
-    mutate(.orig_order = 1:nrow(info)) %>%
+    mutate(.orig_order = seq_len(nrow(info))) %>%
     group_by(variable) %>%
     do(role_rm_machine(., role = old_role, var = vars)) %>%
     ungroup() %>%

--- a/R/window.R
+++ b/R/window.R
@@ -237,7 +237,7 @@ roller <- function(x, stat = "mean", window = 3L, na_rm = TRUE) {
 
   ## Fill in the left-hand points. Add enough data so that the
   ## missing values at the start can be estimated and filled in
-  x2[1:gap] <- x2[gap + 1]
+  x2[seq_len(gap)] <- x2[gap + 1]
 
   ## Right-hand points
   x2[(m - gap + 1):m] <- x2[m - gap]


### PR DESCRIPTION
I noticed there are a couple of places where we use `: that could be replaced with `seq_*()` to make the code a little more robust