### PR TITLE
don't print full vector of names in example for step_dummy_extract()

### DIFF
--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -51,7 +51,8 @@
 #'
 #' dummy_data %>%
 #'   select(starts_with("medium")) %>%
-#'   names()
+#'   names() %>%
+#'   head()
 #'
 #' # More detailed splitting
 #' dummies_specific <- recipe(~medium, data = tate_text) %>%
@@ -62,7 +63,8 @@
 #'
 #' dummy_data_specific %>%
 #'   select(starts_with("medium")) %>%
-#'   names()
+#'   names() %>%
+#'   head()
 #'
 #' tidy(dummies, number = 1)
 #' tidy(dummies_specific, number = 1)

--- a/man/step_dummy_extract.Rd
+++ b/man/step_dummy_extract.Rd
@@ -125,7 +125,8 @@ dummy_data <- bake(dummies, new_data = NULL)
 
 dummy_data \%>\%
   select(starts_with("medium")) \%>\%
-  names()
+  names() \%>\%
+  head()
 
 # More detailed splitting
 dummies_specific <- recipe(~medium, data = tate_text) \%>\%
@@ -136,7 +137,8 @@ dummy_data_specific <- bake(dummies_specific, new_data = NULL)
 
 dummy_data_specific \%>\%
   select(starts_with("medium")) \%>\%
-  names()
+  names() \%>\%
+  head()
 
 tidy(dummies, number = 1)
 tidy(dummies_specific, number = 1)


### PR DESCRIPTION
This is mainly an issue on the pkgdown site https://recipes.tidymodels.org/reference/step_dummy_extract.html

![Kapture 2023-06-15 at 15 27 53](https://github.com/tidymodels/recipes/assets/14034784/23bfe6b4-2709-4134-baa2-71116203c1ec)
