### PR TITLE
Make spline steps work with 1 row bake

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bugs where spline steps (`step_ns()`, `step_bs()`, `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, `step_spline_nonnegative()`) would error if baked with 1 row. (#1191)
+
 # recipes 1.0.7
 
 ## New Steps

--- a/R/bs.R
+++ b/R/bs.R
@@ -132,7 +132,7 @@ bs_statistics <- function(x, args) {
 bs_predict <- function(object, x) {
   xu <- unique(x)
   ru <- predict(object, xu)
-  res <- ru[match(x, xu), ]
+  res <- ru[match(x, xu), , drop = FALSE]
   copy_attrs <- c("class", "degree", "knots", "Boundary.knots", "intercept")
   attributes(res)[copy_attrs] <- attributes(ru)[copy_attrs]
   res

--- a/R/spline_helpers.R
+++ b/R/spline_helpers.R
@@ -45,6 +45,9 @@ spline2_apply <- function(object, new_data) {
   .cl <- rlang::call2(.ns = .ns, .fn = .fn, !!!object, x = rlang::expr(new_data))
   res <- rlang::eval_tidy(.cl)
   res <- apply(res, 2, I)
+  if (length(new_data) == 1) {
+    res <- matrix(res, nrow = 1, dimnames = dimnames(res))
+  }
   colnames(res) <- names0(ncol(res), paste0(nm, "_"))
   tibble::as_tibble(res)
 }

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -97,6 +97,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_bs(disp, deg_free = 3) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -99,7 +99,7 @@ test_that("tunable", {
 
 test_that("works when baked with 1 row", {
   rec <- recipe(mpg ~ ., data = mtcars) %>%
-    step_bs(disp, deg_free = 3) %>%
+    step_bs(disp) %>%
     prep()
 
   expect_no_error(

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -99,6 +99,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_ns(disp, deg_free = 3) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -101,7 +101,7 @@ test_that("tunable", {
 
 test_that("works when baked with 1 row", {
   rec <- recipe(mpg ~ ., data = mtcars) %>%
-    step_ns(disp, deg_free = 3) %>%
+    step_ns(disp) %>%
     prep()
 
   expect_no_error(

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -109,6 +109,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_spline_b(disp) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -109,6 +109,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_spline_convex(disp) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -109,6 +109,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_spline_monotone(disp) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -109,6 +109,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_spline_natural(disp) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -109,6 +109,18 @@ test_that("tunable", {
   )
 })
 
+test_that("works when baked with 1 row", {
+  rec <- recipe(mpg ~ ., data = mtcars) %>%
+    step_spline_nonnegative(disp) %>%
+    prep()
+
+  expect_no_error(
+    res <- bake(rec, mtcars[1, ])
+  )
+
+  expect_identical(nrow(res), 1L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
to close #1191

``` r
library(tidymodels)

ns_rec <- 
  recipe(mpg ~ ., data = mtcars) %>% 
  step_ns(disp, deg_free = 3) %>% 
  prep()

bake(ns_rec, mtcars %>% slice(1))
#> # A tibble: 1 × 13
#>     cyl    hp  drat    wt  qsec    vs    am  gear  carb   mpg disp_ns_1
#>   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>     <dbl>
#> 1     6   110   3.9  2.62  16.5     0     1     4     4    21   -0.0841
#> # ℹ 2 more variables: disp_ns_2 <dbl>, disp_ns_3 <dbl>

ns2_rec <- 
  recipe(mpg ~ ., data = mtcars) %>% 
  step_spline_natural(disp, deg_free = 3) %>% 
  prep()

bake(ns2_rec, mtcars %>% slice(1))
#> # A tibble: 1 × 13
#>     cyl    hp  drat    wt  qsec    vs    am  gear  carb   mpg disp_1 disp_2
#>   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>  <dbl>  <dbl>
#> 1     6   110   3.9  2.62  16.5     0     1     4     4    21  0.521 0.0777
#> # ℹ 1 more variable: disp_3 <dbl>
```

<sup>Created on 2023-08-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>