### PR TITLE
do early exit for long if statement in bake functions

### DIFF
--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -133,8 +133,9 @@ bake.step_YeoJohnson <- function(object, new_data, ...) {
   check_new_data(names(object$lambdas), object, new_data)
 
   if (length(object$lambdas) == 0) {
-    return(as_tibble(new_data))
+    return(new_data)
   }
+
   param <- names(object$lambdas)
   for (i in seq_along(object$lambdas)) {
     new_data[[param[i]]] <-

--- a/R/ica.R
+++ b/R/ica.R
@@ -187,13 +187,13 @@ prep.step_ica <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_ica <- function(object, new_data, ...) {
   uses_dim_red(object)
+  check_new_data(object$columns, object, new_data)
 
   keep_going <- object$num_comp > 0 && length(object$columns) > 0
   if (!keep_going) {
     return(new_data)
   }
 
-  check_new_data(object$columns, object, new_data)
 
   comps <- scale(as.matrix(new_data[, object$columns]),
     center = object$res$means, scale = FALSE

--- a/R/ica.R
+++ b/R/ica.R
@@ -188,7 +188,8 @@ prep.step_ica <- function(x, training, info = NULL, ...) {
 bake.step_ica <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp == 0 || length(object$columns) == 0) {
+  keep_going <- object$num_comp > 0 && length(object$columns) > 0
+  if (!keep_going) {
     return(new_data)
   }
 

--- a/R/ica.R
+++ b/R/ica.R
@@ -188,21 +188,23 @@ prep.step_ica <- function(x, training, info = NULL, ...) {
 bake.step_ica <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp > 0 && length(object$columns) > 0) {
-    check_new_data(object$columns, object, new_data)
-
-    comps <- scale(as.matrix(new_data[, object$columns]),
-      center = object$res$means, scale = FALSE
-    )
-    comps <- comps %*% object$res$K %*% object$res$W
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    colnames(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, comps)
-
-    new_data <- remove_original_cols(new_data, object, object$columns)
+  if (object$num_comp == 0 || length(object$columns) == 0) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+
+  comps <- scale(as.matrix(new_data[, object$columns]),
+    center = object$res$means, scale = FALSE
+  )
+  comps <- comps %*% object$res$K %*% object$res$W
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  colnames(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, comps)
+
+  new_data <- remove_original_cols(new_data, object, object$columns)
   new_data
 }
 

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -151,24 +151,26 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
 bake.step_kpca <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp > 0 && length(object$columns) > 0) {
-    check_new_data(object$columns, object, new_data)
-
-    cl <-
-      rlang::call2(
-        "predict",
-        .ns = "kernlab",
-        object = object$res,
-        rlang::expr(as.matrix(new_data[, object$columns]))
-      )
-    comps <- rlang::eval_tidy(cl)
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    colnames(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, comps)
-    new_data <- remove_original_cols(new_data, object, object$columns)
+  if (object$num_comp == 0 || length(object$columns) == 0) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+
+  cl <-
+    rlang::call2(
+      "predict",
+      .ns = "kernlab",
+      object = object$res,
+      rlang::expr(as.matrix(new_data[, object$columns]))
+    )
+  comps <- rlang::eval_tidy(cl)
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  colnames(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, comps)
+  new_data <- remove_original_cols(new_data, object, object$columns)
   new_data
 }
 

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -150,13 +150,12 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_kpca <- function(object, new_data, ...) {
   uses_dim_red(object)
+  check_new_data(object$columns, object, new_data)
 
   keep_going <- object$num_comp > 0 && length(object$columns) > 0
   if (!keep_going) {
     return(new_data)
   }
-
-  check_new_data(object$columns, object, new_data)
 
   cl <-
     rlang::call2(

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -151,7 +151,8 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
 bake.step_kpca <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp == 0 || length(object$columns) == 0) {
+  keep_going <- object$num_comp > 0 && length(object$columns) > 0
+  if (!keep_going) {
     return(new_data)
   }
 

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -157,13 +157,13 @@ prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_kpca_poly <- function(object, new_data, ...) {
   uses_dim_red(object)
+  check_new_data(object$columns, object, new_data)
 
   keep_going <- object$num_comp > 0 && length(object$columns) > 0
   if (!keep_going) {
     return(new_data)
   }
 
-  check_new_data(object$columns, object, new_data)
   cl <-
     rlang::call2(
       "predict",

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -158,23 +158,25 @@ prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
 bake.step_kpca_poly <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp > 0 && length(object$columns) > 0) {
-    check_new_data(object$columns, object, new_data)
-    cl <-
-      rlang::call2(
-        "predict",
-        .ns = "kernlab",
-        object = object$res,
-        rlang::expr(as.matrix(new_data[, object$columns]))
-      )
-    comps <- rlang::eval_tidy(cl)
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    colnames(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, comps)
-    new_data <- remove_original_cols(new_data, object, object$columns)
+  if (object$num_comp == 0 || length(object$columns) == 0) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+  cl <-
+    rlang::call2(
+      "predict",
+      .ns = "kernlab",
+      object = object$res,
+      rlang::expr(as.matrix(new_data[, object$columns]))
+    )
+  comps <- rlang::eval_tidy(cl)
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  colnames(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, comps)
+  new_data <- remove_original_cols(new_data, object, object$columns)
   new_data
 }
 

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -158,7 +158,8 @@ prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
 bake.step_kpca_poly <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp == 0 || length(object$columns) == 0) {
+  keep_going <- object$num_comp > 0 && length(object$columns) > 0
+  if (!keep_going) {
     return(new_data)
   }
 

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -146,23 +146,25 @@ prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
 bake.step_kpca_rbf <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp > 0 && length(object$columns) > 0) {
-    check_new_data(object$columns, object, new_data)
-    cl <-
-      rlang::call2(
-        "predict",
-        .ns = "kernlab",
-        object = object$res,
-        rlang::expr(as.matrix(new_data[, object$columns]))
-      )
-    comps <- rlang::eval_tidy(cl)
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    colnames(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, comps)
-    new_data <- remove_original_cols(new_data, object, object$columns)
+  if (object$num_comp == 0 || length(object$columns) == 0) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+  cl <-
+    rlang::call2(
+      "predict",
+      .ns = "kernlab",
+      object = object$res,
+      rlang::expr(as.matrix(new_data[, object$columns]))
+    )
+  comps <- rlang::eval_tidy(cl)
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  colnames(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, comps)
+  new_data <- remove_original_cols(new_data, object, object$columns)
   new_data
 }
 

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -146,7 +146,8 @@ prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
 bake.step_kpca_rbf <- function(object, new_data, ...) {
   uses_dim_red(object)
 
-  if (object$num_comp == 0 || length(object$columns) == 0) {
+  keep_going <- object$num_comp > 0 && length(object$columns) > 0
+  if (!keep_going) {
     return(new_data)
   }
 

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -145,13 +145,13 @@ prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
 #' @export
 bake.step_kpca_rbf <- function(object, new_data, ...) {
   uses_dim_red(object)
+  check_new_data(object$columns, object, new_data)
 
   keep_going <- object$num_comp > 0 && length(object$columns) > 0
   if (!keep_going) {
     return(new_data)
   }
 
-  check_new_data(object$columns, object, new_data)
   cl <-
     rlang::call2(
       "predict",

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -178,7 +178,8 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_nnmf <- function(object, new_data, ...) {
-  if (object$num_comp == 0 || length(object$columns) == 0) {
+  keep_going <- object$num_comp > 0 && length(object$columns) > 0
+  if (!keep_going) {
     return(new_data)
   }
 

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -178,19 +178,20 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_nnmf <- function(object, new_data, ...) {
-
-  if (object$num_comp > 0 && length(object$columns) > 0) {
-    check_new_data(object$columns, object, new_data)
-    nnmf_vars <- rownames(object$res@other.data$w)
-    comps <-
-      object$res@apply(dimred_data(new_data[, nnmf_vars, drop = FALSE]))@data
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    colnames(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, comps)
-    new_data <- remove_original_cols(new_data, object, nnmf_vars)
+  if (object$num_comp == 0 || length(object$columns) == 0) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+  nnmf_vars <- rownames(object$res@other.data$w)
+  comps <-
+    object$res@apply(dimred_data(new_data[, nnmf_vars, drop = FALSE]))@data
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  colnames(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, comps)
+  new_data <- remove_original_cols(new_data, object, nnmf_vars)
   new_data
 }
 

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -178,12 +178,13 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_nnmf <- function(object, new_data, ...) {
+  check_new_data(object$columns, object, new_data)
+
   keep_going <- object$num_comp > 0 && length(object$columns) > 0
   if (!keep_going) {
     return(new_data)
   }
 
-  check_new_data(object$columns, object, new_data)
   nnmf_vars <- rownames(object$res@other.data$w)
   comps <-
     object$res@apply(dimred_data(new_data[, nnmf_vars, drop = FALSE]))@data

--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -195,15 +195,17 @@ prep.step_nnmf_sparse <- function(x, training, info = NULL, ...) {
 bake.step_nnmf_sparse <- function(object, new_data, ...) {
   check_new_data(object$res$x_vars, object, new_data)
 
-  if (object$num_comp > 0) {
-    proj_data <- as.matrix(new_data[, object$res$x_vars, drop = FALSE])
-    proj_data <- proj_data %*% object$res$w
-    colnames(proj_data) <- names0(ncol(proj_data), object$prefix)
-    proj_data <- as_tibble(proj_data)
-    proj_data <- check_name(proj_data, new_data, object)
-    new_data <- vec_cbind(new_data, proj_data)
-    new_data <- remove_original_cols(new_data, object, object$res$x_vars)
+  if (object$num_comp == 0) {
+    return(new_data)
   }
+
+  proj_data <- as.matrix(new_data[, object$res$x_vars, drop = FALSE])
+  proj_data <- proj_data %*% object$res$w
+  colnames(proj_data) <- names0(ncol(proj_data), object$prefix)
+  proj_data <- as_tibble(proj_data)
+  proj_data <- check_name(proj_data, new_data, object)
+  new_data <- vec_cbind(new_data, proj_data)
+  new_data <- remove_original_cols(new_data, object, object$res$x_vars)
   new_data
 }
 

--- a/R/pca.R
+++ b/R/pca.R
@@ -229,17 +229,19 @@ bake.step_pca <- function(object, new_data, ...) {
     object$columns <- stats::setNames(nm = rownames(object$res$rotation))
   }
 
-  if (length(object$columns) > 0 && !all(is.na(object$res$rotation))) {
-    check_new_data(object$columns, object, new_data)
-
-    pca_vars <- rownames(object$res$rotation)
-    comps <- scale(new_data[, pca_vars], object$res$center, object$res$scale) %*%
-      object$res$rotation
-    comps <- comps[, seq_len(object$num_comp), drop = FALSE]
-    comps <- check_name(comps, new_data, object)
-    new_data <- vec_cbind(new_data, as_tibble(comps))
-    new_data <- remove_original_cols(new_data, object, pca_vars)
+  if (length(object$columns) == 0 || all(is.na(object$res$rotation))) {
+    return(new_data)
   }
+
+  check_new_data(object$columns, object, new_data)
+
+  pca_vars <- rownames(object$res$rotation)
+  comps <- scale(new_data[, pca_vars], object$res$center, object$res$scale) %*%
+    object$res$rotation
+  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+  comps <- check_name(comps, new_data, object)
+  new_data <- vec_cbind(new_data, as_tibble(comps))
+  new_data <- remove_original_cols(new_data, object, pca_vars)
   new_data
 }
 

--- a/R/pca.R
+++ b/R/pca.R
@@ -225,6 +225,8 @@ prep.step_pca <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_pca <- function(object, new_data, ...) {
+  check_new_data(object$columns, object, new_data)
+
   if (is.null(object$columns)) {
     object$columns <- stats::setNames(nm = rownames(object$res$rotation))
   }
@@ -232,8 +234,6 @@ bake.step_pca <- function(object, new_data, ...) {
   if (length(object$columns) == 0 || all(is.na(object$res$rotation))) {
     return(new_data)
   }
-
-  check_new_data(object$columns, object, new_data)
 
   pca_vars <- rownames(object$res$rotation)
   comps <- scale(new_data[, pca_vars], object$res$center, object$res$scale) %*%

--- a/R/pls.R
+++ b/R/pls.R
@@ -371,30 +371,35 @@ prep.step_pls <- function(x, training, info = NULL, ...) {
 bake.step_pls <- function(object, new_data, ...) {
   check_new_data(get_columns_pls(object), object, new_data)
 
-  if (object$num_comp > 0 && length(get_columns_pls(object)) > 0 && pls_worked(object$res)) {
-    if (use_old_pls(object$res)) {
-      comps <- old_pls_project(object$res, new_data)
-    } else {
-      comps <- pls_project(object$res, new_data)
-    }
-
-    names(comps) <- names0(ncol(comps), object$prefix)
-    comps <- as_tibble(comps)
-    comps <- check_name(comps, new_data, object)
-
-    new_data <- vec_cbind(new_data, comps)
-
-    # Old pls never preserved original columns,
-    # but didn't have the `preserve` option
-    if (use_old_pls(object$res)) {
-      object$preserve <- FALSE
-      pls_vars <- rownames(object$res$projection)
-    } else {
-      pls_vars <- names(object$res$mu)
-    }
-
-    new_data <- remove_original_cols(new_data, object, pls_vars)
+  if (object$num_comp == 0 ||
+      length(get_columns_pls(object)) == 0 ||
+      !pls_worked(object$res)) {
+    return(new_data)
   }
+
+  if (use_old_pls(object$res)) {
+    comps <- old_pls_project(object$res, new_data)
+  } else {
+    comps <- pls_project(object$res, new_data)
+  }
+
+  names(comps) <- names0(ncol(comps), object$prefix)
+  comps <- as_tibble(comps)
+  comps <- check_name(comps, new_data, object)
+
+  new_data <- vec_cbind(new_data, comps)
+
+  # Old pls never preserved original columns,
+  # but didn't have the `preserve` option
+  if (use_old_pls(object$res)) {
+    object$preserve <- FALSE
+    pls_vars <- rownames(object$res$projection)
+  } else {
+    pls_vars <- names(object$res$mu)
+  }
+
+  new_data <- remove_original_cols(new_data, object, pls_vars)
+
   new_data
 }
 

--- a/R/spline_b.R
+++ b/R/spline_b.R
@@ -170,12 +170,15 @@ bake.step_spline_b <- function(object, new_data, ...) {
 
   check_new_data(orig_names, object, new_data)
 
-  if (length(orig_names) > 0) {
-    new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
-    new_cols <- check_name(new_cols, new_data, object, names(new_cols))
-    new_data <- vec_cbind(new_data, new_cols)
-    new_data <- remove_original_cols(new_data, object, orig_names)
+  if (length(orig_names) == 0) {
+    return(new_data)
   }
+
+  new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
+  new_cols <- check_name(new_cols, new_data, object, names(new_cols))
+  new_data <- vec_cbind(new_data, new_cols)
+  new_data <- remove_original_cols(new_data, object, orig_names)
+
   new_data
 }
 

--- a/R/spline_convex.R
+++ b/R/spline_convex.R
@@ -161,12 +161,15 @@ bake.step_spline_convex <- function(object, new_data, ...) {
 
   check_new_data(orig_names, object, new_data)
 
-  if (length(orig_names) > 0) {
-    new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
-    new_cols <- check_name(new_cols, new_data, object, names(new_cols))
-    new_data <- vec_cbind(new_data, new_cols)
-    new_data <- remove_original_cols(new_data, object, orig_names)
+  if (length(orig_names) == 0) {
+    return(new_data)
   }
+
+  new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
+  new_cols <- check_name(new_cols, new_data, object, names(new_cols))
+  new_data <- vec_cbind(new_data, new_cols)
+  new_data <- remove_original_cols(new_data, object, orig_names)
+
   new_data
 }
 

--- a/R/spline_monotone.R
+++ b/R/spline_monotone.R
@@ -162,12 +162,14 @@ bake.step_spline_monotone <- function(object, new_data, ...) {
 
   check_new_data(orig_names, object, new_data)
 
-  if (length(orig_names) > 0) {
-    new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
-    new_cols <- check_name(new_cols, new_data, object, names(new_cols))
-    new_data <- vec_cbind(new_data, new_cols)
-    new_data <- remove_original_cols(new_data, object, orig_names)
+  if (length(orig_names) == 0) {
+    return(new_data)
   }
+
+  new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
+  new_cols <- check_name(new_cols, new_data, object, names(new_cols))
+  new_data <- vec_cbind(new_data, new_cols)
+  new_data <- remove_original_cols(new_data, object, orig_names)
   new_data
 }
 

--- a/R/spline_natural.R
+++ b/R/spline_natural.R
@@ -154,12 +154,15 @@ bake.step_spline_natural <- function(object, new_data, ...) {
 
   check_new_data(orig_names, object, new_data)
 
-  if (length(orig_names) > 0) {
-    new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
-    new_cols <- check_name(new_cols, new_data, object, names(new_cols))
-    new_data <- vec_cbind(new_data, new_cols)
-    new_data <- remove_original_cols(new_data, object, orig_names)
+  if (length(orig_names) == 0) {
+    return(new_data)
   }
+
+  new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
+  new_cols <- check_name(new_cols, new_data, object, names(new_cols))
+  new_data <- vec_cbind(new_data, new_cols)
+  new_data <- remove_original_cols(new_data, object, orig_names)
+
   new_data
 }
 

--- a/R/spline_nonnegative.R
+++ b/R/spline_nonnegative.R
@@ -173,12 +173,15 @@ bake.step_spline_nonnegative <- function(object, new_data, ...) {
 
   check_new_data(orig_names, object, new_data)
 
-  if (length(orig_names) > 0) {
-    new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
-    new_cols <- check_name(new_cols, new_data, object, names(new_cols))
-    new_data <- vec_cbind(new_data, new_cols)
-    new_data <- remove_original_cols(new_data, object, orig_names)
+  if (length(orig_names) == 0) {
+    return(new_data)
   }
+
+  new_cols <- purrr::map2_dfc(object$results, new_data[, orig_names], spline2_apply)
+  new_cols <- check_name(new_cols, new_data, object, names(new_cols))
+  new_data <- vec_cbind(new_data, new_cols)
+  new_data <- remove_original_cols(new_data, object, orig_names)
+
   new_data
 }
 


### PR DESCRIPTION
There are some times where we have a long `if ()` statement, when only trigger sometimes. I switched these over to adopt an early exit strategy. Which we use in other places, such as in `step_count()`

https://github.com/tidymodels/recipes/blob/13849d2a16d300eb66d5b9b40e53dc771b5e4e6a/R/count.R#L141-L146

For this refactor, it is important to remember the rule `!(A and B)` is the same as `!A or !B`.

This PR looks like there are more changes then there actually is. The majority of the changes are indentation changes