### PR TITLE
Refactor documentation of `num_comp` argument

### DIFF
--- a/R/ica.R
+++ b/R/ica.R
@@ -33,14 +33,11 @@
 #'  \pkg{dimRed} and \pkg{fastICA} packages. If not installed, the
 #'  step will stop with a note about installing these packages.
 #'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num_comp < 10`, their names will be `IC1` - `IC9`.
-#'  If `num_comp = 101`, the names would be `IC001` -
-#'  `IC101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "IC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # Tidying
 #'

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -31,15 +31,11 @@
 #'  have non-negative values and take into account that the original data
 #'  have non-negative values.
 #'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num < 10`, their names will be `NNMF1` - `NNMF9`.
-#'  If `num = 101`, the names would be `NNMF001` -
-#'  `NNMF101`.
-#'
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "NNMF"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # Tidying
 #'

--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -23,12 +23,11 @@
 #'  have non-negative values and take into account that the original data have
 #'  non-negative values.
 #'
-#'   The argument `num_comp` controls the number of components that will be
-#'  retained (the original variables that are used to derive the components are
-#'  removed from the data). The new components will have names that begin with
-#'  `prefix` and a sequence of numbers. The variable names are padded with
-#'  zeros. For example, if `num < 10`, their names will be `NNMF1` - `NNMF9`. If
-#'  `num = 101`, the names would be `NNMF001` - `NNMF101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "NNMF"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #'  # Tidying
 #'

--- a/R/pca.R
+++ b/R/pca.R
@@ -48,14 +48,11 @@
 #'  `options` argument or by using [step_center()]
 #'  and [step_scale()].
 #'
-#' The argument `num_comp` controls the number of components that
-#'  will be retained (the original variables that are used to derive
-#'  the components are removed from the data). The new components
-#'  will have names that begin with `prefix` and a sequence of
-#'  numbers. The variable names are padded with zeros. For example,
-#'  if `num_comp < 10`, their names will be `PC1` - `PC9`.
-#'  If `num_comp = 101`, the names would be `PC001` -
-#'  `PC101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "PC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' Alternatively, `threshold` can be used to determine the
 #'  number of components that are required to capture a specified

--- a/R/pls.R
+++ b/R/pls.R
@@ -27,13 +27,11 @@
 #' This step requires the Bioconductor \pkg{mixOmics} package. If not installed, the
 #'  step will stop with a note about installing the package.
 #'
-#' The argument `num_comp` controls the number of components that will
-#'  be retained (the original variables that are used to derive the
-#'  components are removed from the data). The new components will
-#'  have names that begin with `prefix` and a sequence of numbers.
-#'  The variable names are padded with zeros. For example, if `num_comp <
-#'  10`, their names will be `PLS1` - `PLS9`. If `num_comp = 101`, the
-#'  names would be `PLS001` - `PLS101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "PLS"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' Sparsity can be encouraged using the `predictor_prop` parameter. This affects
 #' each PLS component, and indicates the maximum proportion of predictors with

--- a/man-roxygen/kpca-info.R
+++ b/man-roxygen/kpca-info.R
@@ -14,13 +14,11 @@
 #' prior to computing PCA components ([step_normalize()] can be used for
 #' this purpose).
 #'
-#' The argument `num_comp` controls the number of components that will be
-#' retained; the original variables that are used to derive the components are
-#' removed from the data when `keep_original_cols = FALSE`. The new components
-#' will have names that begin with `prefix` and a sequence of numbers. The
-#' variable names are padded with zeros. For example, if `num_comp < 10`, the
-#' new names will be `kPC1` - `kPC9`. If `num_comp = 101`, the names would be
-#' `kPC001` - `kPC101`.
+#' ```{r, echo = FALSE, results="asis"}
+#' prefix <- "kPC"
+#' result <- knitr::knit_child("man/rmd/num_comp.Rmd")
+#' cat(result)
+#' ```
 #'
 #' # tidy() results
 #'
@@ -34,8 +32,3 @@
 #' Karatzoglou, K., Smola, A., Hornik, K., and Zeileis, A. (2004).
 #'  kernlab - An S4 package for kernel methods in R. *Journal
 #'  of Statistical Software*, 11(1), 1-20.
-
-
-
-
-

--- a/man/rmd/num_comp.Rmd
+++ b/man/rmd/num_comp.Rmd
@@ -1,0 +1,11 @@
+```{r, include = FALSE}
+low_range <- paste0("\`", prefix, 1, "\` - \`", prefix, 9, "\`")
+high_range <- paste0("\`", prefix, 001, "\` - \`", prefix, 101, "\`")
+```
+
+The argument `num_comp` controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with `prefix` and a 
+sequence of numbers. The variable names are padded with zeros. For example, if 
+`num_comp < 10`, their names will be `r low_range`. If `num_comp = 101`, 
+the names would be `r high_range`.

--- a/man/step_ica.Rd
+++ b/man/step_ica.Rd
@@ -95,14 +95,12 @@ methodology (see reference below). This step requires the
 \pkg{dimRed} and \pkg{fastICA} packages. If not installed, the
 step will stop with a note about installing these packages.
 
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num_comp < 10}, their names will be \code{IC1} - \code{IC9}.
-If \code{num_comp = 101}, the names would be \code{IC001} -
-\code{IC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{IC1} - \code{IC9}. If \code{num_comp = 101},
+the names would be \code{IC1} - \code{IC101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with columns

--- a/man/step_kpca.Rd
+++ b/man/step_kpca.Rd
@@ -98,13 +98,12 @@ As with ordinary PCA, it is important to center and scale the variables
 prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
 this purpose).
 
-The argument \code{num_comp} controls the number of components that will be
-retained; the original variables that are used to derive the components are
-removed from the data when \code{keep_original_cols = FALSE}. The new components
-will have names that begin with \code{prefix} and a sequence of numbers. The
-variable names are padded with zeros. For example, if \code{num_comp < 10}, the
-new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
-\code{kPC001} - \code{kPC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101},
+the names would be \code{kPC1} - \code{kPC101}.
 }
 \section{tidy() results}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column

--- a/man/step_kpca_poly.Rd
+++ b/man/step_kpca_poly.Rd
@@ -90,13 +90,12 @@ As with ordinary PCA, it is important to center and scale the variables
 prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
 this purpose).
 
-The argument \code{num_comp} controls the number of components that will be
-retained; the original variables that are used to derive the components are
-removed from the data when \code{keep_original_cols = FALSE}. The new components
-will have names that begin with \code{prefix} and a sequence of numbers. The
-variable names are padded with zeros. For example, if \code{num_comp < 10}, the
-new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
-\code{kPC001} - \code{kPC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101},
+the names would be \code{kPC1} - \code{kPC101}.
 }
 \section{tidy() results}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column

--- a/man/step_kpca_rbf.Rd
+++ b/man/step_kpca_rbf.Rd
@@ -88,13 +88,12 @@ As with ordinary PCA, it is important to center and scale the variables
 prior to computing PCA components (\code{\link[=step_normalize]{step_normalize()}} can be used for
 this purpose).
 
-The argument \code{num_comp} controls the number of components that will be
-retained; the original variables that are used to derive the components are
-removed from the data when \code{keep_original_cols = FALSE}. The new components
-will have names that begin with \code{prefix} and a sequence of numbers. The
-variable names are padded with zeros. For example, if \code{num_comp < 10}, the
-new names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101}, the names would be
-\code{kPC001} - \code{kPC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{kPC1} - \code{kPC9}. If \code{num_comp = 101},
+the names would be \code{kPC1} - \code{kPC101}.
 }
 \section{tidy() results}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column

--- a/man/step_nnmf.Rd
+++ b/man/step_nnmf.Rd
@@ -91,14 +91,12 @@ Non-negative matrix factorization computes latent components that
 have non-negative values and take into account that the original data
 have non-negative values.
 
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num < 10}, their names will be \code{NNMF1} - \code{NNMF9}.
-If \code{num = 101}, the names would be \code{NNMF001} -
-\code{NNMF101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{NNMF1} - \code{NNMF9}. If \code{num_comp = 101},
+the names would be \code{NNMF1} - \code{NNMF101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column

--- a/man/step_nnmf_sparse.Rd
+++ b/man/step_nnmf_sparse.Rd
@@ -83,12 +83,12 @@ Non-negative matrix factorization computes latent components that
 have non-negative values and take into account that the original data have
 non-negative values.
 
-The argument \code{num_comp} controls the number of components that will be
-retained (the original variables that are used to derive the components are
-removed from the data). The new components will have names that begin with
-\code{prefix} and a sequence of numbers. The variable names are padded with
-zeros. For example, if \code{num < 10}, their names will be \code{NNMF1} - \code{NNMF9}. If
-\code{num = 101}, the names would be \code{NNMF001} - \code{NNMF101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{NNMF1} - \code{NNMF9}. If \code{num_comp = 101},
+the names would be \code{NNMF1} - \code{NNMF101}.
 }
 \section{Tidying}{
 When you \code{\link[=tidy.recipe]{tidy()}} this step, a tibble with column

--- a/man/step_pca.Rd
+++ b/man/step_pca.Rd
@@ -94,14 +94,12 @@ the PCA calculation. This can be changed using the
 \code{options} argument or by using \code{\link[=step_center]{step_center()}}
 and \code{\link[=step_scale]{step_scale()}}.
 
-The argument \code{num_comp} controls the number of components that
-will be retained (the original variables that are used to derive
-the components are removed from the data). The new components
-will have names that begin with \code{prefix} and a sequence of
-numbers. The variable names are padded with zeros. For example,
-if \code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}.
-If \code{num_comp = 101}, the names would be \code{PC001} -
-\code{PC101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{PC1} - \code{PC9}. If \code{num_comp = 101},
+the names would be \code{PC1} - \code{PC101}.
 
 Alternatively, \code{threshold} can be used to determine the
 number of components that are required to capture a specified

--- a/man/step_pls.Rd
+++ b/man/step_pls.Rd
@@ -93,12 +93,12 @@ the new features.
 This step requires the Bioconductor \pkg{mixOmics} package. If not installed, the
 step will stop with a note about installing the package.
 
-The argument \code{num_comp} controls the number of components that will
-be retained (the original variables that are used to derive the
-components are removed from the data). The new components will
-have names that begin with \code{prefix} and a sequence of numbers.
-The variable names are padded with zeros. For example, if \code{num_comp < 10}, their names will be \code{PLS1} - \code{PLS9}. If \code{num_comp = 101}, the
-names would be \code{PLS001} - \code{PLS101}.
+The argument \code{num_comp} controls the number of components that will be retained
+(the original variables that are used to derive the components are removed from
+the data). The new components will have names that begin with \code{prefix} and a
+sequence of numbers. The variable names are padded with zeros. For example, if
+\code{num_comp < 10}, their names will be \code{PLS1} - \code{PLS9}. If \code{num_comp = 101},
+the names would be \code{PLS1} - \code{PLS101}.
 
 Sparsity can be encouraged using the \code{predictor_prop} parameter. This affects
 each PLS component, and indicates the maximum proportion of predictors with


### PR DESCRIPTION
This PR uses `knitr::knit_child()` to refactor the documented section on how number prefixes work with functions that take `num_comp` arguments