### PR TITLE
Release Candidate 1.0.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: recipes
 Title: Preprocessing and Feature Engineering Steps for Modeling
-Version: 1.0.7.9000
+Version: 1.0.8
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Hadley", "Wickham", , "hadley@posit.co", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+## Bug Fixes
+
 * Fixed bugs where spline steps (`step_ns()`, `step_bs()`, `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, `step_spline_nonnegative()`) would error if baked with 1 row. (#1191)
 
 # recipes 1.0.7

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# recipes (development version)
+# recipes 1.0.8
 
 ## Bug Fixes
 

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -155,7 +155,7 @@ recipe(mpg ~ ., data = mtcars)  \%>\%
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Error in `step_log()`:
-## Caused by error in `prep()` at recipes/R/recipe.R:437:8:
+## Caused by error in `prep()`:
 ## ! Can't subset columns that don't exist.
 ## x Column `wt` doesn't exist.
 }\if{html}{\out{</div>}}

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,27 +1,27 @@
 # Platform
 
-|field    |value                                          |
-|:--------|:----------------------------------------------|
-|version  |R version 4.3.0 (2023-04-21)                   |
-|os       |macOS Ventura 13.4                             |
-|system   |aarch64, darwin20                              |
-|ui       |RStudio                                        |
-|language |(EN)                                           |
-|collate  |en_US.UTF-8                                    |
-|ctype    |en_US.UTF-8                                    |
-|tz       |America/Los_Angeles                            |
-|date     |2023-08-09                                     |
-|rstudio  |2023.09.0-daily+233 Desert Sunflower (desktop) |
-|pandoc   |2.17.1.1 @ /opt/homebrew/bin/pandoc            |
+|field    |value                                                                                      |
+|:--------|:------------------------------------------------------------------------------------------|
+|version  |R version 4.3.0 (2023-04-21)                                                               |
+|os       |macOS Ventura 13.5                                                                         |
+|system   |aarch64, darwin20                                                                          |
+|ui       |RStudio                                                                                    |
+|language |(EN)                                                                                       |
+|collate  |en_US.UTF-8                                                                                |
+|ctype    |en_US.UTF-8                                                                                |
+|tz       |America/Los_Angeles                                                                        |
+|date     |2023-08-25                                                                                 |
+|rstudio  |2023.09.0-daily+343 Desert Sunflower (desktop)                                             |
+|pandoc   |3.1.1 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown) |
 
 # Dependencies
 
 |package      |old        |new        |Δ  |
 |:------------|:----------|:----------|:--|
-|recipes      |1.0.6      |1.0.6.9000 |*  |
+|recipes      |1.0.7      |1.0.7.9000 |*  |
 |cli          |3.6.1      |3.6.1      |   |
 |clock        |0.7.0      |0.7.0      |   |
-|cpp11        |0.4.5      |0.4.5      |   |
+|cpp11        |0.4.6      |0.4.6      |   |
 |data.table   |1.14.8     |1.14.8     |   |
 |diagram      |1.6.5      |1.6.5      |   |
 |digest       |0.6.33     |0.6.33     |   |
@@ -46,8 +46,8 @@
 |pillar       |1.9.0      |1.9.0      |   |
 |pkgconfig    |2.0.3      |2.0.3      |   |
 |prodlim      |2023.03.31 |2023.03.31 |   |
-|progressr    |0.13.0     |0.13.0     |   |
-|purrr        |1.0.1      |1.0.1      |   |
+|progressr    |0.14.0     |0.14.0     |   |
+|purrr        |1.0.2      |1.0.2      |   |
 |R6           |2.5.1      |2.5.1      |   |
 |Rcpp         |1.0.11     |1.0.11     |   |
 |rlang        |1.1.1      |1.1.1      |   |

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -91,19 +91,19 @@ Run `revdepcheck::revdep_details(, "hydrorecipes")` for more info
 ** package ‘hydrorecipes’ successfully unpacked and MD5 sums checked
 ** using staged installation
 ** libs
-using C++ compiler: ‘Apple clang version 14.0.3 (clang-1403.0.22.14.1)’
+using C++ compiler: ‘Apple clang version 15.0.0 (clang-1500.0.40.1)’
 using C++11
-using SDK: ‘MacOSX13.3.sdk’
+using SDK: ‘MacOSX14.0.sdk’
 clang++ -arch arm64 -std=gnu++11 -I"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/include" -DNDEBUG  -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/recipes/new/Rcpp/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppArmadillo/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppParallel/include' -I/opt/R/arm64/include    -fPIC  -falign-functions=64 -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
 clang++ -arch arm64 -std=gnu++11 -I"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/include" -DNDEBUG  -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/recipes/new/Rcpp/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppArmadillo/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppParallel/include' -I/opt/R/arm64/include    -fPIC  -falign-functions=64 -Wall -g -O2  -c lags.cpp -o lags.o
 In file included from lags.cpp:7:
 ...
-          ^
-3 warnings generated.
 clang++ -arch arm64 -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -L/opt/R/arm64/lib -o hydrorecipes.so RcppExports.o lags.o -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -lRblas -L/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0 -L/opt/gfortran/lib -lgfortran -lemutls_w -lquadmath -F/Library/Frameworks/R.framework/Versions/4.3-arm64 -framework R -Wl,-framework -Wl,CoreFoundation
-ld: warning: directory not found for option '-L/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0'
-ld: warning: directory not found for option '-L/opt/gfortran/lib'
-ld: library not found for -lgfortran
+ld: warning: -single_module is obsolete
+ld: warning: -multiply_defined is obsolete
+ld: warning: search path '/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0' not found
+ld: warning: search path '/opt/gfortran/lib' not found
+ld: library 'gfortran' not found
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 make: *** [hydrorecipes.so] Error 1
 ERROR: compilation failed for package ‘hydrorecipes’
@@ -118,19 +118,19 @@ ERROR: compilation failed for package ‘hydrorecipes’
 ** package ‘hydrorecipes’ successfully unpacked and MD5 sums checked
 ** using staged installation
 ** libs
-using C++ compiler: ‘Apple clang version 14.0.3 (clang-1403.0.22.14.1)’
+using C++ compiler: ‘Apple clang version 15.0.0 (clang-1500.0.40.1)’
 using C++11
-using SDK: ‘MacOSX13.3.sdk’
+using SDK: ‘MacOSX14.0.sdk’
 clang++ -arch arm64 -std=gnu++11 -I"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/include" -DNDEBUG  -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/recipes/old/Rcpp/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppArmadillo/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppParallel/include' -I/opt/R/arm64/include    -fPIC  -falign-functions=64 -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
 clang++ -arch arm64 -std=gnu++11 -I"/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/include" -DNDEBUG  -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/recipes/old/Rcpp/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppArmadillo/include' -I'/Users/emilhvitfeldt/Github/recipes/revdep/library.noindex/hydrorecipes/RcppParallel/include' -I/opt/R/arm64/include    -fPIC  -falign-functions=64 -Wall -g -O2  -c lags.cpp -o lags.o
 In file included from lags.cpp:7:
 ...
-          ^
-3 warnings generated.
 clang++ -arch arm64 -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -L/opt/R/arm64/lib -o hydrorecipes.so RcppExports.o lags.o -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib -lRblas -L/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0 -L/opt/gfortran/lib -lgfortran -lemutls_w -lquadmath -F/Library/Frameworks/R.framework/Versions/4.3-arm64 -framework R -Wl,-framework -Wl,CoreFoundation
-ld: warning: directory not found for option '-L/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0'
-ld: warning: directory not found for option '-L/opt/gfortran/lib'
-ld: library not found for -lgfortran
+ld: warning: -single_module is obsolete
+ld: warning: -multiply_defined is obsolete
+ld: warning: search path '/opt/gfortran/lib/gcc/aarch64-apple-darwin20.0/12.2.0' not found
+ld: warning: search path '/opt/gfortran/lib' not found
+ld: library 'gfortran' not found
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 make: *** [hydrorecipes.so] Error 1
 ERROR: compilation failed for package ‘hydrorecipes’


### PR DESCRIPTION
To close #1193

Revdepcheck:

```r
── CHECK ────────────────────────────────────────────── 63 packages ──
✔ additive 0.0.5                         ── E: 0     | W: 0     | N: 0    
✔ applicable 0.1.0                       ── E: 0     | W: 0     | N: 0    
✔ autostats 0.4.0                        ── E: 1     | W: 0     | N: 1    
✔ agua 0.1.3                             ── E: 0     | W: 0     | N: 0    
✔ actxps 1.2.0                           ── E: 0     | W: 0     | N: 0    
✔ baguette 1.0.1                         ── E: 0     | W: 0     | N: 0    
✔ bestNormalize 1.9.1                    ── E: 0     | W: 0     | N: 0    
✔ bayesian 0.0.9                         ── E: 0     | W: 0     | N: 0    
✔ brulee 0.2.0                           ── E: 0     | W: 0     | N: 0    
✔ card 0.1.0                             ── E: 0     | W: 0     | N: 1    
✔ butcher 0.3.3                          ── E: 0     | W: 0     | N: 0    
✔ bundle 0.1.0                           ── E: 1     | W: 0     | N: 0    
✔ correlationfunnel 0.2.0                ── E: 0     | W: 0     | N: 1    
✔ CSCNet 0.1.2                           ── E: 0     | W: 0     | N: 0    
I D2MCS 1.0.1                            ── E: 1     | W: 0     | N: 0    
✔ caret 6.0.94                           ── E: 0     | W: 0     | N: 0    
✔ cvms 1.6.0                             ── E: 0     | W: 0     | N: 0    
✔ easyalluvial 0.3.1                     ── E: 0     | W: 0     | N: 0    
✔ finetune 1.1.0                         ── E: 0     | W: 0     | N: 0    
✔ embed 1.1.2                            ── E: 0     | W: 0     | N: 1    
✔ DALEXtra 2.3.0                         ── E: 0     | W: 0     | N: 0    
✔ hardhat 1.3.0                          ── E: 0     | W: 0     | N: 0    
✔ HTRX 1.2.2                             ── E: 0     | W: 0     | N: 1    
✔ healthcareai 2.5.1                     ── E: 2     | W: 1     | N: 1    
✔ finnts 0.3.0                           ── E: 0     | W: 0     | N: 0    
I hydrorecipes 0.0.3                     ── E: 1     | W: 0     | N: 0    
✔ healthyR.ai 0.0.13                     ── E: 0     | W: 0     | N: 0    
✔ MLDataR 1.0.1                          ── E: 0     | W: 0     | N: 1    
✔ healthyR.ts 0.2.10                     ── E: 0     | W: 0     | N: 1    
✔ modelgrid 1.1.1.0                      ── E: 0     | W: 1     | N: 2    
✔ MachineShop 3.6.2                      ── E: 0     | W: 0     | N: 0    
✔ modeltime.resample 0.2.3               ── E: 0     | W: 0     | N: 1    
✔ modeltime.ensemble 1.0.3               ── E: 0     | W: 0     | N: 1    
✔ modeltime 1.2.7                        ── E: 0     | W: 0     | N: 1    
✔ palmerpenguins 0.1.1                   ── E: 0     | W: 0     | N: 0    
✔ nestedmodels 1.0.4                     ── E: 0     | W: 0     | N: 0    
✔ rules 1.0.2                            ── E: 0     | W: 0     | N: 0    
✔ sknifedatar 0.1.2                      ── E: 1     | W: 0     | N: 0    
✔ rsample 1.2.0                          ── E: 0     | W: 0     | N: 0    
✔ shinyrecipes 0.1.0                     ── E: 0     | W: 0     | N: 1    
✔ probably 1.0.2                         ── E: 0     | W: 0     | N: 0    
✔ SomaDataIO 6.0.0                       ── E: 0     | W: 0     | N: 1    
✔ sparseR 0.2.2                          ── E: 0     | W: 0     | N: 0    
✔ stabiliser 1.0.6                       ── E: 0     | W: 0     | N: 1    
✔ stacks 1.0.2                           ── E: 0     | W: 0     | N: 0    
✔ tabnet 0.4.0                           ── E: 0     | W: 0     | N: 0    
✔ swag 0.1.0                             ── E: 0     | W: 0     | N: 0    
✔ text 1.0                               ── E: 0     | W: 0     | N: 1    
✔ textrecipes 1.0.4                      ── E: 0     | W: 0     | N: 1    
✔ themis 1.0.2                           ── E: 0     | W: 0     | N: 0    
✔ tfhub 0.8.1                            ── E: 1     | W: 0     | N: 0    
✔ tidyAML 0.0.2                          ── E: 0     | W: 0     | N: 0    
✔ tidymodels 1.1.1                       ── E: 1     | W: 0     | N: 0    
✔ tidybins 0.1.0                         ── E: 0     | W: 0     | N: 1    
✔ tune 1.1.2                             ── E: 1     | W: 0     | N: 0    
✔ tidyclust 0.1.2                        ── E: 0     | W: 0     | N: 0    
✔ usemodels 0.2.0                        ── E: 0     | W: 0     | N: 0    
✔ vetiver 0.2.3                          ── E: 0     | W: 0     | N: 0    
I workboots 0.2.0                        ── E: 1     | W: 0     | N: 0    
✔ timetk 2.8.3                           ── E: 0     | W: 0     | N: 1    
✔ workflows 1.1.3                        ── E: 0     | W: 0     | N: 0    
✔ waywiser 0.4.2                         ── E: 0     | W: 0     | N: 1    
✔ workflowsets 1.0.1                     ── E: 0     | W: 0     | N: 0    
OK: 63                                                               
BROKEN: 0
```