### PR TITLE
Unify tests for keep_original_cols arguments

### DIFF
--- a/tests/testthat/_snaps/bs.md
+++ b/tests/testthat/_snaps/bs.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_bs_1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_bs()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * B-splines on: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_bs()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/bs.md
+++ b/tests/testthat/_snaps/bs.md
@@ -8,6 +8,15 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_bs_1
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_bs()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -8,10 +8,10 @@
       ! Name collision occured. The following variable names already exists:
       i  Dan_year
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      date_rec <- prep(date_rec, training = examples, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_date()` after this recipe was created.

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  Dan_year
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_date()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * Date features from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_date()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -120,15 +120,6 @@
       ! Name collision occured. The following variable names already exists:
       i  Species_versicolor
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_dummy()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -163,6 +154,15 @@
       
       -- Operations 
       * Dummy variables from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_dummy()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -120,10 +120,10 @@
       ! Name collision occured. The following variable names already exists:
       i  Species_versicolor
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      dummy_trained <- prep(dummy, training = sacr_fac, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_dummy()` after this recipe was created.

--- a/tests/testthat/_snaps/dummy_extract.md
+++ b/tests/testthat/_snaps/dummy_extract.md
@@ -55,6 +55,15 @@
       -- Operations 
       * Extract patterns from: medium | Trained, ignored weights
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_dummy_extract()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy_extract.md
+++ b/tests/testthat/_snaps/dummy_extract.md
@@ -55,15 +55,6 @@
       -- Operations 
       * Extract patterns from: medium | Trained, ignored weights
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_dummy_extract()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -98,6 +89,15 @@
       
       -- Operations 
       * Extract patterns from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_dummy_extract()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/dummy_multi_choice.md
+++ b/tests/testthat/_snaps/dummy_multi_choice.md
@@ -17,6 +17,15 @@
       ! Name collision occured. The following variable names already exists:
       i  Species_setosa
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_dummy_multi_choice()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy_multi_choice.md
+++ b/tests/testthat/_snaps/dummy_multi_choice.md
@@ -17,15 +17,6 @@
       ! Name collision occured. The following variable names already exists:
       i  Species_setosa
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_dummy_multi_choice()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -60,6 +51,15 @@
       
       -- Operations 
       * Multi-choice dummy variables from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_dummy_multi_choice()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -95,6 +95,15 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_sin_1
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_harmonic()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -95,15 +95,6 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_sin_1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_harmonic()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -138,6 +129,15 @@
       
       -- Operations 
       * Harmonic numeric variables for: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_harmonic()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/holiday.md
+++ b/tests/testthat/_snaps/holiday.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  day_Easter
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_holiday()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * Holiday features from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_holiday()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/holiday.md
+++ b/tests/testthat/_snaps/holiday.md
@@ -8,10 +8,10 @@
       ! Name collision occured. The following variable names already exists:
       i  day_Easter
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      holiday_rec <- prep(holiday_rec, training = test_data, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_holiday()` after this recipe was created.

--- a/tests/testthat/_snaps/ica.md
+++ b/tests/testthat/_snaps/ica.md
@@ -28,15 +28,6 @@
       ! Name collision occured. The following variable names already exists:
       i  IC1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_ica()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -71,6 +62,15 @@
       
       -- Operations 
       * ICA extraction with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_ica()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/ica.md
+++ b/tests/testthat/_snaps/ica.md
@@ -28,6 +28,15 @@
       ! Name collision occured. The following variable names already exists:
       i  IC1
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_ica()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/isomap.md
+++ b/tests/testthat/_snaps/isomap.md
@@ -42,16 +42,6 @@
       ! Name collision occured. The following variable names already exists:
       i  Isomap1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Message
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_isomap()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -86,6 +76,16 @@
       
       -- Operations 
       * Isomap approximation with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Message
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_isomap()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/isomap.md
+++ b/tests/testthat/_snaps/isomap.md
@@ -42,10 +42,10 @@
       ! Name collision occured. The following variable names already exists:
       i  Isomap1
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      im_trained <- prep(im_rec, training = dat1, verbose = FALSE)
+      rec <- prep(rec)
     Message
     Condition
       Warning:

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -33,10 +33,10 @@
       -- Operations 
       * Kernel PCA extraction with: X2, X3, X4, X5, X6 | Trained
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_kpca()` after this recipe was created.

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -33,15 +33,6 @@
       -- Operations 
       * Kernel PCA extraction with: X2, X3, X4, X5, X6 | Trained
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_kpca()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -76,6 +67,15 @@
       
       -- Operations 
       * Kernel PCA extraction with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_kpca()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/kpca_poly.md
+++ b/tests/testthat/_snaps/kpca_poly.md
@@ -27,15 +27,6 @@
       ! Name collision occured. The following variable names already exists:
       i  kPC1
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -70,6 +61,15 @@
       
       -- Operations 
       * Polynomial kernel PCA extraction with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/kpca_rbf.md
+++ b/tests/testthat/_snaps/kpca_rbf.md
@@ -27,13 +27,13 @@
       ! Name collision occured. The following variable names already exists:
       i  kPC1
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
-      'keep_original_cols' was added to `step_kpca_poly()` after this recipe was created.
+      'keep_original_cols' was added to `step_kpca_rbf()` after this recipe was created.
       Regenerate your recipe to avoid this warning.
 
 # empty printing

--- a/tests/testthat/_snaps/kpca_rbf.md
+++ b/tests/testthat/_snaps/kpca_rbf.md
@@ -27,15 +27,6 @@
       ! Name collision occured. The following variable names already exists:
       i  kPC1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_kpca_rbf()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -70,6 +61,15 @@
       
       -- Operations 
       * RBF kernel PCA extraction with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_kpca_rbf()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/nnmf_sparse.md
+++ b/tests/testthat/_snaps/nnmf_sparse.md
@@ -8,6 +8,15 @@
       ! Name collision occured. The following variable names already exists:
       i  NNMF1
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_nnmf_sparse()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/nnmf_sparse.md
+++ b/tests/testthat/_snaps/nnmf_sparse.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  NNMF1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_nnmf_sparse()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * No non-negative matrix factorization was extracted from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_nnmf_sparse()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/ns.md
+++ b/tests/testthat/_snaps/ns.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_ns_1
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_ns()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * Natural splines on: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_ns()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/ns.md
+++ b/tests/testthat/_snaps/ns.md
@@ -8,6 +8,15 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_ns_1
 
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_ns()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/pca.md
+++ b/tests/testthat/_snaps/pca.md
@@ -96,15 +96,6 @@
       -- Operations 
       * PCA extraction with: carbon, hydrogen, oxygen, ... | Trained, ignored weights
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_pca()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -139,6 +130,15 @@
       
       -- Operations 
       * No PCA components were extracted from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_pca()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/pca.md
+++ b/tests/testthat/_snaps/pca.md
@@ -56,15 +56,6 @@
       ! Name collision occured. The following variable names already exists:
       i  PC1
 
-# can prep recipes with no keep_original_cols
-
-    Code
-      pca_extract_trained <- prep(pca_extract, training = biomass_tr, verbose = FALSE)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_pca()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # case weights
 
     Code
@@ -104,6 +95,15 @@
       
       -- Operations 
       * PCA extraction with: carbon, hydrogen, oxygen, ... | Trained, ignored weights
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_pca()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # empty printing
 

--- a/tests/testthat/_snaps/pls.md
+++ b/tests/testthat/_snaps/pls.md
@@ -35,10 +35,10 @@
       ! The `preserve` argument of `step_pls()` was deprecated in recipes 0.1.16 and is now defunct.
       i Please use the `keep_original_cols` argument instead.
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      pls_trained <- prep(pls_rec, training = biom_tr, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_pls()` after this recipe was created.

--- a/tests/testthat/_snaps/pls.md
+++ b/tests/testthat/_snaps/pls.md
@@ -35,15 +35,6 @@
       ! The `preserve` argument of `step_pls()` was deprecated in recipes 0.1.16 and is now defunct.
       i Please use the `keep_original_cols` argument instead.
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_pls()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -78,6 +69,15 @@
       
       -- Operations 
       * PLS feature extraction with: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_pls()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -35,10 +35,10 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_o_disp
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
-      prep1 <- prep(rec1, training = ex_dat, verbose = FALSE)
+      rec <- prep(rec)
     Condition
       Warning:
       'keep_original_cols' was added to `step_ratio()` after this recipe was created.

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -35,15 +35,6 @@
       ! Name collision occured. The following variable names already exists:
       i  mpg_o_disp
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_ratio()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -78,6 +69,15 @@
       
       -- Operations 
       * Ratios from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_ratio()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/time.md
+++ b/tests/testthat/_snaps/time.md
@@ -8,7 +8,7 @@
       ! Name collision occured. The following variable names already exists:
       i  time_hour
 
-# can prep recipes with no keep_original_cols
+# keep_original_cols - can prep recipes with it missing
 
     Code
       rec <- prep(rec)

--- a/tests/testthat/_snaps/time.md
+++ b/tests/testthat/_snaps/time.md
@@ -8,15 +8,6 @@
       ! Name collision occured. The following variable names already exists:
       i  time_hour
 
-# keep_original_cols - can prep recipes with it missing
-
-    Code
-      rec <- prep(rec)
-    Condition
-      Warning:
-      'keep_original_cols' was added to `step_time()` after this recipe was created.
-      Regenerate your recipe to avoid this warning.
-
 # empty printing
 
     Code
@@ -51,6 +42,15 @@
       
       -- Operations 
       * Time features from: <none> | Trained
+
+# keep_original_cols - can prep recipes with it missing
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_time()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
 
 # printing
 

--- a/tests/testthat/_snaps/time.md
+++ b/tests/testthat/_snaps/time.md
@@ -8,6 +8,15 @@
       ! Name collision occured. The following variable names already exists:
       i  time_hour
 
+# can prep recipes with no keep_original_cols
+
+    Code
+      rec <- prep(rec)
+    Condition
+      Warning:
+      'keep_original_cols' was added to `step_time()` after this recipe was created.
+      Regenerate your recipe to avoid this warning.
+
 # empty printing
 
     Code

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -123,7 +123,7 @@ test_that("keep_original_cols works", {
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   rec <- recipe(~ mpg, mtcars) %>%
     step_bs(all_predictors())
 

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -97,48 +97,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("mpg_bs_1", "mpg_bs_2", "mpg_bs_3")
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_bs(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_bs(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_bs(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -188,6 +146,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("mpg_bs_1", "mpg_bs_2", "mpg_bs_3")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_bs(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_bs(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_bs(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -181,48 +181,6 @@ test_that("can bake and recipes with no locale", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("Dan_dow", "Dan_month", "Dan_year")
-
-  rec <- recipe(~ Dan, examples) %>%
-    step_date(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ Dan, examples) %>%
-    step_date(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("Dan", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ Dan, examples) %>%
-    step_date(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = examples),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -278,6 +236,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("Dan_dow", "Dan_month", "Dan_year")
+
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("Dan", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = examples),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -103,19 +103,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  date_rec <- recipe(~ Dan + Stefan, examples) %>%
-    step_date(all_predictors(), features = feats, keep_original_cols = FALSE)
-
-  date_rec <- prep(date_rec, training = examples)
-  date_res <- bake(date_rec, new_data = examples)
-
-  expect_equal(
-    colnames(date_res),
-    c(paste0("Dan_", feats), paste0("Stefan_", feats))
-  )
-})
-
 test_that("locale argument have recipe work in different locale", {
   old_locale <- Sys.getlocale("LC_TIME")
   withr::defer(Sys.setlocale("LC_TIME", old_locale))
@@ -194,18 +181,44 @@ test_that("can bake and recipes with no locale", {
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
-  date_rec <- recipe(~ Dan + Stefan, examples) %>%
-    step_date(all_predictors(), features = feats, keep_original_cols = FALSE)
+test_that("keep_original_cols works", {
+  new_names <- c("Dan_dow", "Dan_month", "Dan_year")
 
-  date_rec$steps[[1]]$keep_original_cols <- NULL
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("Dan", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ Dan, examples) %>%
+    step_date(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
 
   expect_snapshot(
-    date_rec <- prep(date_rec, training = examples, verbose = FALSE)
+    rec <- prep(rec)
   )
 
   expect_error(
-    date_res <- bake(date_rec, new_data = examples, all_predictors()),
+    bake(rec, new_data = examples),
     NA
   )
 })

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -325,48 +325,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("Species_versicolor", "Species_virginica")
-
-  rec <- recipe(~ Species, iris) %>%
-    step_dummy(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ Species, iris) %>%
-    step_dummy(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("Species", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ Species, iris) %>%
-    step_dummy(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = iris),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -415,6 +373,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("Species_versicolor", "Species_virginica")
+
+  rec <- recipe(~ Species, iris) %>%
+    step_dummy(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ Species, iris) %>%
+    step_dummy(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("Species", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ Species, iris) %>%
+    step_dummy(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = iris),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-dummy_extract.R
+++ b/tests/testthat/test-dummy_extract.R
@@ -296,50 +296,6 @@ test_that("case weights", {
   expect_snapshot(dummy_prepped)
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("colors_", c("blue", "red", "white", "other"))
-
-  rec <- recipe(~ colors, data = color_examples) %>%
-    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
-                       keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ colors, data = color_examples) %>%
-    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
-                       keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("colors", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ colors, data = color_examples) %>%
-    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')")
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = color_examples),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -389,6 +345,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("colors_", c("blue", "red", "white", "other"))
+
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
+                       keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
+                       keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("colors", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')")
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = color_examples),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-dummy_extract.R
+++ b/tests/testthat/test-dummy_extract.R
@@ -296,6 +296,50 @@ test_that("case weights", {
   expect_snapshot(dummy_prepped)
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("colors_", c("blue", "red", "white", "other"))
+
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
+                       keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')",
+                       keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("colors", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ colors, data = color_examples) %>%
+    step_dummy_extract(colors, pattern = "(?<=')[^',]+(?=')")
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = color_examples),
+    NA
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-dummy_multi_choice.R
+++ b/tests/testthat/test-dummy_multi_choice.R
@@ -133,48 +133,6 @@ test_that("factor levels are preserved", {
   expect_identical(ncol(data1), ncol(data2))
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("lang_1_", c("Armenian", "English", "Spanish"))
-
-  rec <- recipe(~ lang_1, data = languages) %>%
-    step_dummy_multi_choice(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ lang_1, data = languages) %>%
-    step_dummy_multi_choice(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("lang_1", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ lang_1, data = languages) %>%
-    step_dummy_multi_choice(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = languages),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -224,6 +182,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("lang_1_", c("Armenian", "English", "Spanish"))
+
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("lang_1", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = languages),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-dummy_multi_choice.R
+++ b/tests/testthat/test-dummy_multi_choice.R
@@ -133,6 +133,48 @@ test_that("factor levels are preserved", {
   expect_identical(ncol(data1), ncol(data2))
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("lang_1_", c("Armenian", "English", "Spanish"))
+
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("lang_1", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ lang_1, data = languages) %>%
+    step_dummy_multi_choice(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = languages),
+    NA
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-harmonic.R
+++ b/tests/testthat/test-harmonic.R
@@ -104,26 +104,6 @@ test_that("harmonic frequencies", {
   expect_equal(ncol(rec), 7)
 })
 
-
-test_that("harmonic keep_original_cols", {
-  harmonic_dat <- tibble(
-    osc = sin(2 * pi * x_second / (3600 * 6)),
-    time_var = x_second
-  )
-
-  rec <- recipe(osc ~ time_var, data = harmonic_dat) %>%
-    step_harmonic(time_var,
-      frequency = c(1, 1.93, 2),
-      cycle_size = 86400,
-      keep_original_cols = TRUE
-    ) %>%
-    prep() %>%
-    bake(new_data = NULL)
-
-  expect_equal(ncol(rec), 8)
-})
-
-
 test_that("harmonic phase", {
   harmonic_dat_1 <- tibble(
     osc = sin(2 * pi * x_second / 86400),
@@ -434,6 +414,50 @@ test_that("tunable", {
   expect_equal(
     names(rec_param),
     c("name", "call_info", "source", "component", "component_id")
+  )
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("mpg_sin_1", "mpg_cos_1")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
+                  keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
+                  keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5)
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
   )
 })
 

--- a/tests/testthat/test-harmonic.R
+++ b/tests/testthat/test-harmonic.R
@@ -417,50 +417,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("mpg_sin_1", "mpg_cos_1")
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
-                  keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
-                  keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5)
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -525,6 +481,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("mpg_sin_1", "mpg_cos_1")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
+                  keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5,
+                  keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_harmonic(all_predictors(), frequency = 3, cycle_size = 2.5)
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-holiday.R
+++ b/tests/testthat/test-holiday.R
@@ -183,43 +183,46 @@ test_that("check_name() is used", {
   )
 })
 
-holiday_rec <- recipe(~day, test_data) %>%
-  step_holiday(all_predictors(), holidays = exp_dates$holiday)
-
-holiday_rec <- prep(holiday_rec, training = test_data)
-
 test_that("keep_original_cols works", {
-  holiday_rec <- recipe(~day, test_data) %>%
-    step_holiday(all_predictors(),
-      holidays = exp_dates$holiday,
-      keep_original_cols = FALSE
-    )
+  new_names <- c("day_ChristmasDay", "day_USMemorialDay", "day_Easter")
 
-  holiday_rec <- prep(holiday_rec, training = test_data)
-  holiday_ind <- bake(holiday_rec, test_data)
+  rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday,
+                 keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(holiday_ind),
-    c(
-      "day_ChristmasDay",
-      "day_USMemorialDay",
-      "day_Easter"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday,
+                 keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("day", new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
-  holiday_rec <- recipe(~day, test_data) %>%
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <-  recipe(~day, test_data) %>%
     step_holiday(all_predictors(), holidays = exp_dates$holiday)
 
-  holiday_rec$steps[[1]]$keep_original_cols <- NULL
+  rec$steps[[1]]$keep_original_cols <- NULL
 
   expect_snapshot(
-    holiday_rec <- prep(holiday_rec, training = test_data, verbose = FALSE)
+    rec <- prep(rec)
   )
 
   expect_error(
-    holiday_ind <- bake(holiday_rec, new_data = test_data, all_predictors()),
+    bake(rec, new_data = test_data),
     NA
   )
 })

--- a/tests/testthat/test-holiday.R
+++ b/tests/testthat/test-holiday.R
@@ -183,50 +183,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("day_ChristmasDay", "day_USMemorialDay", "day_Easter")
-
-  rec <- recipe(~day, test_data) %>%
-    step_holiday(all_predictors(), holidays = exp_dates$holiday,
-                 keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~day, test_data) %>%
-    step_holiday(all_predictors(), holidays = exp_dates$holiday,
-                 keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("day", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <-  recipe(~day, test_data) %>%
-    step_holiday(all_predictors(), holidays = exp_dates$holiday)
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -276,6 +232,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("day_ChristmasDay", "day_USMemorialDay", "day_Easter")
+
+  rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday,
+                 keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday,
+                 keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("day", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <-  recipe(~day, test_data) %>%
+    step_holiday(all_predictors(), holidays = exp_dates$holiday)
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = test_data),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -127,56 +127,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  skip_if_not_installed("dimRed")
-  skip_if_not_installed("fastICA")
-  skip_if_not_installed("RSpectra")
-
-  new_names <- c("IC1", "IC2", "IC3", "IC4", "IC5")
-
-  rec <- recipe(~ ., mtcars) %>%
-    step_ica(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ ., mtcars) %>%
-    step_ica(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c(colnames(mtcars), new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  skip_if_not_installed("dimRed")
-  skip_if_not_installed("fastICA")
-  skip_if_not_installed("RSpectra")
-
-  rec <- recipe(~ ., mtcars) %>%
-    step_ica(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_ica(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
@@ -260,6 +210,56 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("dimRed")
+  skip_if_not_installed("fastICA")
+  skip_if_not_installed("RSpectra")
+
+  new_names <- c("IC1", "IC2", "IC3", "IC4", "IC5")
+
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c(colnames(mtcars), new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("dimRed")
+  skip_if_not_installed("fastICA")
+  skip_if_not_installed("RSpectra")
+
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -132,41 +132,47 @@ test_that("keep_original_cols works", {
   skip_if_not_installed("fastICA")
   skip_if_not_installed("RSpectra")
 
-  ica_extract <- rec %>%
-    step_ica(carbon, hydrogen, oxygen, nitrogen, sulfur,
-      num_comp = 2,
-      id = "", keep_original_cols = TRUE
-    )
+  new_names <- c("IC1", "IC2", "IC3", "IC4", "IC5")
 
-  set.seed(12)
-  ica_extract_trained <- prep(ica_extract, training = biomass_tr, verbose = FALSE)
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors(), keep_original_cols = FALSE)
 
-  ica_pred <- bake(ica_extract_trained, new_data = biomass_te, all_predictors())
-
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(ica_pred),
-    c(
-      "carbon", "hydrogen", "oxygen", "nitrogen", "sulfur",
-      "IC1", "IC2"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c(colnames(mtcars), new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_if_not_installed("dimRed")
   skip_if_not_installed("fastICA")
   skip_if_not_installed("RSpectra")
 
-  ica_extract <- rec %>%
-    step_ica(carbon, hydrogen, oxygen, nitrogen, sulfur, num_comp = 2, id = "")
+  rec <- recipe(~ ., mtcars) %>%
+    step_ica(all_predictors())
 
-  ica_extract$steps[[1]]$keep_original_cols <- NULL
+  rec$steps[[1]]$keep_original_cols <- NULL
 
-  ica_extract_trained <- prep(ica_extract, training = biomass_tr, verbose = FALSE)
+  expect_snapshot(
+    rec <- prep(rec)
+  )
 
   expect_error(
-    ica_pred <- bake(ica_extract_trained, new_data = biomass_te, all_predictors()),
+    bake(rec, new_data = mtcars),
     NA
   )
 })

--- a/tests/testthat/test-isomap.R
+++ b/tests/testthat/test-isomap.R
@@ -149,23 +149,34 @@ test_that("keep_original_cols works", {
   skip_if_not_installed("dimRed")
   skip_if(getRversion() <= "3.4.4")
 
-  im_rec <- rec %>%
-    step_isomap(x1, x2, x3, neighbors = 3, num_terms = 3, id = "", keep_original_cols = TRUE)
+  new_names <- c("Isomap1", "Isomap2", "Isomap3")
 
-  im_trained <- prep(im_rec, training = dat1, verbose = FALSE)
+  rec <- recipe(~., data = dat1) %>%
+    step_isomap(x1, x2, x3, neighbors = 3, num_terms = 3,
+                keep_original_cols = FALSE)
 
-  im_pred <- bake(im_trained, new_data = dat2)
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(im_pred),
-    c(
-      "x1", "x2", "x3",
-      "Isomap1", "Isomap2", "Isomap3"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~., data = dat1) %>%
+    step_isomap(x1, x2, x3, neighbors = 3, num_terms = 3,
+                keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("x1", "x2", "x3", new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_on_cran()
   skip_if_not_installed("RSpectra")
   skip_if_not_installed("igraph")
@@ -173,18 +184,18 @@ test_that("can prep recipes with no keep_original_cols", {
   skip_if_not_installed("dimRed")
   skip_if(getRversion() <= "3.4.4")
 
-  im_rec <- rec %>%
+  rec <- recipe(~., data = dat1) %>%
     step_isomap(x1, x2, x3, neighbors = 3, num_terms = 3)
 
-  im_rec$steps[[1]]$keep_original_cols <- NULL
+  rec$steps[[1]]$keep_original_cols <- NULL
 
   expect_snapshot(
-    im_trained <- prep(im_rec, training = dat1, verbose = FALSE),
+    rec <- prep(rec),
     transform = scrub_timestamp
   )
 
   expect_error(
-    im_pred <- bake(im_trained, new_data = dat2, all_predictors()),
+    bake(rec, new_data = dat1),
     NA
   )
 })

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -79,51 +79,6 @@ test_that("No kPCA comps", {
   expect_snapshot(pca_extract)
 })
 
-
-test_that("keep_original_cols works", {
-  skip_if_not_installed("kernlab")
-  new_names <- paste0("kPC", 1:5)
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  skip_if_not_installed("kernlab")
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
@@ -184,6 +139,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expected)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -82,41 +82,45 @@ test_that("No kPCA comps", {
 
 test_that("keep_original_cols works", {
   skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
 
-  kpca_rec <- rec %>%
-    step_kpca(X2, X3, X4, X5, X6, id = "", keep_original_cols = TRUE)
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors(), keep_original_cols = FALSE)
 
-  kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-
-  pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors())
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(pca_pred),
-    c(
-      "X2", "X3", "X4", "X5", "X6",
-      "kPC1", "kPC2", "kPC3", "kPC4", "kPC5"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_if_not_installed("kernlab")
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca(all_predictors())
 
-  kpca_rec <- rec %>%
-    step_kpca(X2, X3, X4, X5, X6, id = "")
+  rec$steps[[1]]$keep_original_cols <- NULL
 
-  kpca_rec$steps[[1]]$keep_original_cols <- NULL
-
-  suppressWarnings(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+  expect_snapshot(
+    rec <- prep(rec)
   )
 
   expect_error(
-    pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
+    bake(rec, new_data = mtcars),
     NA
-  )
-  expect_snapshot(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )
 })
 

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -86,50 +86,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  skip_if_not_installed("kernlab")
-  new_names <- paste0("kPC", 1:5)
-
-  rec <- recipe(~ ., tr_dat) %>%
-    step_kpca_poly(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ ., tr_dat) %>%
-    step_kpca_poly(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c(colnames(tr_dat), new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  skip_if_not_installed("kernlab")
-  rec <- recipe(~ ., tr_dat) %>%
-    step_kpca_poly(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = tr_dat),
-    NA
-  )
-})
-
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_poly(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
@@ -197,6 +153,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
+
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c(colnames(tr_dat), new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = tr_dat),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -88,41 +88,45 @@ test_that("tunable", {
 
 test_that("keep_original_cols works", {
   skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
 
-  kpca_rec <- rec %>%
-    step_kpca_poly(X2, X3, X4, X5, X6, id = "", keep_original_cols = TRUE)
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors(), keep_original_cols = FALSE)
 
-  kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-
-  pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors())
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(pca_pred),
-    c(
-      "X2", "X3", "X4", "X5", "X6",
-      "kPC1", "kPC2", "kPC3", "kPC4", "kPC5"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c(colnames(tr_dat), new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_if_not_installed("kernlab")
+  rec <- recipe(~ ., tr_dat) %>%
+    step_kpca_poly(all_predictors())
 
-  kpca_rec <- rec %>%
-    step_kpca_poly(X2, X3, X4, X5, X6, id = "")
+  rec$steps[[1]]$keep_original_cols <- NULL
 
-  kpca_rec$steps[[1]]$keep_original_cols <- NULL
-
-  suppressWarnings(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+  expect_snapshot(
+    rec <- prep(rec)
   )
 
   expect_error(
-    pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
+    bake(rec, new_data = tr_dat),
     NA
-  )
-  expect_snapshot(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE),
   )
 })
 

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -86,51 +86,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  skip_if_not_installed("kernlab")
-  new_names <- paste0("kPC", 1:5)
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca_rbf(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca_rbf(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  skip_if_not_installed("kernlab")
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_kpca_rbf(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
-
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%
     step_kpca_rbf(all_predictors(), num_comp = 0, keep_original_cols = FALSE) %>%
@@ -192,6 +147,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("kernlab")
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -88,44 +88,48 @@ test_that("tunable", {
 
 test_that("keep_original_cols works", {
   skip_if_not_installed("kernlab")
+  new_names <- paste0("kPC", 1:5)
 
-  kpca_rec <- rec %>%
-    step_kpca_rbf(X2, X3, X4, X5, X6, id = "", keep_original_cols = TRUE)
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors(), keep_original_cols = FALSE)
 
-  kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-
-  pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors())
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(pca_pred),
-    c(
-      "X2", "X3", "X4", "X5", "X6",
-      "kPC1", "kPC2", "kPC3", "kPC4", "kPC5"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_if_not_installed("kernlab")
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_kpca_rbf(all_predictors())
 
-  kpca_rec <- rec %>%
-    step_kpca_poly(X2, X3, X4, X5, X6, id = "")
+  rec$steps[[1]]$keep_original_cols <- NULL
 
-  kpca_rec$steps[[1]]$keep_original_cols <- NULL
-
-  suppressWarnings(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
+  expect_snapshot(
+    rec <- prep(rec)
   )
 
   expect_error(
-    pca_pred <- bake(kpca_trained, new_data = te_dat, all_predictors()),
+    bake(rec, new_data = mtcars),
     NA
   )
-
-  expect_snapshot(
-    kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
-  )
 })
+
 
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(~ ., data = mtcars) %>%

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -27,6 +27,50 @@ test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)",
   expect_identical(res, tibble::as_tibble(mtcars))
 })
 
+test_that("keep_original_cols works", {
+  skip_if_not_installed("RcppML")
+  library(Matrix)
+  new_names <- c("NNMF1")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -121,6 +121,8 @@ test_that("keep_original_cols works", {
 })
 
 test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("RcppML")
+  library(Matrix)
   rec <- recipe(~ mpg, mtcars) %>%
     step_nnmf_sparse(all_predictors())
 

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -27,50 +27,6 @@ test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)",
   expect_identical(res, tibble::as_tibble(mtcars))
 })
 
-test_that("keep_original_cols works", {
-  skip_if_not_installed("RcppML")
-  library(Matrix)
-  new_names <- c("NNMF1")
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_nnmf_sparse(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_nnmf_sparse(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_nnmf_sparse(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -134,6 +90,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("RcppML")
+  library(Matrix)
+  new_names <- c("NNMF1")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_nnmf_sparse(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -99,48 +99,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("mpg_ns_1", "mpg_ns_2")
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_ns(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_ns(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_ns(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -190,6 +148,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("mpg_ns_1", "mpg_ns_2")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_ns(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_ns(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_ns(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -125,7 +125,7 @@ test_that("keep_original_cols works", {
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   rec <- recipe(~ mpg, mtcars) %>%
     step_ns(all_predictors())
 

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -250,48 +250,6 @@ test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)",
   expect_identical(res, tibble::as_tibble(mtcars))
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("PC1")
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_pca(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_pca(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_pca(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -348,6 +306,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("PC1")
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_pca(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_pca(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_pca(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -262,34 +262,44 @@ test_that("tunable", {
 
 test_that("keep_original_cols works", {
   skip_if_not_installed("mixOmics")
-  pls_rec <- recipe(HHV ~ ., data = biom_tr) %>%
-    step_pls(all_predictors(), outcome = "HHV", num_comp = 3, keep_original_cols = TRUE)
+  new_names <- c("vs", "PLS1")
 
-  pls_trained <- prep(pls_rec)
-  pls_pred <- bake(pls_trained, new_data = biom_te, all_predictors())
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs", keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(pls_pred),
-    c(
-      "carbon", "hydrogen", "oxygen", "nitrogen", "sulfur",
-      "PLS1", "PLS2", "PLS3"
-    )
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs", keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
   )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
+test_that("keep_original_cols - can prep recipes with it missing", {
   skip_if_not_installed("mixOmics")
-  pls_rec <- recipe(HHV ~ ., data = biom_tr) %>%
-    step_pls(all_predictors(), outcome = "HHV", num_comp = 3)
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs")
 
-  pls_rec$steps[[1]]$keep_original_cols <- NULL
+  rec$steps[[1]]$keep_original_cols <- NULL
 
   expect_snapshot(
-    pls_trained <- prep(pls_rec, training = biom_tr, verbose = FALSE)
+    rec <- prep(rec)
   )
 
   expect_error(
-    pls_pred <- bake(pls_trained, new_data = biom_te, all_predictors()),
+    bake(rec, new_data = mtcars),
     NA
   )
 })

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -260,50 +260,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  skip_if_not_installed("mixOmics")
-  new_names <- c("vs", "PLS1")
-
-  rec <- recipe(vs ~ mpg, mtcars) %>%
-    step_pls(all_predictors(), outcome = "vs", keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(vs ~ mpg, mtcars) %>%
-    step_pls(all_predictors(), outcome = "vs", keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  skip_if_not_installed("mixOmics")
-  rec <- recipe(vs ~ mpg, mtcars) %>%
-    step_pls(all_predictors(), outcome = "vs")
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 test_that("Do nothing for num_comps = 0 and keep_original_cols = FALSE (#1152)", {
   rec <- recipe(carb ~ ., data = mtcars) %>%
     step_pls(all_predictors(), outcome = "carb",
@@ -370,6 +326,50 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  skip_if_not_installed("mixOmics")
+  new_names <- c("vs", "PLS1")
+
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs", keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs", keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  skip_if_not_installed("mixOmics")
+  rec <- recipe(vs ~ mpg, mtcars) %>%
+    step_pls(all_predictors(), outcome = "vs")
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-poly_bernstein.R
+++ b/tests/testthat/test-poly_bernstein.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_poly_bernstein(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_poly_bernstein(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_poly_bernstein() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-poly_bernstein.R
+++ b/tests/testthat/test-poly_bernstein.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_poly_bernstein(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_poly_bernstein(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_poly_bernstein() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_poly_bernstein(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_poly_bernstein(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_poly_bernstein() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -148,35 +148,43 @@ test_that("check_name() is used", {
 })
 
 test_that("keep_original_cols works", {
-  rec1 <- rec %>%
-    step_ratio(x1,
-      denom = denom_vars(all_numeric()),
-      id = "", keep_original_cols = FALSE
-    )
+  new_names <- c("mpg_o_disp")
 
-  rec1 <- prep(rec1, ex_dat, verbose = FALSE)
-  obs1 <- bake(rec1, ex_dat)
-  res1 <- tibble(
-    x5        = factor(letters[1:10]),
-    x1_o_x2   = ex_dat$x1 / ex_dat$x2,
-    x1_o_x3   = ex_dat$x1 / ex_dat$x3,
-    x1_o_x4   = ex_dat$x1 / ex_dat$x4
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
   )
-  expect_equal(res1, obs1)
+
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", "disp", new_names)
+  )
 })
 
-test_that("can prep recipes with no keep_original_cols", {
-  rec1 <- rec %>%
-    step_ratio(x1, denom = denom_vars(all_numeric()), id = "")
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp))
 
-  rec1$steps[[1]]$keep_original_cols <- NULL
+  rec$steps[[1]]$keep_original_cols <- NULL
 
   expect_snapshot(
-    prep1 <- prep(rec1, training = ex_dat, verbose = FALSE)
+    rec <- prep(rec)
   )
 
   expect_error(
-    obs1 <- bake(prep1, new_data = ex_dat, all_predictors()),
+    bake(rec, new_data = mtcars),
     NA
   )
 })

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -147,48 +147,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- c("mpg_o_disp")
-
-  rec <- recipe(~ mpg + disp, mtcars) %>%
-    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg + disp, mtcars) %>%
-    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", "disp", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  rec <- recipe(~ mpg + disp, mtcars) %>%
-    step_ratio(mpg, denom = denom_vars(disp))
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -238,6 +196,48 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- c("mpg_o_disp")
+
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", "disp", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  rec <- recipe(~ mpg + disp, mtcars) %>%
+    step_ratio(mpg, denom = denom_vars(disp))
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = mtcars),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_b(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_b(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_spline_b() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_b(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_b(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_b() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_b(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_b(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_b() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_convex(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_convex(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_spline_convex() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_convex(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_convex(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_convex() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_convex(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_convex(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_convex() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_monotone(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_monotone(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_monotone() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_monotone(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_monotone(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_spline_monotone() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_monotone(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_monotone(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_monotone() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_natural(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_natural(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_spline_natural() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_natural(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_natural(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_natural() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_natural(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_natural(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_natural() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -111,38 +111,6 @@ test_that("tunable", {
   )
 })
 
-test_that("keep_original_cols works", {
-  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_nonnegative(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ mpg, mtcars) %>%
-    step_spline_nonnegative(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("mpg", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  # step_spline_nonnegative() was added after keep_original_cols
-  # Making this test case unlikely
-  expect_true(TRUE)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -192,6 +160,38 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_nonnegative(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_nonnegative(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_nonnegative() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -111,6 +111,38 @@ test_that("tunable", {
   )
 })
 
+test_that("keep_original_cols works", {
+  new_names <- paste0("mpg_", formatC(1:10, width = 2, flag = "0"))
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_nonnegative(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ mpg, mtcars) %>%
+    step_spline_nonnegative(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("mpg", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  # step_spline_nonnegative() was added after keep_original_cols
+  # Making this test case unlikely
+  expect_true(TRUE)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -106,59 +106,6 @@ test_that("check_name() is used", {
     prep(rec, training = dat)
   )
 })
-
-test_that("keep_original_cols works", {
-  examples <- data.frame(
-    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
-      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
-  )
-
-  new_names <- c("times_hour", "times_minute", "times_second")
-
-  rec <- recipe(~ times, examples) %>%
-    step_time(all_predictors(), keep_original_cols = FALSE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    new_names
-  )
-
-  rec <- recipe(~ times, examples) %>%
-    step_time(all_predictors(), keep_original_cols = TRUE)
-
-  rec <- prep(rec)
-  res <- bake(rec, new_data = NULL)
-
-  expect_equal(
-    colnames(res),
-    c("times", new_names)
-  )
-})
-
-test_that("keep_original_cols - can prep recipes with it missing", {
-  examples <- data.frame(
-    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
-      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
-  )
-
-  rec <- recipe(~ times, examples) %>%
-    step_time(all_predictors())
-
-  rec$steps[[1]]$keep_original_cols <- NULL
-
-  expect_snapshot(
-    rec <- prep(rec)
-  )
-
-  expect_error(
-    bake(rec, new_data = examples),
-    NA
-  )
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -215,6 +162,58 @@ test_that("empty selection tidy method works", {
   rec <- prep(rec, mtcars)
 
   expect_identical(tidy(rec, number = 1), expect)
+})
+
+test_that("keep_original_cols works", {
+  examples <- data.frame(
+    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
+      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
+  )
+
+  new_names <- c("times_hour", "times_minute", "times_second")
+
+  rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors(), keep_original_cols = FALSE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("times", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  examples <- data.frame(
+    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
+      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
+  )
+
+  rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = examples),
+    NA
+  )
 })
 
 test_that("printing", {

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -113,15 +113,49 @@ test_that("keep_original_cols works", {
       lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
   )
 
-  date_rec <- recipe(~ times, examples) %>%
+  new_names <- c("times_hour", "times_minute", "times_second")
+
+  rec <- recipe(~ times, examples) %>%
     step_time(all_predictors(), keep_original_cols = FALSE)
 
-  date_rec <- prep(date_rec, training = examples)
-  date_res <- bake(date_rec, new_data = examples)
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
 
   expect_equal(
-    colnames(date_res),
-    paste0("times_", c("hour", "minute", "second"))
+    colnames(res),
+    new_names
+  )
+
+  rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors(), keep_original_cols = TRUE)
+
+  rec <- prep(rec)
+  res <- bake(rec, new_data = NULL)
+
+  expect_equal(
+    colnames(res),
+    c("times", new_names)
+  )
+})
+
+test_that("keep_original_cols - can prep recipes with it missing", {
+  examples <- data.frame(
+    times = lubridate::ymd_hms("2022-05-06 10:01:07") +
+      lubridate::hours(1:5) + lubridate::minutes(1:5) + lubridate::seconds(1:5)
+  )
+
+  rec <- recipe(~ times, examples) %>%
+    step_time(all_predictors())
+
+  rec$steps[[1]]$keep_original_cols <- NULL
+
+  expect_snapshot(
+    rec <- prep(rec)
+  )
+
+  expect_error(
+    bake(rec, new_data = examples),
+    NA
   )
 })
 


### PR DESCRIPTION
This PR aims to make sure the `keep_original_cols` argument as adequate and consistent test coverage.

Appears that all steps were using `keep_original_cols` correctly. Most tests did not tests for one of the two options `keep_original_cols = FALSE` or `keep_original_cols = TRUE`. The tests do now.

Moreover, many tests are now run with slightly simpler code and less data.