### PR TITLE
remove skip_if packageVersion rlang

### DIFF
--- a/tests/testthat/test-BoxCox.R
+++ b/tests/testthat/test-BoxCox.R
@@ -74,7 +74,6 @@ test_that("simple Box Cox", {
   expect_equal(exp_lambda[!is.na(exp_lambda)], rec_trained$steps[[1]]$lambdas, tolerance = .001)
   expect_equal(as.matrix(exp_dat), as.matrix(rec_trans), tolerance = .05)
 
-  skip_if(packageVersion("rlang") < "1.0.0")
   # Capture warnings
   expect_snapshot(
     rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)

--- a/tests/testthat/test-hyperbolic.R
+++ b/tests/testthat/test-hyperbolic.R
@@ -57,7 +57,6 @@ test_that("simple hyperbolic trans", {
 })
 
 test_that("wrong function", {
-  skip_if(packageVersion("rlang") < "1.0.0")
   rec <- recipe(mpg ~ ., mtcars)
   expect_snapshot_error(step_hyperbolic(rec, func = "cos"))
 })

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -71,7 +71,6 @@ test_that("No kPCA comps", {
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(
     pca_extract <- rec %>%
       step_kpca(X2, X3, X4, X5, X6, num_comp = 0, id = "") %>%
@@ -116,7 +115,6 @@ test_that("can prep recipes with no keep_original_cols", {
     pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
     NA
   )
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -54,7 +54,6 @@ test_that("No kPCA comps", {
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(pca_extract)
 })
 
@@ -139,7 +138,6 @@ test_that("can prep recipes with no keep_original_cols", {
     pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
     NA
   )
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -54,7 +54,6 @@ test_that("No kPCA comps", {
     tidy(pca_extract, 1),
     tibble::tibble(terms = paste0("X", 2:6), id = "")
   )
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(pca_extract)
 })
 
@@ -137,7 +136,6 @@ test_that("can prep recipes with no keep_original_cols", {
     NA
   )
 
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(
     kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
   )

--- a/tests/testthat/test-nzv.R
+++ b/tests/testthat/test-nzv.R
@@ -61,7 +61,6 @@ test_that("altered freq_cut and unique_cut", {
 
   expect_equal(filtering_trained$steps[[1]]$removals, removed)
 
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot_error(
     rec %>%
       step_nzv(x1, x2, x3, x4, options = list(freq_cut = 50, unique_cut = 10))

--- a/tests/testthat/test-pls_old.R
+++ b/tests/testthat/test-pls_old.R
@@ -26,6 +26,5 @@ test_that("check old PLS scores from recipes version <= 0.1.12", {
 
   suppressWarnings(new_values_te <- bake(old_pls, biom_te))
   expect_equal(new_values_te, old_pls_te)
-  skip_if(packageVersion("rlang") < "1.0.0")
   expect_snapshot(new_values_te <- bake(old_pls, biom_te))
 })

--- a/tests/testthat/test-range_check.R
+++ b/tests/testthat/test-range_check.R
@@ -44,7 +44,6 @@ test_that("in recipe", {
   expect_error(bake(rec1, test), NA)
   expect_warning(bake(rec1, test), NA)
 
-  skip_if(packageVersion("rlang") < "1.0.0")
   rec2 <- recipe(train) %>%
     check_range(x, y) %>%
     prep()


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1132

recipes requires rlang >= 1.0.3, so we can remove these skips