### PR TITLE
let step_interact() work with empty selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bug where `step_interact()` didn't work with empty selection.
+
 # recipes 1.0.6
 
 ## Improvements

--- a/tests/testthat/_snaps/interact.md
+++ b/tests/testthat/_snaps/interact.md
@@ -16,6 +16,41 @@
       Error in `step_interact()`:
       ! The following required columns are missing from `new_data` in step '': z and x1.
 
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Interactions with: <none>
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Interactions with: <none> | Trained
+
 # printing
 
     Code

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -301,6 +301,43 @@ test_that("bake method errors when needed non-standard role columns are missing"
   expect_snapshot(bake(int_rec_trained, dat_tr[, 4:6]), error = TRUE)
 })
 
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_interact(rec)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})
+
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_center(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
+test_that("empty selection tidy method works", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_center(rec)
+
+  expect <- tibble(terms = character(), value = double(), id = character())
+
+  expect_identical(tidy(rec, number = 1), expect)
+
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
+})
+
 test_that("printing", {
   rec <- recipe(y ~ ., data = dat_tr) %>%
     step_interact(~ x1:x2)


### PR DESCRIPTION
This bug came up when I started working on https://github.com/tidymodels/recipes/issues/1134


## PR

``` r
library(recipes)

recipe(mpg ~ ., mtcars) |>
  step_interact() |>
  prep() |>
  bake(new_data = NULL)
#> # A tibble: 32 × 11
#>      cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb   mpg
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1     6  160    110  3.9   2.62  16.5     0     1     4     4  21  
#>  2     6  160    110  3.9   2.88  17.0     0     1     4     4  21  
#>  3     4  108     93  3.85  2.32  18.6     1     1     4     1  22.8
#>  4     6  258    110  3.08  3.22  19.4     1     0     3     1  21.4
#>  5     8  360    175  3.15  3.44  17.0     0     0     3     2  18.7
#>  6     6  225    105  2.76  3.46  20.2     1     0     3     1  18.1
#>  7     8  360    245  3.21  3.57  15.8     0     0     3     4  14.3
#>  8     4  147.    62  3.69  3.19  20       1     0     4     2  24.4
#>  9     4  141.    95  3.92  3.15  22.9     1     0     4     2  22.8
#> 10     6  168.   123  3.92  3.44  18.3     1     0     4     4  19.2
#> # ℹ 22 more rows
```

## Main

``` r
library(recipes)

recipe(mpg ~ ., mtcars) |>
  step_interact() |>
  prep() |>
  bake(new_data = NULL)
#> Error in step_interact_new(terms = terms, trained = trained, role = role, : argument "terms" is missing, with no default
```
