### PR TITLE
refactor step_regex() and step_count()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* `step_regex()` and `step_count()` will now informatively error if name collision occurs.
+
 * Fixed bugs where `step_classdist()`, `step_count()`, `step_depth()`,  `step_geodist()`,  `step_interact()`, `step_nnmf_sparse()`, and  `step_regex()` didn't work with empty selection. All steps now leave data unmodified when having empty selections.
 
 * `step_classdist()`, `step_count()` and `step_depth()` no longer returns a column with all `NA`s with empty selections.

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -15,6 +15,16 @@
       Caused by error in `prep()`:
       ! All columns selected for the step should be string, factor, or ordered.
 
+# check_name() is used
+
+    Code
+      prep(rec, training = dat)
+    Condition
+      Error in `step_count()`:
+      Caused by error in `bake()`:
+      ! Name collision occured. The following variable names already exists:
+      i  Sepal.Width
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/regex.md
+++ b/tests/testthat/_snaps/regex.md
@@ -15,6 +15,16 @@
       Caused by error in `prep()`:
       ! All columns selected for the step should be string, factor, or ordered.
 
+# check_name() is used
+
+    Code
+      prep(rec, training = dat)
+    Condition
+      Error in `step_regex()`:
+      Caused by error in `bake()`:
+      ! Name collision occured. The following variable names already exists:
+      i  Sepal.Width
+
 # empty printing
 
     Code

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -55,6 +55,18 @@ test_that("bad selector(s)", {
   )
 })
 
+test_that("check_name() is used", {
+  dat <- iris
+
+  rec <- recipe(~., data = dat) |>
+    step_count(Species, result = "Sepal.Width")
+
+  expect_snapshot(
+    error = TRUE,
+    prep(rec, training = dat)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-regex.R
+++ b/tests/testthat/test-regex.R
@@ -47,6 +47,18 @@ test_that("bad selector(s)", {
   )
 })
 
+test_that("check_name() is used", {
+  dat <- iris
+
+  rec <- recipe(~., data = dat) |>
+    step_regex(Species, result = "Sepal.Width")
+
+  expect_snapshot(
+    error = TRUE,
+    prep(rec, training = dat)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
Related to https://github.com/tidymodels/recipes/pull/1156.

This PR does a small refactor to `step_regex()` and `step_count()` to bring them up to the same standard as #1156.

Further, the steps new use `check_name()`, and will thus error in `result` is set to a name that is in the data set. Previously it would silently overwrite.