### PR TITLE
Standardize columns param documentation

### DIFF
--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -4,13 +4,12 @@
 #'  recipe step that will create a two-level factor from a single
 #'  dummy variable.
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param levels A length 2 character string that indicates the
 #'  factor levels for the 1's (in the first position) and the zeros
 #'  (second)
 #' @param ref_first Logical. Should the first level, which replaces
 #' 1's, be the factor reference level?
-#' @param columns A vector with the selected variable names. This
-#'  is `NULL` until computed by [prep()].
 #' @template step-return
 #' @details This operation may be useful for situations where a
 #'  binary piece of information may need to be represented as

--- a/R/date.R
+++ b/R/date.R
@@ -31,9 +31,6 @@
 #'  On Linux systems you can use `system("locale -a")` to list all the
 #'  installed locales. Can be a locales string, or a [clock::clock_labels()]
 #'  object. Defaults to `clock::clock_locale()$labels`.
-#' @param columns A character string of variables that will be
-#'  used as inputs. This field is a placeholder and will be
-#'  populated once [prep()] is used.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
 #' @template step-return

--- a/R/factor2string.R
+++ b/R/factor2string.R
@@ -3,8 +3,7 @@
 #' `step_factor2string` will convert one or more factor vectors to strings.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variables that will be converted. This
-#'   is `NULL` until computed by [prep()].
+#' @inheritParams step_pca
 #' @template step-return
 #' @family dummy variable and encoding steps
 #' @export

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -16,8 +16,6 @@
 #'  created from previous versions of recipes, a value of `FALSE` is used.
 #' @param log A logical: should the distance be transformed by
 #'  the natural log function?
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @param name A single character value to use for the new
 #'  predictor column. If a column exists with this name, an error is
 #'  issued.

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -10,9 +10,6 @@
 #' @param holidays A character string that includes at least one
 #'  holiday supported by the `timeDate` package. See
 #'  [timeDate::listHolidays()] for a complete list.
-#' @param columns A character string of variables that will be
-#'  used as inputs. This field is a placeholder and will be
-#'  populated once [prep()] is used.
 #' @template step-return
 #' @family dummy variable and encoding steps
 #' @seealso [timeDate::listHolidays()]

--- a/R/hyperbolic.R
+++ b/R/hyperbolic.R
@@ -5,11 +5,10 @@
 #'  function.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param func A character value for the function. Valid values
 #'  are "sinh", "cosh", or "tanh".
 #' @param inverse A logical: should the inverse function be used?
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @template step-return
 #' @family individual transformation steps
 #' @export

--- a/R/ica.R
+++ b/R/ica.R
@@ -15,8 +15,6 @@
 #' @param res The [fastICA::fastICA()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -5,14 +5,13 @@
 #'
 #' @inheritParams step_impute_bag
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param neighbors The number of neighbors.
 #' @param options A named list of options to pass to [gower::gower_topn()].
 #'  Available options are currently `nthread` and `eps`.
 #' @param ref_data A tibble of data that will reflect the data preprocessing
 #'  done up to the point of this imputation step. This is `NULL` until the step
 #'  is trained by [prep()].
-#' @param columns The column names that will be imputed and used for
-#'  imputation. This is `NULL` until the step is trained by [prep()].
 #' @template step-return
 #' @family imputation steps
 #' @export

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -5,11 +5,10 @@
 #'  variables by the measure of location (e.g. median) within a moving window.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param ... One or more selector functions to choose variables to be imputed;
 #'  these columns must be non-integer numerics (i.e., double precision).
 #'  See [selections()] for more details.
-#' @param columns A named numeric vector of columns. This is
-#'  `NULL` until computed by [prep()].
 #' @param window The size of the window around a point to be imputed. Should be
 #'  an odd integer greater than one. See Details below for a discussion of
 #'  points at the ends of the series.

--- a/R/indicate_na.R
+++ b/R/indicate_na.R
@@ -6,8 +6,6 @@
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the terms argument.
 #' @param prefix A character string that will be the prefix to the
 #'  resulting new variables. Defaults to "na_ind".
 #' @template step-return

--- a/R/inverse.R
+++ b/R/inverse.R
@@ -4,10 +4,9 @@
 #'  step that will inverse transform the data.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param offset An optional value to add to the data prior to
 #'  logging (to avoid `1/0`).
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @template step-return
 #' @family individual transformation steps
 #' @export

--- a/R/invlogit.R
+++ b/R/invlogit.R
@@ -5,8 +5,7 @@
 #'  zero and one.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
+#' @inheritParams step_pca
 #' @template step-return
 #' @family individual transformation steps
 #' @export

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -15,8 +15,6 @@
 #' @param res The [dimRed::Isomap()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -12,8 +12,6 @@
 #'  (or at all).
 #' @param res An S4 [kernlab::kpca()] object is stored here once this
 #'  preprocessing step has be trained by [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -10,8 +10,6 @@
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -10,8 +10,6 @@
 #' @param res An S4 [kernlab::kpca()] object is stored
 #'  here once this preprocessing step has be trained by
 #'  [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/lag.R
+++ b/R/lag.R
@@ -12,8 +12,6 @@
 #' @param lag A vector of positive integers. Each specified column will be
 #'  lagged for each value in the vector.
 #' @param prefix A prefix for generated column names, default to "lag_".
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @param default Passed to `dplyr::lag`, determines what fills empty rows
 #'   left by lagging (defaults to NA).
 #' @template step-return

--- a/R/log.R
+++ b/R/log.R
@@ -4,11 +4,10 @@
 #'  that will log transform data.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param base A numeric value for the base.
 #' @param offset An optional value to add to the data prior to
 #'  logging (to avoid `log(0)`).
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @param signed A logical indicating whether to take the signed log.
 #'  This is sign(x) * log(abs(x)) when abs(x) => 1 or 0 if abs(x) < 1.
 #'  If `TRUE` the `offset` argument will be ignored.

--- a/R/logit.R
+++ b/R/logit.R
@@ -4,8 +4,7 @@
 #'  step that will logit transform the data.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
+#' @inheritParams step_pca
 #' @param offset A numeric value to modify values of the columns that are either
 #' one or zero. They are modified to be `x - offset` or `offset`, respectively.
 #' @template step-return

--- a/R/missing.R
+++ b/R/missing.R
@@ -3,6 +3,7 @@
 #' `check_missing` creates a *specification* of a recipe
 #'  operation that will check if variables contain missing values.
 #'
+#' @inheritParams step_pca
 #' @param recipe A recipe object. The check will be added to the
 #'  sequence of operations for this recipe.
 #' @param ... One or more selector functions to choose variables
@@ -11,8 +12,6 @@
 #'  created.
 #' @param trained A logical for whether the selectors in `...`
 #' have been resolved by [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the terms argument.
 #' @param id A character string that is unique to this check to identify it.
 #' @param skip A logical. Should the check be skipped when the
 #'  recipe is baked by [bake()]? While all operations are baked

--- a/R/naomit.R
+++ b/R/naomit.R
@@ -6,11 +6,10 @@
 #'
 #' @template row-ops
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param role Unused, include for consistency with other steps.
 #' @param trained A logical to indicate if the quantities for preprocessing
 #'   have been estimated. Again included for consistency.
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #'
 #' @template case-weights-not-supported
 #'

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -21,8 +21,6 @@
 #' @param res The `NNMF()` object is stored
 #'  here once this preprocessing step has been trained by
 #'  [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @param prefix A character string that will be the prefix to the
 #'  resulting new variables. See notes below.
 #' @param seed An integer that will be used to set the seed in isolation

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -5,9 +5,7 @@
 #'  numeric scores.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variables that will be
-#'  converted. This is `NULL` until computed by
-#'  [prep()].
+#' @inheritParams step_pca
 #' @param convert A function that takes an ordinal factor vector
 #'  as an input and outputs a single numeric variable.
 #' @template step-return

--- a/R/pca.R
+++ b/R/pca.R
@@ -23,8 +23,8 @@
 #'  should not be passed here (or at all).
 #' @param res The [stats::prcomp.default()] object is stored here once this
 #'  preprocessing step has be trained by [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
+#' @param columns A character string of the selected variable names. This field
+#'   is a placeholder and will be populated once [prep()] is used.
 #' @param prefix A character string for the prefix of the resulting new
 #'  variables. See notes below.
 #' @param keep_original_cols A logical to keep the original variables in the

--- a/R/pls.R
+++ b/R/pls.R
@@ -17,8 +17,6 @@
 #' arguments).
 #' @param res A list of results are stored here once this preprocessing step
 #'  has been trained by [prep()].
-#' @param columns A character string of variable names that will
-#'  be populated elsewhere.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/profile.R
+++ b/R/profile.R
@@ -7,6 +7,7 @@
 #'  models.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param profile A call to [dplyr::vars()]) to specify which
 #'  variable will be profiled (see [selections()]). If a column is
 #'  included in both lists to be fixed and to be profiled, an error
@@ -32,9 +33,6 @@
 #'  of their possible levels are profiled). In the case of date
 #'  variables, `pctl = FALSE` will always be used since there is no
 #'  quantile method for dates.
-#' @param columns A character string that contains the names of
-#'  columns that should be fixed and their values. These values are
-#'  not determined until [prep()] is called.
 #' @details This step is atypical in that, when baked, the
 #'  `new_data` argument is ignored; the resulting data set is
 #'  based on the fixed and profiled variable's information.

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -20,9 +20,6 @@
 #'  listing.
 #' @param naming A function that defines the naming convention for
 #'  new ratio columns.
-#' @param columns The column names used in the ratios. This
-#'  argument is not populated until [prep()] is
-#'  executed.
 #' @template step-return
 #' @details
 #'

--- a/R/relu.R
+++ b/R/relu.R
@@ -14,8 +14,6 @@
 #' @param prefix A prefix for generated column names, defaults to "right_relu_"
 #'   for right hinge transformation and "left_relu_" for reversed/left hinge
 #'   transformations.
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @template step-return
 #' @family individual transformation steps
 #' @export

--- a/R/shuffle.R
+++ b/R/shuffle.R
@@ -5,9 +5,7 @@
 #'  variables.
 #'
 #' @inheritParams step_center
-#' @param columns A character string that contains the names of
-#'  columns that should be shuffled. These values are not determined
-#'  until [prep()] is called.
+#' @inheritParams step_pca
 #' @template step-return
 #' @details
 #'

--- a/R/spatialsign.R
+++ b/R/spatialsign.R
@@ -8,8 +8,6 @@
 #' @inheritParams step_center
 #' @param na_rm A logical: should missing data be removed from the
 #'  norm computation?
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/sqrt.R
+++ b/R/sqrt.R
@@ -4,8 +4,7 @@
 #'  step that will square root transform the data.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
+#' @inheritParams step_pca
 #' @template step-return
 #' @family individual transformation steps
 #' @details

--- a/R/time.R
+++ b/R/time.R
@@ -12,9 +12,6 @@
 #' @param features A character string that includes at least one
 #'  of the following values: `am` (is is AM), `hour`, `hour12`, `minute`,
 #'  `second`, `decimal_day`.
-#' @param columns A character string of variables that will be
-#'  used as inputs. This field is a placeholder and will be
-#'  populated once [prep()] is used.
 #' @param keep_original_cols A logical to keep the original variables in the
 #'  output. Defaults to `TRUE`.
 #' @template step-return

--- a/R/unorder.R
+++ b/R/unorder.R
@@ -4,8 +4,7 @@
 #'  step that will transform the data.
 #'
 #' @inheritParams step_center
-#' @param columns A character string of variable names that will
-#'  be populated (eventually) by the `terms` argument.
+#' @inheritParams step_pca
 #' @template step-return
 #' @family dummy variable and encoding steps
 #' @export

--- a/R/window.R
+++ b/R/window.R
@@ -5,6 +5,7 @@
 #'  functions that compute statistics across moving windows.
 #'
 #' @inheritParams step_center
+#' @inheritParams step_pca
 #' @param role For model terms created by this step, what analysis
 #'  role should they be assigned? If `names` is left to be
 #'  `NULL`, the rolling statistics replace the original columns
@@ -19,9 +20,6 @@
 #'  values are: `'max'`, `'mean'`, `'median'`,
 #'  `'min'`, `'prod'`, `'sd'`, `'sum'`,
 #'  `'var'`
-#' @param columns A character string that contains the names of
-#'  columns that should be processed. These values are not
-#'  determined until [prep()] is called.
 #' @param names An optional character string that is the same
 #'  length of the number of terms selected by `terms`. If you
 #'  are not sure what columns will be selected, use the

--- a/man/check_missing.Rd
+++ b/man/check_missing.Rd
@@ -27,8 +27,8 @@ created.}
 \item{trained}{A logical for whether the selectors in \code{...}
 have been resolved by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the terms argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the check be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/check_new_values.Rd
+++ b/man/check_new_values.Rd
@@ -29,8 +29,8 @@ created.}
 \item{trained}{A logical for whether the selectors in \code{...}
 have been resolved by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the terms argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{ignore_NA}{A logical that indicates if we should consider missing
 values as value or not. Defaults to \code{TRUE}.}

--- a/man/step_bin2factor.Rd
+++ b/man/step_bin2factor.Rd
@@ -36,8 +36,8 @@ factor levels for the 1's (in the first position) and the zeros
 \item{ref_first}{Logical. Should the first level, which replaces
 1's, be the factor reference level?}
 
-\item{columns}{A vector with the selected variable names. This
-is \code{NULL} until computed by \code{\link[=prep]{prep()}}.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_date.Rd
+++ b/man/step_date.Rd
@@ -61,9 +61,8 @@ On Linux systems you can use \code{system("locale -a")} to list all the
 installed locales. Can be a locales string, or a \code{\link[clock:clock_labels]{clock::clock_labels()}}
 object. Defaults to \code{clock::clock_locale()$labels}.}
 
-\item{columns}{A character string of variables that will be
-used as inputs. This field is a placeholder and will be
-populated once \code{\link[=prep]{prep()}} is used.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{TRUE}.}

--- a/man/step_factor2string.Rd
+++ b/man/step_factor2string.Rd
@@ -27,8 +27,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variables that will be converted. This
-is \code{NULL} until computed by \code{\link[=prep]{prep()}}.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -49,8 +49,8 @@ the natural log function?}
 predictor column. If a column exists with this name, an error is
 issued.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_harmonic.Rd
+++ b/man/step_harmonic.Rd
@@ -50,8 +50,8 @@ is 0.}
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_holiday.Rd
+++ b/man/step_holiday.Rd
@@ -35,9 +35,8 @@ preprocessing have been estimated.}
 holiday supported by the \code{timeDate} package. See
 \code{\link[timeDate:holiday-Listing]{timeDate::listHolidays()}} for a complete list.}
 
-\item{columns}{A character string of variables that will be
-used as inputs. This field is a placeholder and will be
-populated once \code{\link[=prep]{prep()}} is used.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{TRUE}.}

--- a/man/step_hyperbolic.Rd
+++ b/man/step_hyperbolic.Rd
@@ -34,8 +34,8 @@ are "sinh", "cosh", or "tanh".}
 
 \item{inverse}{A logical: should the inverse function be used?}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -52,8 +52,8 @@ running ICA.}
 here once this preprocessing step has be trained by
 \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}

--- a/man/step_impute_knn.Rd
+++ b/man/step_impute_knn.Rd
@@ -63,8 +63,8 @@ Available options are currently \code{nthread} and \code{eps}.}
 done up to the point of this imputation step. This is \code{NULL} until the step
 is trained by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{The column names that will be imputed and used for
-imputation. This is \code{NULL} until the step is trained by \code{\link[=prep]{prep()}}.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_impute_roll.Rd
+++ b/man/step_impute_roll.Rd
@@ -43,8 +43,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A named numeric vector of columns. This is
-\code{NULL} until computed by \code{\link[=prep]{prep()}}.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{statistic}{A function with a single argument for the data to compute
 the imputed value. Only complete values will be passed to the function and

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -29,8 +29,8 @@ the original variables will be used as \emph{predictors} in a model.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the terms argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string that will be the prefix to the
 resulting new variables. Defaults to "na_ind".}

--- a/man/step_inverse.Rd
+++ b/man/step_inverse.Rd
@@ -31,8 +31,8 @@ logging (to avoid \code{1/0}).}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_invlogit.Rd
+++ b/man/step_invlogit.Rd
@@ -27,8 +27,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_isomap.Rd
+++ b/man/step_isomap.Rd
@@ -47,8 +47,8 @@ used.}
 here once this preprocessing step has be trained by
 \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -42,8 +42,8 @@ stay unchanged.}
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored here once this
 preprocessing step has be trained by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{options}{A list of options to \code{\link[kernlab:kpca]{kernlab::kpca()}}. Defaults are set for
 the arguments \code{kernel} and \code{kpar} but others can be passed in.

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -45,8 +45,8 @@ stay unchanged.}
 here once this preprocessing step has be trained by
 \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{degree, scale_factor, offset}{Numeric values for the polynomial kernel function.}
 

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -43,8 +43,8 @@ stay unchanged.}
 here once this preprocessing step has be trained by
 \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{sigma}{A numeric value for the radial basis function parameter.}
 

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -39,8 +39,8 @@ lagged for each value in the vector.}
 \item{default}{Passed to \code{dplyr::lag}, determines what fills empty rows
 left by lagging (defaults to NA).}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_log.Rd
+++ b/man/step_log.Rd
@@ -35,8 +35,8 @@ preprocessing have been estimated.}
 \item{offset}{An optional value to add to the data prior to
 logging (to avoid \code{log(0)}).}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_logit.Rd
+++ b/man/step_logit.Rd
@@ -31,8 +31,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_naomit.Rd
+++ b/man/step_naomit.Rd
@@ -26,8 +26,8 @@ for this step. See \code{\link[=selections]{selections()}} for more details.}
 \item{trained}{A logical to indicate if the quantities for preprocessing
 have been estimated. Again included for consistency.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -53,8 +53,8 @@ processing is turned off in favor of resample-level parallelization.}
 here once this preprocessing step has been trained by
 \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string that will be the prefix to the
 resulting new variables. See notes below.}

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -28,9 +28,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variables that will be
-converted. This is \code{NULL} until computed by
-\code{\link[=prep]{prep()}}.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{convert}{A function that takes an ordinal factor vector
 as an input and outputs a single numeric variable.}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -53,8 +53,8 @@ should not be passed here (or at all).}
 \item{res}{The \code{\link[stats:prcomp]{stats::prcomp.default()}} object is stored here once this
 preprocessing step has be trained by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -59,8 +59,8 @@ original predictor data should be retained along with the new features.}
 \item{res}{A list of results are stored here once this preprocessing step
 has been trained by \code{\link[=prep]{prep()}}.}
 
-\item{columns}{A character string of variable names that will
-be populated elsewhere.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{prefix}{A character string for the prefix of the resulting new
 variables. See notes below.}

--- a/man/step_profile.Rd
+++ b/man/step_profile.Rd
@@ -54,9 +54,8 @@ of their possible levels are profiled). In the case of date
 variables, \code{pctl = FALSE} will always be used since there is no
 quantile method for dates.}
 
-\item{columns}{A character string that contains the names of
-columns that should be fixed and their values. These values are
-not determined until \code{\link[=prep]{prep()}} is called.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/man/step_ratio.Rd
+++ b/man/step_ratio.Rd
@@ -49,9 +49,8 @@ listing.}
 \item{naming}{A function that defines the naming convention for
 new ratio columns.}
 
-\item{columns}{The column names used in the ratios. This
-argument is not populated until \code{\link[=prep]{prep()}} is
-executed.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{TRUE}.}

--- a/man/step_relu.Rd
+++ b/man/step_relu.Rd
@@ -44,8 +44,8 @@ approximation to the rectified linear transformation, should be used.}
 for right hinge transformation and "left_relu_" for reversed/left hinge
 transformations.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_shuffle.Rd
+++ b/man/step_shuffle.Rd
@@ -27,9 +27,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string that contains the names of
-columns that should be shuffled. These values are not determined
-until \code{\link[=prep]{prep()}} is called.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_spatialsign.Rd
+++ b/man/step_spatialsign.Rd
@@ -32,8 +32,8 @@ norm computation?}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_sqrt.Rd
+++ b/man/step_sqrt.Rd
@@ -27,8 +27,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_time.Rd
+++ b/man/step_time.Rd
@@ -35,9 +35,8 @@ preprocessing have been estimated.}
 of the following values: \code{am} (is is AM), \code{hour}, \code{hour12}, \code{minute},
 \code{second}, \code{decimal_day}.}
 
-\item{columns}{A character string of variables that will be
-used as inputs. This field is a placeholder and will be
-populated once \code{\link[=prep]{prep()}} is used.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{TRUE}.}

--- a/man/step_unorder.Rd
+++ b/man/step_unorder.Rd
@@ -27,8 +27,8 @@ created.}
 \item{trained}{A logical to indicate if the quantities for
 preprocessing have been estimated.}
 
-\item{columns}{A character string of variable names that will
-be populated (eventually) by the \code{terms} argument.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -46,9 +46,8 @@ values are: \code{'max'}, \code{'mean'}, \code{'median'},
 \code{'min'}, \code{'prod'}, \code{'sd'}, \code{'sum'},
 \code{'var'}}
 
-\item{columns}{A character string that contains the names of
-columns that should be processed. These values are not
-determined until \code{\link[=prep]{prep()}} is called.}
+\item{columns}{A character string of the selected variable names. This field
+is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{names}{An optional character string that is the same
 length of the number of terms selected by \code{terms}. If you


### PR DESCRIPTION
Turned out that the `columns` argument in the different steps did the same thing, and was just documented in a bunch of different wants. This PR fixes that and uses the updated `step_pca()` version