### PR TITLE
remove check_factor_vars() and make step_dummy() error for character input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Documentation for tidy methods for all steps has been added when missing and improved to describe the return value more accurately. (#936)
 
+* `step_dummy()` now works with character input as documented. (#1233)
+
 # recipes 1.0.8
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Documentation for tidy methods for all steps has been added when missing and improved to describe the return value more accurately. (#936)
 
-* `step_dummy()` now works with character input as documented. (#1233)
+* `step_dummy()` will now error if passed character instead of loudly ignoring them. Only applicable when setting `strings_as_factors = FALSE`. (#1233)
 
 # recipes 1.0.8
 

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -183,6 +183,10 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     levels <- vector(mode = "list", length = length(col_names))
     names(levels) <- col_names
     for (i in seq_along(col_names)) {
+      if (is.character(training[[col_names[i]]])) {
+        training[[col_names[i]]] <- factor(training[[col_names[i]]])
+      }
+
       form <- rlang::new_formula(lhs = NULL, rhs = rlang::sym(col_names[i]))
       if (x$one_hot) {
         form <- stats::update.formula(form, ~ . -1)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -174,19 +174,12 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names], types = c("string", "factor", "ordered"))
 
   if (length(col_names) > 0) {
-
-
-
     ## I hate doing this but currently we are going to have
     ## to save the terms object from the original (= training)
     ## data
     levels <- vector(mode = "list", length = length(col_names))
     names(levels) <- col_names
     for (i in seq_along(col_names)) {
-      if (is.character(training[[col_names[i]]])) {
-        training[[col_names[i]]] <- factor(training[[col_names[i]]])
-      }
-
       form <- rlang::new_formula(lhs = NULL, rhs = rlang::sym(col_names[i]))
       if (x$one_hot) {
         form <- stats::update.formula(form, ~ . -1)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -174,7 +174,8 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names], types = c("string", "factor", "ordered"))
 
   if (length(col_names) > 0) {
-    col_names <- check_factor_vars(training, col_names, "step_dummy")
+
+
 
     ## I hate doing this but currently we are going to have
     ## to save the terms object from the original (= training)
@@ -219,31 +220,6 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     skip = x$skip,
     id = x$id
   )
-}
-
-check_factor_vars <- function(data, col_names, step_name, call = caller_env()) {
-  fac_check <- vapply(data[, col_names], is.factor, logical(1))
-  if (any(!fac_check)) {
-    rlang::warn(
-      paste0(
-        "The following variables are not factor vectors and will be ignored: ",
-        paste0("`", names(fac_check)[!fac_check], "`", collapse = ", ")
-      )
-    )
-  }
-  col_names <- col_names[fac_check]
-  if (length(col_names) == 0) {
-    rlang::abort(
-      paste0(
-        "The `terms` argument in `",
-        step_name,
-        "` did not select ",
-        "any factor columns."
-      ),
-      call = call
-    )
-  }
-  col_names
 }
 
 warn_new_levels <- function(dat, lvl, details = NULL) {

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -1,8 +1,8 @@
 #' Create traditional dummy variables
 #'
 #' `step_dummy()` creates a *specification* of a recipe step that will convert
-#' nominal data (e.g. characters or factors) into one or more numeric binary
-#' model terms corresponding to the levels of the original data.
+#' nominal data (e.g. factors) into one or more numeric binary model terms
+#' corresponding to the levels of the original data.
 #'
 #' @inheritParams step_pca
 #' @inheritParams step_center
@@ -171,7 +171,7 @@ step_dummy_new <-
 #' @export
 prep.step_dummy <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
-  check_type(training[, col_names], types = c("string", "factor", "ordered"))
+  check_type(training[, col_names], types = c("factor", "ordered"))
 
   if (length(col_names) > 0) {
     ## I hate doing this but currently we are going to have

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -41,7 +41,7 @@
 #'   \item{columns}{character, names of resulting columns}
 #'   \item{id}{character, id of this step}
 #' }
-#' 
+#'
 #' The return value is ordered according to the frequency of `columns` entries in the training data set.
 #'
 #' @template case-weights-unsupervised
@@ -168,8 +168,6 @@ prep.step_dummy_extract <- function(x, training, info = NULL, ...) {
   }
 
   if (length(col_names) > 0) {
-    col_names <- check_factor_vars(training, col_names, "step_dummy_extract")
-
     levels <- vector(mode = "list", length = length(col_names))
     names(levels) <- col_names
     for (col_name in col_names) {

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -64,8 +64,8 @@ sequence of any existing operations.
 }
 \description{
 \code{step_dummy()} creates a \emph{specification} of a recipe step that will convert
-nominal data (e.g. characters or factors) into one or more numeric binary
-model terms corresponding to the levels of the original data.
+nominal data (e.g. factors) into one or more numeric binary model terms
+corresponding to the levels of the original data.
 }
 \details{
 \code{step_dummy()} will create a set of binary dummy variables from a factor

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -1,19 +1,8 @@
-# dummy variables with non-factor inputs
+# check_type() is used
 
     Code
-      prep(dummy, training = sacr, verbose = FALSE, strings_as_factors = FALSE)
-    Condition
-      Warning:
-      The following variables are not factor vectors and will be ignored: `city`, `zip`
-      Error in `step_dummy()`:
-      Caused by error in `prep()`:
-      ! The `terms` argument in `step_dummy` did not select any factor columns.
-
----
-
-    Code
-      recipe(sqft ~ zip + price + city, data = sacr_fac_ish) %>% step_dummy(city, zip,
-        price) %>% prep(training = sacr_fac_ish, verbose = FALSE, strings_as_factors = FALSE)
+      recipe(sqft ~ zip + price + city, data = sacr) %>% step_dummy(city, zip, price) %>%
+        prep()
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -1,3 +1,12 @@
+# dummy variables errors with character inputs
+
+    Code
+      prep(dummy, training = sacr, verbose = FALSE, strings_as_factors = FALSE)
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! All columns selected for the step should be factor, or ordered.
+
 # check_type() is used
 
     Code
@@ -6,7 +15,7 @@
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      ! All columns selected for the step should be factor, or ordered.
 
 # tests for NA values in factor
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -27,5 +27,5 @@
     Code
       conditionMessage(attr(res, "condition"))
     Output
-      [1] "Error in `step_dummy()`:\nCaused by error in `prep()`:\n! All columns selected for the step should be string, factor, or ordered."
+      [1] "Error in `step_dummy()`:\nCaused by error in `prep()`:\n! All columns selected for the step should be factor, or ordered."
 

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -65,11 +65,12 @@ test_that("dummy variables with factor inputs", {
   )
 })
 
-test_that("dummy variables with character inputs", {
+test_that("dummy variables errors with character inputs", {
   rec <- recipe(sqft ~ zip + city, data = sacr)
   dummy <- rec %>% step_dummy(city, zip)
 
-  expect_no_error(
+  expect_snapshot(
+    error = TRUE,
     prep(dummy, training = sacr, verbose = FALSE, strings_as_factors = FALSE)
   )
 })

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -65,23 +65,21 @@ test_that("dummy variables with factor inputs", {
   )
 })
 
-test_that("dummy variables with non-factor inputs", {
+test_that("dummy variables with character inputs", {
   rec <- recipe(sqft ~ zip + city, data = sacr)
   dummy <- rec %>% step_dummy(city, zip)
 
-  expect_snapshot(error = TRUE,
+  expect_no_error(
     prep(dummy, training = sacr, verbose = FALSE, strings_as_factors = FALSE)
   )
+})
 
-  sacr_fac_ish <-
-    sacr_fac %>%
-    mutate(city = as.character(city))
-
+test_that("check_type() is used", {
   expect_snapshot(
     error = TRUE,
-    recipe(sqft ~ zip + price + city, data = sacr_fac_ish) %>%
+    recipe(sqft ~ zip + price + city, data = sacr) %>%
       step_dummy(city, zip, price) %>%
-      prep(training = sacr_fac_ish, verbose = FALSE, strings_as_factors = FALSE)
+      prep()
   )
 })
 


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1226

According to the documentation, `step_dummy()` is able to take character and factor variables.

https://github.com/tidymodels/recipes/blob/main/R/dummy.R#L3-L5

This was not the case, as `check_factor_vars()` would exclude non-factor variables. ~~This PR fixes that discrepancy by allowing `step_dummy()` to take in character predictors. Which was only really an issue when `strings_as_factors = FALSE`~~

This PR fixes that by letting `step_dummy()` error on character input. Which only happens when `strings_as_factors = FALSE`
