### PR TITLE
Spline efficiency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 # recipes 1.0.8
 
+## Improvements
+
+* Minor speed-up and reduced memory consumption for spline steps that rely on `spline2_apply` (#1200)
+
 ## Bug Fixes
 
 * Fixed bugs where spline steps (`step_ns()`, `step_bs()`, `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, `step_spline_nonnegative()`) would error if baked with 1 row. (#1191)

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -18,7 +18,7 @@
 #' @seealso [dummy_extract_names()]
 #' @export
 #' @details `step_dummy_extract()` will create a set of integer dummy
-#'  variables from a character variable by extract individual strings
+#'  variables from a character variable by extracting individual strings
 #'  by either splitting or extracting then counting those to create
 #'  count variables.
 #'

--- a/R/spline_helpers.R
+++ b/R/spline_helpers.R
@@ -44,12 +44,10 @@ spline2_apply <- function(object, new_data) {
   object$nm <- NULL
   .cl <- rlang::call2(.ns = .ns, .fn = .fn, !!!object, x = rlang::expr(new_data))
   res <- rlang::eval_tidy(.cl)
-  # res <- apply(res, 2, I)
   attributes(res) <- list(dim = dim(res), dimnames = dimnames(res))
   if (length(new_data) == 1) {
     res <- matrix(res, nrow = 1, dimnames = dimnames(res))
   }
   colnames(res) <- names0(ncol(res), paste0(nm, "_"))
   tibble::as_tibble(res)
-  # res
 }

--- a/R/spline_helpers.R
+++ b/R/spline_helpers.R
@@ -44,10 +44,12 @@ spline2_apply <- function(object, new_data) {
   object$nm <- NULL
   .cl <- rlang::call2(.ns = .ns, .fn = .fn, !!!object, x = rlang::expr(new_data))
   res <- rlang::eval_tidy(.cl)
-  res <- apply(res, 2, I)
+  # res <- apply(res, 2, I)
+  attributes(res) <- list(dim = dim(res), dimnames = dimnames(res))
   if (length(new_data) == 1) {
     res <- matrix(res, nrow = 1, dimnames = dimnames(res))
   }
   colnames(res) <- names0(ncol(res), paste0(nm, "_"))
   tibble::as_tibble(res)
+  # res
 }


### PR DESCRIPTION
spline2_apply speed and memory. To close #1200

One line replacement to improve the efficiency of spline steps on large datasets. See attached reprex.

``` r
library(recipes) 
library(bench)
library(splines2)

n <- 20000000

# create data
x <- as.numeric(1:n)
deg_free <- 8

# b-spline
s <- bSpline(x, deg_free = deg_free)

bench::mark(
  apply(s, 2, I),
  {attributes(s) <- list(dim = dim(s), dimnames = dimnames(s));s},
  iterations = 1
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 apply(s, 2, I)                       1.08s  1.08s   9.30e-1    2.01GB     2.79
#> 2 { attributes(s) <- list(dim = dim(… 6.31µs 6.31µs   1.58e+5        0B     0
```

<sup>Created on 2023-09-27 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>