### PR TITLE
document relationship between num_comps and keep_original_cols

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -11,7 +11,7 @@
 #'  If `num_comp` is greater than the number of columns or the number of
 #'  possible components, a smaller value will be used. If `num_comp = 0`
 #'  is set then no transformation is done and selected variables will
-#'  stay unchanged.
+#'  stay unchanged, regardless of the value of `keep_original_cols`.
 #' @param threshold A fraction of the total variance that should be covered by
 #'  the components. For example, `threshold = .75` means that `step_pca` should
 #'  generate enough components to capture 75 percent of the variability in the

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -38,7 +38,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{options}{A list of options to
 \code{\link[fastICA:fastICA]{fastICA::fastICA()}}. No defaults are set here.

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -37,7 +37,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored here once this
 preprocessing step has be trained by \code{\link[=prep]{prep()}}.}

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -39,7 +39,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored
 here once this preprocessing step has be trained by

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -37,7 +37,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{res}{An S4 \code{\link[kernlab:kpca]{kernlab::kpca()}} object is stored
 here once this preprocessing step has be trained by

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -39,7 +39,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{num_run}{A positive integer for the number of computations runs used
 to obtain a consensus projection.}

--- a/man/step_nnmf_sparse.Rd
+++ b/man/step_nnmf_sparse.Rd
@@ -38,7 +38,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{penalty}{A non-negative number used as a penalization factor for the
 loadings. Values are usually between zero and one.}

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -38,7 +38,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{threshold}{A fraction of the total variance that should be covered by
 the components. For example, \code{threshold = .75} means that \code{step_pca} should

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -40,7 +40,7 @@ preprocessing have been estimated.}
 If \code{num_comp} is greater than the number of columns or the number of
 possible components, a smaller value will be used. If \code{num_comp = 0}
 is set then no transformation is done and selected variables will
-stay unchanged.}
+stay unchanged, regardless of the value of \code{keep_original_cols}.}
 
 \item{predictor_prop}{The maximum number of original predictors that can have
 non-zero coefficients for each PLS component (via regularization).}

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -172,10 +172,6 @@ test_that("can prep recipes with no keep_original_cols", {
 })
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
-  skip_if_not_installed("dimRed")
-  skip_if_not_installed("fastICA")
-  skip_if_not_installed("RSpectra")
-
   rec <- recipe(~ ., data = mtcars) %>%
     step_ica(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -171,6 +171,20 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("dimRed")
+  skip_if_not_installed("fastICA")
+  skip_if_not_installed("RSpectra")
+
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_ica(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -171,7 +171,7 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_ica(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -120,6 +120,17 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_kpca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -121,7 +121,6 @@ test_that("can prep recipes with no keep_original_cols", {
 })
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
-  skip_if_not_installed("kernlab")
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -120,7 +120,7 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -126,7 +126,7 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_poly(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -127,7 +127,6 @@ test_that("can prep recipes with no keep_original_cols", {
 })
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
-  skip_if_not_installed("kernlab")
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_poly(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -126,6 +126,17 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_kpca_poly(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -127,6 +127,17 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_kpca_rbf(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -128,7 +128,6 @@ test_that("can prep recipes with no keep_original_cols", {
 })
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
-  skip_if_not_installed("kernlab")
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_rbf(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -127,7 +127,7 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_rbf(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -14,6 +14,19 @@ test_that("check_name() is used", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("RcppML")
+  library(Matrix)
+
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_nnmf_sparse(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -14,7 +14,7 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   skip_if_not_installed("RcppML")
   library(Matrix)
 

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -279,7 +279,7 @@ test_that("case weights", {
   expect_snapshot(pca_extract_trained)
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_pca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
     prep()

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -279,6 +279,16 @@ test_that("case weights", {
   expect_snapshot(pca_extract_trained)
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  rec <- recipe(~ ., data = mtcars) %>%
+    step_pca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -295,8 +295,6 @@ test_that("can prep recipes with no keep_original_cols", {
 })
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
-  skip_if_not_installed("mixOmics")
-
   rec <- recipe(carb ~ ., data = mtcars) %>%
     step_pls(all_predictors(), outcome = "carb",
              num_comp = 0, keep_original_cols = FALSE) %>%

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -294,7 +294,7 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
-test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(carb ~ ., data = mtcars) %>%
     step_pls(all_predictors(), outcome = "carb",
              num_comp = 0, keep_original_cols = FALSE) %>%

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -294,6 +294,19 @@ test_that("can prep recipes with no keep_original_cols", {
   )
 })
 
+test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE #1152", {
+  skip_if_not_installed("mixOmics")
+
+  rec <- recipe(carb ~ ., data = mtcars) %>%
+    step_pls(all_predictors(), outcome = "carb",
+             num_comp = 0, keep_original_cols = FALSE) %>%
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_identical(res, tibble::as_tibble(mtcars))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1152

This PR adds a line to the documentation of `num_comp` about its relationship to `keep_original_cols` and then add a test to the affected steps to make sure that that behavior is correct