### PR TITLE
switch check_type() to use cli package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * It is now documented that `step_spline_b()` can be made periodic. (#1223)
 
+* When errors are thrown about wrongly typed input to steps, the offending variables and their types are now listed. (#1217)
+
 # recipes 1.0.8
 
 ## Improvements

--- a/R/misc.R
+++ b/R/misc.R
@@ -425,14 +425,13 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
   if (is.null(types)) {
     if (quant) {
       all_good <- vapply(dat, is.numeric, logical(1))
-      label <- "numeric"
+      types <- "numeric"
     } else {
       all_good <- vapply(dat, is_qual, logical(1))
-      label <- "factor or character"
+      types <- "factor or character"
     }
   } else {
     all_good <- purrr::map_lgl(get_types(dat)$type, ~ any(.x %in% types))
-    label <- glue::glue_collapse(types, sep = ", ", last = ", or ")
   }
 
   if (!all(all_good)) {
@@ -462,7 +461,7 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
     )
     names(problems) <- rep("*", length(problems))
 
-    message <- "All columns selected for the step should be {label}."
+    message <- "All columns selected for the step should be {.or {types}}."
 
     cli::cli_abort(
       c("x" = message, problems),

--- a/R/misc.R
+++ b/R/misc.R
@@ -436,13 +436,36 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
   }
 
   if (!all(all_good)) {
-    rlang::abort(
-      paste0(
-        "All columns selected for the step",
-        " should be ",
-        label,
-        "."
-      ),
+    info <- get_types(dat)[!all_good, ]
+    classes <- map_chr(info$type, function(x) x[1])
+    counts <- vctrs::vec_split(info$variable, classes)
+    counts$count <- lengths(counts$val)
+    counts$text_len <- cli::console_width() - 19 - (counts$count > 1) -
+      nchar(counts$key)
+
+    # cli::ansi_collapse() doesn't work for length(x) == 1
+    # https://github.com/r-lib/cli/issues/590
+    variable_collapse <- function(x, width) {
+      x <- paste0("{.var ", x, "}")
+      if (length(x) == 1) {
+        res <- cli::ansi_strtrim(x, width = width)
+      } else {
+        res <- cli::ansi_collapse(x, width = width, style = "head")
+      }
+      res
+    }
+
+    problems <- glue::glue_data(
+      counts,
+      "{count} {key} variable{ifelse(count == 1, '', 's')} \\
+      found: {purrr::map2_chr(val, text_len, variable_collapse)}"
+    )
+    names(problems) <- rep("*", length(problems))
+
+    message <- "All columns selected for the step should be {label}."
+
+    cli::cli_abort(
+      c("x" = message, problems),
       call = call
     )
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -439,8 +439,8 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
     classes <- map_chr(info$type, function(x) x[1])
     counts <- vctrs::vec_split(info$variable, classes)
     counts$count <- lengths(counts$val)
-    counts$text_len <- cli::console_width() - 19 - (counts$count > 1) -
-      nchar(counts$key)
+    counts$text_len <- cli::console_width() - 18 - (counts$count > 1) -
+      nchar(counts$key) - (counts$count > 2)
 
     # cli::ansi_collapse() doesn't work for length(x) == 1
     # https://github.com/r-lib/cli/issues/590
@@ -448,8 +448,14 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
       x <- paste0("{.var ", x, "}")
       if (length(x) == 1) {
         res <- cli::ansi_strtrim(x, width = width)
+      } else if (length(x) == 2) {
+        res <- cli::ansi_collapse(
+          x, last = " and ", width = width, style = "head"
+        )
       } else {
-        res <- cli::ansi_collapse(x, width = width, style = "head")
+        res <- cli::ansi_collapse(
+          x, width = width, style = "head"
+        )
       }
       res
     }

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -130,7 +130,7 @@ prep.step_ratio <- function(x, training, info = NULL, ...) {
   col_names <- col_names[!(col_names$top == col_names$bottom), ]
 
   check_type(
-    training[, c(col_names$top, col_names$bottom)],
+    training[, unique(c(col_names$top, col_names$bottom))],
     types = c("double", "integer")
   )
 

--- a/tests/testthat/_snaps/bin2factor.md
+++ b/tests/testthat/_snaps/bin2factor.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_bin2factor()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, integer, or logical.
+      x All columns selected for the step should be double, integer, or logical.
+      * 1 factor variable found: `description`
 
 ---
 

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -13,7 +13,8 @@
     Condition
       Error in `step_count()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `rows`
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/cut.md
+++ b/tests/testthat/_snaps/cut.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_cut()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `cat_var`
 
 ---
@@ -15,7 +15,7 @@
     Condition
       Error in `step_cut()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `cat_var`
 
 # full_breaks_check will give warnings

--- a/tests/testthat/_snaps/cut.md
+++ b/tests/testthat/_snaps/cut.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_cut()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `cat_var`
 
 ---
 
@@ -14,7 +15,8 @@
     Condition
       Error in `step_cut()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `cat_var`
 
 # full_breaks_check will give warnings
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -17,7 +17,8 @@
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `price`
 
 # tests for NA values in factor
 

--- a/tests/testthat/_snaps/dummy_multi_choice.md
+++ b/tests/testthat/_snaps/dummy_multi_choice.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_dummy_multi_choice()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be nominal, or logical.
+      x All columns selected for the step should be nominal or logical.
       * 11 double variables found: `mpg`, `cyl`, `disp`, `hp`, ...
 
 # check_name() is used

--- a/tests/testthat/_snaps/dummy_multi_choice.md
+++ b/tests/testthat/_snaps/dummy_multi_choice.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_dummy_multi_choice()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be nominal, or logical.
+      x All columns selected for the step should be nominal, or logical.
+      * 11 double variables found: `mpg`, `cyl`, `disp`, `hp`, ...
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/factor2string.md
+++ b/tests/testthat/_snaps/factor2string.md
@@ -6,7 +6,7 @@
       Error in `step_factor2string()`:
       Caused by error in `prep()`:
       x All columns selected for the step should be factor or ordered.
-      * 2 string variables found: `w`, and `x`
+      * 2 string variables found: `w` and `x`
 
 # empty printing
 

--- a/tests/testthat/_snaps/factor2string.md
+++ b/tests/testthat/_snaps/factor2string.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_factor2string()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be factor, or ordered.
+      x All columns selected for the step should be factor or ordered.
       * 2 string variables found: `w`, and `x`
 
 # empty printing

--- a/tests/testthat/_snaps/factor2string.md
+++ b/tests/testthat/_snaps/factor2string.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_factor2string()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be factor, or ordered.
+      x All columns selected for the step should be factor, or ordered.
+      * 2 string variables found: `w`, and `x`
 
 # empty printing
 

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -61,7 +61,8 @@
     Condition
       Error in `step_harmonic()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be date, datetime, or numeric.
+      x All columns selected for the step should be date, datetime, or numeric.
+      * 1 factor variable found: `time_var`
 
 # harmonic cycle_size length
 

--- a/tests/testthat/_snaps/impute_mean.md
+++ b/tests/testthat/_snaps/impute_mean.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_impute_mean()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `Job`
 
 # Deprecation warning

--- a/tests/testthat/_snaps/impute_mean.md
+++ b/tests/testthat/_snaps/impute_mean.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_impute_mean()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `Job`
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/impute_median.md
+++ b/tests/testthat/_snaps/impute_median.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_impute_median()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `Job`
 
 # Deprecation warning

--- a/tests/testthat/_snaps/impute_median.md
+++ b/tests/testthat/_snaps/impute_median.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_impute_median()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `Job`
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/impute_roll.md
+++ b/tests/testthat/_snaps/impute_roll.md
@@ -6,7 +6,8 @@
     Condition
       Error in `step_impute_roll()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double.
+      x All columns selected for the step should be double.
+      * 1 date variable found: `day`
 
 ---
 
@@ -25,7 +26,8 @@
     Condition
       Error in `step_impute_roll()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double.
+      x All columns selected for the step should be double.
+      * 1 integer variable found: `x4`
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -27,5 +27,5 @@
     Code
       conditionMessage(attr(res, "condition"))
     Output
-      [1] "Error in `step_dummy()`:\nCaused by error in `prep()`:\n! All columns selected for the step should be string, factor, or ordered."
+      [1] "Error in `step_dummy()`:\nCaused by error in `prep()`:\nx All columns selected for the step should be string, factor, or ordered.\n* 11 double variables found: `mpg`, `cyl`, `disp`, `hp`, ..."
 

--- a/tests/testthat/_snaps/novel.md
+++ b/tests/testthat/_snaps/novel.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_novel()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 4 double variables found: `Sepal.Length`, `Sepal.Width`, ...
 
 ---
 

--- a/tests/testthat/_snaps/num2factor.md
+++ b/tests/testthat/_snaps/num2factor.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_num2factor()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `w`
 
 ---

--- a/tests/testthat/_snaps/num2factor.md
+++ b/tests/testthat/_snaps/num2factor.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_num2factor()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `w`
 
 ---
 

--- a/tests/testthat/_snaps/ordinalscore.md
+++ b/tests/testthat/_snaps/ordinalscore.md
@@ -5,7 +5,9 @@
     Condition
       Error in `step_ordinalscore()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be ordered.
+      x All columns selected for the step should be ordered.
+      * 1 double variable found: `numbers`
+      * 1 factor variable found: `fact`
 
 # empty printing
 

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `x5`
 
 ---
@@ -15,7 +15,7 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `x5`
 
 ---
@@ -25,7 +25,7 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 8 factor variables found: `x5`, `x5`, `x5`, `x5`, ...
 
 # check_name() is used

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -26,7 +26,7 @@
       Error in `step_ratio()`:
       Caused by error in `prep()`:
       x All columns selected for the step should be double or integer.
-      * 8 factor variables found: `x5`, `x5`, `x5`, `x5`, ...
+      * 1 factor variable found: `x5`
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `x5`
 
 ---
 
@@ -14,7 +15,8 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `x5`
 
 ---
 
@@ -23,7 +25,8 @@
     Condition
       Error in `step_ratio()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 8 factor variables found: `x5`, `x5`, `x5`, `x5`, ...
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/regex.md
+++ b/tests/testthat/_snaps/regex.md
@@ -13,7 +13,8 @@
     Condition
       Error in `step_regex()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `rows`
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/relevel.md
+++ b/tests/testthat/_snaps/relevel.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_relevel()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `sqft`
 
 ---
 

--- a/tests/testthat/_snaps/relu.md
+++ b/tests/testthat/_snaps/relu.md
@@ -29,7 +29,8 @@
     Condition
       Error in `step_relu()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `val2`
 
 # empty printing
 

--- a/tests/testthat/_snaps/relu.md
+++ b/tests/testthat/_snaps/relu.md
@@ -29,7 +29,7 @@
     Condition
       Error in `step_relu()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `val2`
 
 # empty printing

--- a/tests/testthat/_snaps/string2factor.md
+++ b/tests/testthat/_snaps/string2factor.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_string2factor()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `n`
 
 ---
 

--- a/tests/testthat/_snaps/unknown.md
+++ b/tests/testthat/_snaps/unknown.md
@@ -19,7 +19,8 @@
     Condition
       Error in `step_unknown()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be string, factor, or ordered.
+      x All columns selected for the step should be string, factor, or ordered.
+      * 1 integer variable found: `sqft`
 
 ---
 

--- a/tests/testthat/_snaps/window.md
+++ b/tests/testthat/_snaps/window.md
@@ -71,7 +71,8 @@
     Condition
       Error in `step_window()`:
       Caused by error in `prep()`:
-      ! All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double, or integer.
+      * 1 factor variable found: `fac`
 
 ---
 

--- a/tests/testthat/_snaps/window.md
+++ b/tests/testthat/_snaps/window.md
@@ -71,7 +71,7 @@
     Condition
       Error in `step_window()`:
       Caused by error in `prep()`:
-      x All columns selected for the step should be double, or integer.
+      x All columns selected for the step should be double or integer.
       * 1 factor variable found: `fac`
 
 ---


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/1217.

This PR switches `check_type()` to use {cli} in its errors. Additionally and more importantly, it lists the offending variables and their types 🎉 

``` r
library(recipes)
library(modeldata)

recipe(~., data = iris) |>
  step_date(all_predictors()) |>
  prep()
#> Error in `step_date()`:
#> Caused by error in `prep()`:
#> ✖ All columns selected for the step should be date, or datetime.
#> • 4 double variables found: `Sepal.Length`, `Sepal.Width`, …
#> • 1 factor variable found: `Species`

recipe(~., data = ames) |>
  step_date(all_predictors()) |>
  prep()
#> Error in `step_date()`:
#> Caused by error in `prep()`:
#> ✖ All columns selected for the step should be date, or datetime.
#> • 40 factor variables found: `MS_SubClass`, `MS_Zoning`, `Street`, …
#> • 12 double variables found: `Lot_Frontage`, `Mas_Vnr_Area`, …
#> • 22 integer variables found: `Lot_Area`, `Year_Built`, …
```