### PR TITLE
make sure all steps return zero row tibble with empty selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `step_regex()` no longer returns a column with all 0s with empty selections.
 
+* `step_poly_bernstein()`, `step_profile()`, `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, and `step_spline_nonnegative()` now correctly return a zero row tibble when used with empty selection. (#1133)
+
 # recipes 1.0.6
 
 ## Improvements

--- a/R/poly_bernstein.R
+++ b/R/poly_bernstein.R
@@ -180,9 +180,6 @@ print.step_poly_bernstein <-
 tidy.step_poly_bernstein <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/R/profile.R
+++ b/R/profile.R
@@ -233,6 +233,10 @@ tidy.step_profile <- function(x, ...) {
     fixed_names <- sel2char(x$terms)
     prof_names <- sel2char(x$profile)
   }
+
+  if (length(fixed_names) == 0) {
+    return(tibble(terms = character(), type = character(), id = character()))
+  }
   fixed_res <- tibble(
     terms = fixed_names,
     type = rep("fixed", length = length(fixed_names))

--- a/R/spline_b.R
+++ b/R/spline_b.R
@@ -197,9 +197,6 @@ print.step_spline_b <-
 tidy.step_spline_b <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/R/spline_convex.R
+++ b/R/spline_convex.R
@@ -188,9 +188,6 @@ print.step_spline_convex <-
 tidy.step_spline_convex <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/R/spline_monotone.R
+++ b/R/spline_monotone.R
@@ -189,9 +189,6 @@ print.step_spline_monotone <-
 tidy.step_spline_monotone <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/R/spline_natural.R
+++ b/R/spline_natural.R
@@ -181,9 +181,6 @@ print.step_spline_natural <-
 tidy.step_spline_natural <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/R/spline_nonnegative.R
+++ b/R/spline_nonnegative.R
@@ -200,9 +200,6 @@ print.step_spline_nonnegative <-
 tidy.step_spline_nonnegative <- function(x, ...) {
   if (is_trained(x)) {
     terms <- names(x$results)
-    if (length(terms) == 0) {
-      terms <- "<none>"
-    }
   } else {
     terms <- sel2char(x$terms)
   }

--- a/tests/testthat/test-poly_bernstein.R
+++ b/tests/testthat/test-poly_bernstein.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_poly_bernstein(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -149,13 +149,9 @@ test_that("empty selection prep/bake is a no-op", {
 
 test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
-  rec <- step_profile(rec, profile = vars(mpg), id = "foo")
+  rec <- step_profile(rec, profile = vars(mpg))
 
-  expect <- tibble(
-    terms = "mpg",
-    type = "profiled",
-    id = "foo"
-  )
+  expect <- tibble(terms = character(), type = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spline_b(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spline_convex(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spline_monotone(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spline_natural(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -155,13 +155,13 @@ test_that("empty selection tidy method works", {
   rec <- recipe(mpg ~ ., mtcars)
   rec <- step_spline_nonnegative(rec)
 
-  expect <- tibble(terms = "<none>", id = character())
+  expect <- tibble(terms = character(), id = character())
 
   expect_identical(tidy(rec, number = 1), expect)
 
-  rec_prepped <- prep(rec, mtcars)
-  expect_prepped <- tibble::tibble(terms = "<none>", id = rec_prepped$steps[[1]]$id)
-  expect_identical(tidy(rec_prepped, number = 1), expect_prepped)
+  rec <- prep(rec, mtcars)
+
+  expect_identical(tidy(rec, number = 1), expect)
 })
 
 test_that("printing", {


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1133.
related to https://github.com/tidymodels/recipes/issues/1130

a couple of steps didn't return zero-row tibbles with empty selections. This PR fixes that