### PR TITLE
loopify step_window()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * The `keep_original_cols` argument has been added to `step_classdist()`, `step_count()`, `step_depth()`, `step_geodist()`, `step_indicate_na()`, `step_interact()`, `step_lag()`, `step_poly()`, `step_regex()`, `step_window()`. The default for each step is set to preserve past behavior. This change should mean that every step that produces new columns has the `keep_original_cols` argument.
 
+* `step_window()` now throws an error instead of silently overwriting if `names` argument overlaps with existing columns. (#1172)
+
 # recipes 1.0.6
 
 ## Improvements

--- a/R/window.R
+++ b/R/window.R
@@ -278,6 +278,7 @@ bake.step_window <- function(object, new_data, ...) {
   } else {
     names(new_values) <- object$names
     new_values <- tibble::new_tibble(new_values)
+    new_values <- check_name(new_values, new_data, object, newname = object$names)
     new_data <- vec_cbind(new_data, new_values)
     new_data <- remove_original_cols(new_data, object, col_names)
   }

--- a/R/window.R
+++ b/R/window.R
@@ -257,30 +257,31 @@ roller <- function(x, stat = "mean", window = 3L, na_rm = TRUE) {
 
 #' @export
 bake.step_window <- function(object, new_data, ...) {
-  check_new_data(names(object$columns), object, new_data)
+  col_names <- names(object$columns)
+  check_new_data(col_names, object, new_data)
 
-  for (i in seq(along.with = object$columns)) {
-    if (!is.null(object$names)) {
-      new_data[[object$names[i]]] <-
-        roller(
-          x = new_data[[object$columns[i]]],
-          stat = object$statistic,
-          na_rm = object$na_rm,
-          window = object$size
-        )
-    } else {
-      new_data[[object$columns[i]]] <-
-        roller(
-          x = new_data[[object$columns[i]]],
-          stat = object$statistic,
-          na_rm = object$na_rm,
-          window = object$size
-        )
+  new_values <- list()
+
+  for (col_name in col_names) {
+    new_values[[col_name]] <- roller(
+      x = new_data[[col_name]],
+      stat = object$statistic,
+      na_rm = object$na_rm,
+      window = object$size
+    )
+  }
+
+  if (is.null(object$names)) {
+    for (col_name in col_names) {
+      new_data[[col_name]] <- new_values[[col_name]]
     }
+  } else {
+    names(new_values) <- object$names
+    new_values <- tibble::new_tibble(new_values)
+    new_data <- vec_cbind(new_data, new_values)
+    new_data <- remove_original_cols(new_data, object, col_names)
   }
-  if (!is.null(object$names)) {
-    new_data <- remove_original_cols(new_data, object, names(object$columns))
-  }
+
   new_data
 }
 

--- a/tests/testthat/_snaps/window.md
+++ b/tests/testthat/_snaps/window.md
@@ -90,6 +90,16 @@
       Caused by error in `prep()`:
       ! There were 2 term(s) selected but 1 values for the new features were passed to `names`.
 
+# check_name() is used
+
+    Code
+      prep(rec, training = dat)
+    Condition
+      Error in `step_window()`:
+      Caused by error in `bake()`:
+      ! Name collision occured. The following variable names already exists:
+      i  new_value
+
 # empty printing
 
     Code

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -129,6 +129,8 @@ test_that("tunable", {
 })
 
 test_that("check_name() is used", {
+  skip_if_not_installed("RcppRoll")
+
   dat <- mtcars
   dat$new_value <- dat$mpg
 

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -128,6 +128,19 @@ test_that("tunable", {
   )
 })
 
+test_that("check_name() is used", {
+  dat <- mtcars
+  dat$new_value <- dat$mpg
+
+  rec <- recipe(~ ., data = dat) %>%
+    step_window(mpg, names = "new_value")
+
+  expect_snapshot(
+    error = TRUE,
+    prep(rec, training = dat)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
Ref: https://github.com/tidymodels/recipes/pull/1156

This PR does two things:
- turns `bake.step_window()` more loopy to adhere to #1156 
- adds missing `check_name()`