### PR TITLE
Add remaining infrastructure tests for empty selections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # recipes (development version)
 
-* Fixed bug where `step_interact()` didn't work with empty selection.
+* Fixed bugs where `step_classdist()`, `step_count()`, `step_depth()`,  `step_geodist()`,  `step_interact()`, `step_nnmf_sparse()`, and  `step_regex()` didn't work with empty selection.
+
+* `step_classdist()`, `step_count()` and `step_depth()` no longer returns a column with all `NA`s with empty selections.
+
+* `step_regex()` no longer returns a column with all 0s with empty selections.
 
 # recipes 1.0.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # recipes (development version)
 
-* Fixed bugs where `step_classdist()`, `step_count()`, `step_depth()`,  `step_geodist()`,  `step_interact()`, `step_nnmf_sparse()`, and  `step_regex()` didn't work with empty selection.
+* Fixed bugs where `step_classdist()`, `step_count()`, `step_depth()`,  `step_geodist()`,  `step_interact()`, `step_nnmf_sparse()`, and  `step_regex()` didn't work with empty selection. All steps now leave data unmodified when having empty selections.
 
 * `step_classdist()`, `step_count()` and `step_depth()` no longer returns a column with all `NA`s with empty selections.
 

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -227,6 +227,10 @@ mah_pooled <- function(means, x, cov_mat) {
 
 #' @export
 bake.step_classdist <- function(object, new_data, ...) {
+  if (length(object$objects[[1]]$center) == 0) {
+    return(new_data)
+  }
+
   if (object$pool) {
     x_cols <- names(object$objects[["center"]][[1]])
     check_new_data(x_cols, object, new_data)

--- a/R/count.R
+++ b/R/count.R
@@ -142,8 +142,6 @@ bake.step_count <- function(object, new_data, ...) {
   check_new_data(names(object$input), object, new_data)
 
   if (length(object$input) == 0L) {
-    # Empty selection, but still return the new column
-    new_data[, object$result] <- if (object$normalize) NA_real_ else NA_integer_
     return(new_data)
   }
 

--- a/R/depth.R
+++ b/R/depth.R
@@ -173,6 +173,10 @@ get_depth <- function(tr_dat, new_dat, metric, opts) {
 
 #' @export
 bake.step_depth <- function(object, new_data, ...) {
+  if (ncol(object$data[[1]]) == 0) {
+    return(new_data)
+  }
+
   x_names <- colnames(object$data[[1]])
   check_new_data(x_names, object, new_data)
 

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -210,6 +210,10 @@ geo_dist_calc_lat_lon <- function(x_1, y_1, x_2, y_2, earth_radius = 6371e3,
 bake.step_geodist <- function(object, new_data, ...) {
   check_new_data(names(object$columns), object, new_data)
 
+  if (length(object$columns) == 0) {
+    return(new_data)
+  }
+
   object <- check_is_lat_lon(object)
 
   if (object$is_lat_lon) {

--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -151,7 +151,7 @@ prep.step_nnmf_sparse <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
   check_type(training[, col_names], types = c("double", "integer"))
 
-  if (x$num_comp > 0) {
+  if (x$num_comp > 0 && length(col_names) > 0) {
     x$num_comp <- min(x$num_comp, length(col_names))
     dat <- tibble_to_sparse(training[, col_names], transp = TRUE)
     cl <- nnmf_pen_call(x)
@@ -172,6 +172,7 @@ prep.step_nnmf_sparse <- function(x, training, info = NULL, ...) {
     }
   } else {
     nnm <- list(x_vars = col_names, w = NULL)
+    x$num_comp <- 0
   }
 
   step_nnmf_sparse_new(

--- a/R/regex.R
+++ b/R/regex.R
@@ -134,8 +134,6 @@ prep.step_regex <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_regex <- function(object, new_data, ...) {
   if (length(object$input) == 0) {
-    # Handle empty selection by adding an all `0` column
-    new_data[[object$result]] <- rep(0, times = nrow(new_data))
     return(new_data)
   }
 

--- a/tests/testthat/_snaps/geodist.md
+++ b/tests/testthat/_snaps/geodist.md
@@ -162,6 +162,41 @@
       Error in `step_geodist()`:
       ! `is_lat_lon` should be a single logical value.
 
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Geographical distances from 0.5 x 0.25 using: NULL, NULL
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Geographical distances from 0.5 x 0.25 using: <none> | Trained
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -9,6 +9,41 @@
       Caused by error:
       ! object 'const' not found
 
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Variable mutation for: <none>
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Variable mutation for: <none> | Trained
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/newvalues.md
+++ b/tests/testthat/_snaps/newvalues.md
@@ -154,3 +154,38 @@
       -- Operations 
       * Checking no new_values for: <none> | Trained
 
+# printing
+
+    Code
+      print(rec)
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Checking no new_values for: disp
+
+---
+
+    Code
+      prep(rec)
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Checking no new_values for: disp | Trained
+

--- a/tests/testthat/_snaps/nnmf_sparse.md
+++ b/tests/testthat/_snaps/nnmf_sparse.md
@@ -8,3 +8,38 @@
       ! Name collision occured. The following variable names already exists:
       i  NNMF1
 
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Non-negative matrix factorization for: <none>
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * No non-negative matrix factorization was extracted from: <none> | Trained
+

--- a/tests/testthat/_snaps/nnmf_sparse.md
+++ b/tests/testthat/_snaps/nnmf_sparse.md
@@ -43,3 +43,38 @@
       -- Operations 
       * No non-negative matrix factorization was extracted from: <none> | Trained
 
+# printing
+
+    Code
+      print(rec)
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Non-negative matrix factorization for: disp, drat
+
+---
+
+    Code
+      prep(rec)
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Non-negative matrix factorization for: disp, drat | Trained
+

--- a/tests/testthat/_snaps/sample.md
+++ b/tests/testthat/_snaps/sample.md
@@ -60,6 +60,41 @@
       -- Operations 
       * Row sampling: <none> | Trained, weighted
 
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Row sampling: <none>
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Row sampling: <none> | Trained
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -1,3 +1,38 @@
+# empty printing
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Operations 
+      * Variables selected: <none>
+
+---
+
+    Code
+      rec
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:    1
+      predictor: 10
+      
+      -- Training information 
+      Training data contained 32 data points and no incomplete rows.
+      
+      -- Operations 
+      * Variables selected: <none> | Trained
+
 # printing
 
     Code

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -74,6 +74,19 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_arrange(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
 test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_arrange(rec)

--- a/tests/testthat/test-classdist.R
+++ b/tests/testthat/test-classdist.R
@@ -102,28 +102,6 @@ test_that("prefix", {
   expect_true(any(grepl("centroid_", names(dists))))
 })
 
-test_that("empty selection prep/bake returns NA columns", {
-  rec1 <- recipe(Species ~ ., iris)
-  rec2 <- step_classdist(rec1, class = "Species", pool = FALSE)
-  rec3 <- step_classdist(rec1, class = "Species", pool = TRUE)
-
-  rec2 <- prep(rec2, iris)
-  rec3 <- prep(rec3, iris)
-
-  baked2 <- bake(rec2, iris)
-  baked3 <- bake(rec3, iris)
-
-  expect <- rep(NA_real_, nrow(iris))
-
-  expect_identical(baked2$classdist_setosa, expect)
-  expect_identical(baked2$classdist_versicolor, expect)
-  expect_identical(baked2$classdist_virginica, expect)
-
-  expect_identical(baked3$classdist_setosa, expect)
-  expect_identical(baked3$classdist_versicolor, expect)
-  expect_identical(baked3$classdist_virginica, expect)
-})
-
 test_that("case weights", {
   set.seed(1)
   wts <- runif(32)
@@ -216,6 +194,19 @@ test_that("empty printing", {
   rec <- prep(rec, iris)
 
   expect_snapshot(rec)
+})
+
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_classdist(rec1, class = "mpg")
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
 })
 
 test_that("empty selection tidy method works", {

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -55,17 +55,6 @@ test_that("bad selector(s)", {
   )
 })
 
-test_that("empty selection prep/bake adds an NA column", {
-  rec1 <- recipe(mpg ~ ., mtcars)
-  rec2 <- step_count(rec1, pattern = "rock")
-
-  rec2 <- prep(rec2, mtcars)
-
-  baked2 <- bake(rec2, mtcars)
-
-  expect_identical(baked2$rock, rep(NA_integer_, nrow(mtcars)))
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -94,6 +83,19 @@ test_that("empty printing", {
   rec <- prep(rec, mtcars)
 
   expect_snapshot(rec)
+})
+
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_count(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
 })
 
 test_that("empty selection tidy method works", {

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -81,20 +81,6 @@ test_that("prefix", {
   expect_true(any(grepl("spatial_", names(dists))))
 })
 
-test_that("empty selection prep/bake adds NA columns", {
-  skip_if_not_installed("ddalpha")
-  rec1 <- recipe(Species ~ ., iris)
-  rec2 <- step_depth(rec1, class = "Species")
-
-  rec2 <- prep(rec2, iris)
-
-  baked2 <- bake(rec2, iris)
-
-  expect_identical(baked2$depth_setosa, rep(NA_real_, nrow(iris)))
-  expect_identical(baked2$depth_versicolor, rep(NA_real_, nrow(iris)))
-  expect_identical(baked2$depth_virginica, rep(NA_real_, nrow(iris)))
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -121,6 +107,20 @@ test_that("empty printing", {
   rec <- prep(rec, iris)
 
   expect_snapshot(rec)
+})
+
+test_that("empty selection prep/bake is a no-op", {
+  skip_if_not_installed("ddalpha")
+  rec1 <- recipe(Species ~ ., iris)
+  rec2 <- step_depth(rec1, class = "Species")
+
+  rec1 <- prep(rec1, iris)
+  rec2 <- prep(rec2, iris)
+
+  baked1 <- bake(rec1, iris)
+  baked2 <- bake(rec2, iris)
+
+  expect_identical(baked1, baked2)
 })
 
 test_that("empty selection tidy method works", {

--- a/tests/testthat/test-geodist.R
+++ b/tests/testthat/test-geodist.R
@@ -246,6 +246,19 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_geodist(rec1, ref_lat = 0.5, ref_lon = 0.25, is_lat_lon = FALSE)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
 test_that("printing", {
   rec <- recipe(~ x + y, data = rand_data) %>%
     step_geodist(

--- a/tests/testthat/test-geodist.R
+++ b/tests/testthat/test-geodist.R
@@ -235,6 +235,17 @@ test_that("bake method errors when needed non-standard role columns are missing"
                class = "new_data_missing_column")
 })
 
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_geodist(rec, ref_lat = 0.5, ref_lon = 0.25, is_lat_lon = FALSE)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})
+
 test_that("printing", {
   rec <- recipe(~ x + y, data = rand_data) %>%
     step_geodist(

--- a/tests/testthat/test-intercept.R
+++ b/tests/testthat/test-intercept.R
@@ -67,6 +67,12 @@ test_that("check_name() is used", {
 
 # Infrastructure ---------------------------------------------------------------
 
+test_that("empty printing", {
+  # Here for completeness
+  # step_intercept() is special as it can't be used without selection
+  expect_true(TRUE)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = ex_dat) %>%
     step_intercept()

--- a/tests/testthat/test-intercept.R
+++ b/tests/testthat/test-intercept.R
@@ -73,6 +73,12 @@ test_that("empty printing", {
   expect_true(TRUE)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  # Here for completeness
+  # step_intercept() is special as it can't be used without selection
+  expect_true(TRUE)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = ex_dat) %>%
     step_intercept()

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -122,6 +122,20 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_mutate(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
+
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%
     step_mutate(x = 5)

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -93,15 +93,6 @@ test_that("can use unnamed expressions like `across()` (#759)", {
   )
 })
 
-test_that("no input", {
-  no_inputs <-
-    iris_rec %>%
-    step_mutate() %>%
-    prep(training = iris) %>%
-    bake(new_data = NULL, composition = "data.frame")
-  expect_equal(no_inputs, iris)
-})
-
 test_that("tidying allows for named and unnamed expressions", {
   rec <- step_mutate(iris_rec, x = mean(y), id = "named")
   tidied <- tidy(rec, id = "named")
@@ -119,6 +110,17 @@ test_that("tidying allows for named and unnamed expressions", {
 })
 
 # Infrastructure ---------------------------------------------------------------
+
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_mutate(rec)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})
 
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%

--- a/tests/testthat/test-newvalues.R
+++ b/tests/testthat/test-newvalues.R
@@ -193,3 +193,11 @@ test_that("empty selection tidy method works", {
 
   expect_identical(tidy(rec, number = 1), expect)
 })
+
+test_that("printing", {
+  rec <- recipe(mpg ~ ., mtcars) %>%
+    check_new_values(disp)
+
+  expect_snapshot(print(rec))
+  expect_snapshot(prep(rec))
+})

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -15,3 +15,14 @@ test_that("check_name() is used", {
 })
 
 # Infrastructure ---------------------------------------------------------------
+
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_nnmf_sparse(rec)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -27,6 +27,20 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  library(Matrix)
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_nnmf_sparse(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
 test_that("printing", {
   library(Matrix)
   rec <- recipe(mpg ~ ., mtcars) %>%

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -26,3 +26,12 @@ test_that("empty printing", {
 
   expect_snapshot(rec)
 })
+
+test_that("printing", {
+  library(Matrix)
+  rec <- recipe(mpg ~ ., mtcars) %>%
+    step_nnmf_sparse(disp, drat)
+
+  expect_snapshot(print(rec))
+  expect_snapshot(prep(rec))
+})

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -17,6 +17,8 @@ test_that("check_name() is used", {
 # Infrastructure ---------------------------------------------------------------
 
 test_that("empty printing", {
+  skip_if_not_installed("RcppML")
+  library(Matrix)
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_nnmf_sparse(rec)
 
@@ -28,6 +30,7 @@ test_that("empty printing", {
 })
 
 test_that("empty selection prep/bake is a no-op", {
+  skip_if_not_installed("RcppML")
   library(Matrix)
   rec1 <- recipe(mpg ~ ., mtcars)
   rec2 <- step_nnmf_sparse(rec1)
@@ -42,6 +45,7 @@ test_that("empty selection prep/bake is a no-op", {
 })
 
 test_that("printing", {
+  skip_if_not_installed("RcppML")
   library(Matrix)
   rec <- recipe(mpg ~ ., mtcars) %>%
     step_nnmf_sparse(disp, drat)

--- a/tests/testthat/test-regex.R
+++ b/tests/testthat/test-regex.R
@@ -47,19 +47,6 @@ test_that("bad selector(s)", {
   )
 })
 
-test_that("empty selection prep/bake adds a 0 column", {
-  rec1 <- recipe(mpg ~ ., mtcars)
-  rec2 <- step_regex(rec1, pattern = "xxx")
-
-  rec1 <- prep(rec1, mtcars)
-  rec2 <- prep(rec2, mtcars)
-
-  baked1 <- bake(rec1, mtcars)
-  baked2 <- bake(rec2, mtcars)
-
-  expect_identical(baked2$xxx, rep(0, nrow(mtcars)))
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -86,6 +73,19 @@ test_that("empty printing", {
   rec <- prep(rec, mtcars)
 
   expect_snapshot(rec)
+})
+
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_regex(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
 })
 
 test_that("empty selection tidy method works", {

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -150,6 +150,19 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  rec1 <- recipe(mpg ~ ., mtcars)
+  rec2 <- step_sample(rec1)
+
+  rec1 <- prep(rec1, mtcars)
+  rec2 <- prep(rec2, mtcars)
+
+  baked1 <- bake(rec1, mtcars)
+  baked2 <- bake(rec2, mtcars)
+
+  expect_identical(baked1, baked2)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%
     step_sample()

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -139,6 +139,17 @@ test_that("sample with case weights", {
 
 # Infrastructure ---------------------------------------------------------------
 
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_sample(rec)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%
     step_sample()

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -145,6 +145,17 @@ test_that("bake method errors when needed non-standard role columns are missing"
                class = "new_data_missing_column")
 })
 
+test_that("empty printing", {
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_select(rec)
+
+  expect_snapshot(rec)
+
+  rec <- prep(rec, mtcars)
+
+  expect_snapshot(rec)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%
     step_select(Species)

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -156,6 +156,12 @@ test_that("empty printing", {
   expect_snapshot(rec)
 })
 
+test_that("empty selection prep/bake is a no-op", {
+  # Here for completeness
+  # step_select() will mimick dplyr::select() by not selecting anything
+  expect_true(TRUE)
+})
+
 test_that("printing", {
   rec <- recipe(~., data = iris) %>%
     step_select(Species)


### PR DESCRIPTION
Part of overall project: https://github.com/tidymodels/recipes/issues/1130
dealing with part of https://github.com/tidymodels/recipes/issues/1134 by adding tests for

- Empty printing
- printing
- empty selection prep/bake is a no-op

Doing the other 2 types in a different PR for ease of review.

