### PR TITLE
make step_interact() work when formula is passed in a object

### DIFF
--- a/R/interact.R
+++ b/R/interact.R
@@ -145,7 +145,16 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
 
   # make backwards compatible with 1.0.6 (#1138)
   if (!is_formula(x)) {
-    tmp_terms <- as.formula(rlang::as_label(x$terms[[1]]))
+    tmp_terms <- rlang::as_label(x$terms[[1]])
+    if (substr(tmp_terms, 1, 1) == "~") {
+      tmp_terms <- as.formula(tmp_terms)
+    } else {
+      tmp_terms <- rlang::eval_tidy(x$terms[[1]])
+      if (!is_formula(tmp_terms)) {
+        rlang::abort("`term` must be a formula.")
+      }
+    }
+
     environment(tmp_terms) <- environment(x$terms[[1]])
     x$terms <- tmp_terms
   }

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -282,6 +282,26 @@ test_that("missing columns", {
 #   all.equal(te_og, te_new)
 # })
 
+test_that("works when formula is passed in as an object", {
+  rec1 <- recipe(~., data = mtcars) %>%
+    step_interact(terms = ~vs:am, id = "") %>%
+    prep()
+
+  cars_formula <- ~ vs:am
+  rec2 <- recipe(~., data = mtcars) %>%
+    step_interact(terms = cars_formula, id = "") %>%
+    prep()
+
+  expect_identical(rec1, rec2)
+
+  cars_formula <- ~ vs:am
+  rec3 <- recipe(~., data = mtcars) %>%
+    step_interact(terms = !!cars_formula, id = "") %>%
+    prep()
+
+  expect_identical(rec1, rec3)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
In preparation for a CRAN release, I found that the following code no longer working on dev

``` r
library(recipes)

cars_formula <- ~ vs:am

recipe(~., data = mtcars) %>%
  step_interact(terms = cars_formula) %>%
  prep()
#> Error in `step_interact()`:
#> Caused by error in `formula.character()`:
#> ! invalid formula "cars_formula": not a call
```

This PR fixes that regression. There isn't a news bullet since this PR keeps functionality with current CRAN version

