### PR TITLE
Only use `[[` for subsetting single columns

### DIFF
--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -135,7 +135,7 @@ bake.step_BoxCox <- function(object, new_data, ...) {
   check_new_data(param, object, new_data)
 
   for (i in seq_along(object$lambdas)) {
-    new_data[, param[i]] <- bc_trans(getElement(new_data, param[i]), lambda = object$lambdas[i])
+    new_data[, param[i]] <- bc_trans(new_data[[param[i]]], lambda = object$lambdas[i])
   }
 
   new_data

--- a/R/BoxCox.R
+++ b/R/BoxCox.R
@@ -135,7 +135,10 @@ bake.step_BoxCox <- function(object, new_data, ...) {
   check_new_data(param, object, new_data)
 
   for (i in seq_along(object$lambdas)) {
-    new_data[, param[i]] <- bc_trans(new_data[[param[i]]], lambda = object$lambdas[i])
+    new_data[[param[i]]] <- bc_trans(
+      new_data[[param[i]]],
+      lambda = object$lambdas[i]
+    )
   }
 
   new_data

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -137,7 +137,7 @@ bake.step_YeoJohnson <- function(object, new_data, ...) {
   }
   param <- names(object$lambdas)
   for (i in seq_along(object$lambdas)) {
-    new_data[, param[i]] <-
+    new_data[[param[i]]] <-
       yj_transform(
         new_data[[param[i]]],
         lambda = object$lambdas[param[i]]

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -138,7 +138,8 @@ bake.step_YeoJohnson <- function(object, new_data, ...) {
   param <- names(object$lambdas)
   for (i in seq_along(object$lambdas)) {
     new_data[, param[i]] <-
-      yj_transform(getElement(new_data, param[i]),
+      yj_transform(
+        new_data[[param[i]]],
         lambda = object$lambdas[param[i]]
       )
   }

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -110,7 +110,7 @@ bake.step_bin2factor <- function(object, new_data, ...) {
 
   levs <- if (object$ref_first) object$levels else rev(object$levels)
   for (col_name in object$columns) {
-    new_data[, col_name] <-
+    new_data[[col_name]] <-
       factor(ifelse(
         new_data[[col_name]] == 1,
         object$levels[1],

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -109,10 +109,10 @@ bake.step_bin2factor <- function(object, new_data, ...) {
   check_new_data(names(object$columns), object, new_data)
 
   levs <- if (object$ref_first) object$levels else rev(object$levels)
-  for (i in seq_along(object$columns)) {
-    new_data[, object$columns[i]] <-
+  for (col_name in object$columns) {
+    new_data[, col_name] <-
       factor(ifelse(
-        getElement(new_data, object$columns[i]) == 1,
+        new_data[[col_name]] == 1,
         object$levels[1],
         object$levels[2]
       ),

--- a/R/bs.R
+++ b/R/bs.R
@@ -176,7 +176,7 @@ bake.step_bs <- function(object, new_data, ...) {
     cols <- (strt):(strt + new_cols[i] - 1)
     orig_var <- attr(object$objects[[i]], "var")
     bs_values[, cols] <-
-      bs_predict(object$objects[[i]], getElement(new_data, i))
+      bs_predict(object$objects[[i]], new_data[[i]])
     new_names <-
       paste(orig_var, "bs", names0(new_cols[i], ""), sep = "_")
     colnames(bs_values)[cols] <- new_names

--- a/R/bs.R
+++ b/R/bs.R
@@ -181,7 +181,7 @@ bake.step_bs <- function(object, new_data, ...) {
       paste(orig_var, "bs", names0(new_cols[i], ""), sep = "_")
     colnames(bs_values)[cols] <- new_names
     strt <- max(cols) + 1
-    new_data[, orig_var] <- NULL
+    new_data[[orig_var]] <- NULL
   }
   bs_values <- as_tibble(bs_values)
   bs_values <- check_name(bs_values, new_data, object, names(bs_values))

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -168,12 +168,11 @@ prep.step_classdist <- function(x, training, info = NULL, ...) {
     wts <- NULL
   }
 
-  x_dat <-
-    split(training[, x_names], getElement(training, class_var))
+  x_dat <- split(training[, x_names], training[[class_var]])
   if (is.null(wts)) {
     wts_split <- map(x_dat, ~NULL)
   } else {
-    wts_split <- split(as.double(wts), getElement(training, class_var))
+    wts_split <- split(as.double(wts), training[[class_var]])
   }
   if (x$pool) {
     res <- list(

--- a/R/count.R
+++ b/R/count.R
@@ -149,7 +149,7 @@ bake.step_count <- function(object, new_data, ...) {
   ## sub in options
   regex <- expr(
     gregexpr(
-      text = getElement(new_data, object$input),
+      text = new_data[[object$input]],
       pattern = object$pattern,
       ignore.case = FALSE,
       perl = FALSE,
@@ -163,7 +163,7 @@ bake.step_count <- function(object, new_data, ...) {
 
   new_data[, object$result] <- vapply(eval(regex), counter, integer(1))
   if (object$normalize) {
-    totals <- nchar(as.character(getElement(new_data, object$input)))
+    totals <- nchar(as.character(new_data[[object$input]]))
     new_data[, object$result] <- new_data[, object$result] / totals
   }
   new_data

--- a/R/cut.R
+++ b/R/cut.R
@@ -105,7 +105,7 @@ prep.step_cut <- function(x, training, info = NULL, ...) {
   names(all_breaks) <- col_names
   for (col_name in col_names) {
     all_breaks[[col_name]] <-
-      create_full_breaks(training[, col_name, drop = TRUE], breaks = x$breaks)
+      create_full_breaks(training[[col_name]], breaks = x$breaks)
     full_breaks_check(all_breaks[[col_name]])
   }
 
@@ -145,7 +145,7 @@ bake.step_cut <- function(object, new_data, ...) {
 
   for (col_name in names(object$breaks)) {
     res <- cut_var(
-      new_data[, col_name, drop = TRUE],
+      new_data[[col_name]],
       object$breaks[[col_name]],
       object$include_outside_range
     )

--- a/R/cut.R
+++ b/R/cut.R
@@ -149,7 +149,7 @@ bake.step_cut <- function(object, new_data, ...) {
       object$breaks[[col_name]],
       object$include_outside_range
     )
-    new_data[, col_name] <- res
+    new_data[[col_name]] <- res
   }
   new_data
 }

--- a/R/date.R
+++ b/R/date.R
@@ -168,7 +168,7 @@ prep.step_date <- function(x, training, info = NULL, ...) {
 
 
 ord2fac <- function(x, what) {
-  x <- getElement(x, what)
+  x <- x[[what]]
   factor(as.character(x), levels = levels(x), ordered = FALSE)
 }
 
@@ -265,7 +265,7 @@ bake.step_date <- function(object, new_data, ...) {
     cols <- (strt):(strt + new_cols[i] - 1)
 
     tmp <- get_date_features(
-      dt = getElement(new_data, object$columns[i]),
+      dt = new_data[[object$columns[i]]],
       feats = object$features,
       locale = object$locale %||% Sys.getlocale("LC_TIME"),
       abbr = object$abbr,

--- a/R/depth.R
+++ b/R/depth.R
@@ -140,8 +140,7 @@ prep.step_depth <- function(x, training, info = NULL, ...) {
 
   class_var <- x$class[1]
 
-  x_dat <-
-    split(training[, x_names], getElement(training, class_var))
+  x_dat <- split(training[, x_names], training[[class_var]])
   x_dat <- lapply(x_dat, as.matrix)
   step_depth_new(
     terms = x$terms,

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -380,7 +380,7 @@ prep.step_discretize <- function(x, training, info = NULL, ...) {
 bake.step_discretize <- function(object, new_data, ...) {
   check_new_data(names(object$objects), object, new_data)
   for (i in names(object$objects)) {
-    new_data[, i] <- predict(object$objects[[i]], new_data[[i]])
+    new_data[[i]] <- predict(object$objects[[i]], new_data[[i]])
   }
   new_data
 }

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -380,8 +380,7 @@ prep.step_discretize <- function(x, training, info = NULL, ...) {
 bake.step_discretize <- function(object, new_data, ...) {
   check_new_data(names(object$objects), object, new_data)
   for (i in names(object$objects)) {
-    new_data[, i] <-
-      predict(object$objects[[i]], getElement(new_data, i))
+    new_data[, i] <- predict(object$objects[[i]], new_data[[i]])
   }
   new_data
 }

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -196,8 +196,7 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
       ## factor levels at the end of `prep.recipe` since it is
       ## not a factor anymore. We'll save them here and reset them
       ## in `bake.step_dummy` just prior to calling `model.matrix`
-      attr(levels[[i]], "values") <-
-        levels(getElement(training, col_names[i]))
+      attr(levels[[i]], "values") <- levels(training[[col_names[i]]])
       attr(levels[[i]], ".Environment") <- NULL
     }
   } else {
@@ -301,7 +300,8 @@ bake.step_dummy <- function(object, new_data, ...) {
     )
 
     new_data[, orig_var] <-
-      factor(getElement(new_data, orig_var),
+      factor(
+        new_data[[orig_var]],
         levels = attr(object$levels[[i]], "values"),
         ordered = fac_type == "ordered"
       )

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -336,7 +336,7 @@ bake.step_dummy <- function(object, new_data, ...) {
 
     new_data <- bind_cols(new_data, indicators)
     if (any(!object$preserve, !keep_original_cols)) {
-      new_data[, col_names[i]] <- NULL
+      new_data[[col_names[i]]] <- NULL
     }
   }
   new_data

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -235,7 +235,7 @@ bake.step_dummy_extract <- function(object, new_data, ...) {
     orig_var <- names(object$levels)[i]
 
     elements <- dummy_extract(
-      getElement(new_data, orig_var),
+      new_data[[orig_var]],
       sep = object$sep, pattern = object$pattern
     )
 

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -251,7 +251,7 @@ bake.step_dummy_extract <- function(object, new_data, ...) {
     new_data <- bind_cols(new_data, indicators)
 
     if (!keep_original_cols) {
-      new_data[, col_names[i]] <- NULL
+      new_data[[col_names[i]]] <- NULL
     }
   }
   new_data

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -113,9 +113,8 @@ bake.step_hyperbolic <- function(object, new_data, ...) {
     get(object$func)
   }
   col_names <- object$columns
-  for (i in seq_along(col_names)) {
-    new_data[, col_names[i]] <-
-      func(getElement(new_data, col_names[i]))
+  for (col_name in col_names) {
+    new_data[, col_name] <- func(new_data[[col_name]])
   }
   new_data
 }

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -114,7 +114,7 @@ bake.step_hyperbolic <- function(object, new_data, ...) {
   }
   col_names <- object$columns
   for (col_name in col_names) {
-    new_data[, col_name] <- func(new_data[[col_name]])
+    new_data[[col_name]] <- func(new_data[[col_name]])
   }
   new_data
 }

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -281,7 +281,7 @@ bake.step_impute_bag <- function(object, new_data, ...) {
   old_data <- new_data
   for (i in seq(along.with = object$models)) {
     imp_var <- names(object$models)[i]
-    missing_rows <- !complete.cases(new_data[, imp_var])
+    missing_rows <- !complete.cases(new_data[[imp_var]])
     if (any(missing_rows)) {
       preds <- object$models[[imp_var]]$..imp_vars
       pred_data <- old_data[missing_rows, preds, drop = FALSE]

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -235,7 +235,7 @@ nn_index <- function(miss_data, ref_data, vars, K, opt) {
 
 nn_pred <- function(index, dat) {
   dat <- dat[index, ]
-  dat <- getElement(dat, names(dat))
+  dat <- dat[[names(dat)]]
   dat <- dat[!is.na(dat)]
   est <- if (is.factor(dat) | is.character(dat)) {
     mode_est(dat)

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -206,7 +206,7 @@ bake.step_impute_linear <- function(object, new_data, ...) {
   old_data <- new_data
   for (i in seq(along.with = object$models)) {
     imp_var <- names(object$models)[i]
-    missing_rows <- !complete.cases(new_data[, imp_var])
+    missing_rows <- !complete.cases(new_data[[imp_var]])
     if (any(missing_rows)) {
       preds <- object$models[[imp_var]]$..imp_vars
       pred_data <- old_data[missing_rows, preds, drop = FALSE]

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -155,7 +155,7 @@ bake.step_impute_mode <- function(object, new_data, ...) {
   check_new_data(names(object$modes), object, new_data)
 
   for (i in names(object$modes)) {
-    if (any(is.na(new_data[, i]))) {
+    if (any(is.na(new_data[[i]]))) {
       if (is.null(object$ptype)) {
         rlang::warn(
           paste0(

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -95,7 +95,7 @@ bake.step_inverse <- function(object, new_data, ...) {
   check_new_data(names(object$columns), object, new_data)
 
   for (i in seq_along(object$columns)) {
-    new_data[, object$columns[i]] <-
+    new_data[[object$columns[i]]] <-
       1 / (new_data[[object$columns[i]]] + object$offset)
   }
   new_data

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -90,7 +90,7 @@ bake.step_invlogit <- function(object, new_data, ...) {
   check_new_data(names(object$columns), object, new_data)
 
   for (i in seq_along(object$columns)) {
-    new_data[, object$columns[i]] <-
+    new_data[[object$columns[i]]] <-
       binomial()$linkinv(
         unlist(
           new_data[[object$columns[i]]],

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -91,9 +91,12 @@ bake.step_invlogit <- function(object, new_data, ...) {
 
   for (i in seq_along(object$columns)) {
     new_data[, object$columns[i]] <-
-      binomial()$linkinv(unlist(getElement(new_data, object$columns[i]),
-        use.names = FALSE
-      ))
+      binomial()$linkinv(
+        unlist(
+          new_data[[object$columns[i]]],
+          use.names = FALSE
+          )
+      )
   }
   new_data
 }

--- a/R/log.R
+++ b/R/log.R
@@ -129,7 +129,7 @@ bake.step_log <- function(object, new_data, ...) {
 
   if (!object$signed) {
     for (i in seq_along(col_names)) {
-      new_data[, col_names[i]] <-
+      new_data[[col_names[i]]] <-
         log(new_data[[col_names[i]]] + object$offset, base = object$base)
     }
   } else {
@@ -137,7 +137,7 @@ bake.step_log <- function(object, new_data, ...) {
       rlang::warn("When signed is TRUE, offset will be ignored")
     }
     for (i in seq_along(col_names)) {
-      new_data[, col_names[i]] <-
+      new_data[[col_names[i]]] <-
         ifelse(abs(new_data[[col_names[i]]]) < 1,
           0,
           sign(new_data[[col_names[i]]]) *

--- a/R/logit.R
+++ b/R/logit.R
@@ -103,7 +103,7 @@ bake.step_logit <- function(object, new_data, ...) {
   check_new_data(names(object$columns), object, new_data)
 
   for (i in seq_along(object$columns)) {
-    new_data[, object$columns[i]] <-
+    new_data[[object$columns[i]]] <-
       binomial()$linkfun(
         pre_logit(new_data[[object$columns[i]]], object$offset)
       )

--- a/R/ns.R
+++ b/R/ns.R
@@ -166,7 +166,7 @@ bake.step_ns <- function(object, new_data, ...) {
     cols <- (strt):(strt + new_cols[i] - 1)
     orig_var <- attr(object$objects[[i]], "var")
     ns_values[, cols] <-
-      ns_predict(object$objects[[i]], getElement(new_data, i))
+      ns_predict(object$objects[[i]], new_data[[i]])
     new_names <-
       paste(orig_var, "ns", names0(new_cols[i], ""), sep = "_")
     colnames(ns_values)[cols] <- new_names

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -127,7 +127,7 @@ bake.step_ordinalscore <- function(object, new_data, ...) {
   scores <- lapply(scores, vec_cast, integer())
 
   for (i in object$columns) {
-    new_data[, i] <- scores[[i]]
+    new_data[[i]] <- scores[[i]]
   }
   new_data
 }

--- a/R/other.R
+++ b/R/other.R
@@ -179,10 +179,10 @@ bake.step_other <- function(object, new_data, ...) {
   check_new_data(names(object$objects), object, new_data)
   for (i in names(object$objects)) {
     if (object$objects[[i]]$collapse) {
-      tmp <- if (!is.character(new_data[, i])) {
-        as.character(getElement(new_data, i))
-      } else {
-        getElement(new_data, i)
+      tmp <- new_data[[i]]
+
+      if (!is.character(tmp)) {
+        tmp <- as.character(tmp)
       }
 
       tmp <- ifelse(
@@ -199,7 +199,7 @@ bake.step_other <- function(object, new_data, ...) {
         )
       )
 
-      new_data[, i] <- tmp
+      new_data[[i]] <- tmp
     }
   }
   new_data

--- a/R/regex.R
+++ b/R/regex.R
@@ -143,7 +143,7 @@ bake.step_regex <- function(object, new_data, ...) {
   ## sub in options
   regex <- expr(
     grepl(
-      x = getElement(new_data, object$input),
+      x = new_data[[object$input]],
       pattern = object$pattern,
       ignore.case = FALSE,
       perl = FALSE,

--- a/R/sample.R
+++ b/R/sample.R
@@ -133,7 +133,7 @@ bake.step_sample <- function(object, new_data, ...) {
 
   if (isTRUE(object$case_weights)) {
     wts_col <- purrr::map_lgl(new_data, hardhat::is_case_weights)
-    wts <- getElement(new_data, names(which(wts_col)))
+    wts <- new_data[[names(which(wts_col))]]
     wts <- as.double(wts)
   } else {
     wts <- NULL

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -90,10 +90,11 @@ bake.step_shuffle <- function(object, new_data, ...) {
 
   if (length(object$columns) > 0) {
     for (i in seq_along(object$columns)) {
-      new_data[, object$columns[i]] <-
-        sample(getElement(new_data, object$columns[i]))
+      new_data[[object$columns[i]]] <-
+        sample(new_data[[object$columns[i]]])
     }
   }
+
   new_data
 }
 

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -141,7 +141,7 @@ bake.step_spatialsign <- function(object, new_data, ...) {
 
   if (isTRUE(object$case_weights)) {
     wts_col <- purrr::map_lgl(new_data, hardhat::is_case_weights)
-    wts <- getElement(new_data, names(which(wts_col)))
+    wts <- new_data[[names(which(wts_col))]]
     wts <- as.double(wts)
   } else {
     wts <- 1

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -87,7 +87,7 @@ bake.step_sqrt <- function(object, new_data, ...) {
 
   col_names <- object$columns
   for (i in seq_along(col_names)) {
-    new_data[, col_names[i]] <- sqrt(new_data[[col_names[i]]])
+    new_data[[col_names[i]]] <- sqrt(new_data[[col_names[i]]])
   }
   new_data
 }

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -87,8 +87,7 @@ bake.step_sqrt <- function(object, new_data, ...) {
 
   col_names <- object$columns
   for (i in seq_along(col_names)) {
-    new_data[, col_names[i]] <-
-      sqrt(getElement(new_data, col_names[i]))
+    new_data[, col_names[i]] <- sqrt(new_data[[col_names[i]]])
   }
   new_data
 }

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -95,8 +95,9 @@ bake.step_unorder <- function(object, new_data, ...) {
 
   for (i in seq_along(object$columns)) {
     new_data[, object$columns[i]] <-
-      factor(as.character(getElement(new_data, object$columns[i])),
-        levels = levels(getElement(new_data, object$columns[i]))
+      factor(
+        x = as.character(new_data[[object$columns[i]]]),
+        levels = levels(new_data[[object$columns[i]]])
       )
   }
   new_data

--- a/R/window.R
+++ b/R/window.R
@@ -256,17 +256,17 @@ bake.step_window <- function(object, new_data, ...) {
 
   for (i in seq(along.with = object$columns)) {
     if (!is.null(object$names)) {
-      new_data[, object$names[i]] <-
+      new_data[[object$names[i]]] <-
         roller(
-          x = getElement(new_data, object$columns[i]),
+          x = new_data[[object$columns[i]]],
           stat = object$statistic,
           na_rm = object$na_rm,
           window = object$size
         )
     } else {
-      new_data[, object$columns[i]] <-
+      new_data[[object$columns[i]]] <-
         roller(
-          x = getElement(new_data, object$columns[i]),
+          x = new_data[[object$columns[i]]],
           stat = object$statistic,
           na_rm = object$na_rm,
           window = object$size


### PR DESCRIPTION
This is another refactor/standardize PR

I noticed that we are using every method under the sun to pull out a single column from a data.frame. This PR aims to only use `[[` for consistency.

Not that it matters hugely, but this also provides the smallest of speedups

``` r
col_name <- "vs"
bench::mark(
  mtcars[, col_name, drop = TRUE],
  getElement(mtcars, col_name),
  mtcars[[col_name]]
)
#> # A tibble: 3 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mtcars[, col_name, drop = TRUE]   2.62µs   3.03µs   303949.   13.28KB     30.4
#> 2 getElement(mtcars, col_name)      2.05µs   2.34µs   403596.    4.88KB     40.4
#> 3 mtcars[[col_name]]                1.72µs   1.97µs   464780.        0B     46.5
```
