### PR TITLE
use cli for all recipe.R functions

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -608,7 +608,10 @@ bake <- function(object, ...) {
 #' @export
 bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   if (rlang::is_missing(new_data)) {
-    rlang::abort("'new_data' must be either a data frame or NULL. No value is not allowed.")
+    cli::cli_abort(
+      "{.arg new_data} must be either a data frame or NULL. \\
+      No value is not allowed."
+    )
   }
 
   if (is.null(new_data)) {
@@ -616,16 +619,17 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   }
 
   if (!fully_trained(object)) {
-    rlang::abort("At least one step has not been trained. Please run `prep`.")
+    cli::cli_abort(c(
+      "*" = "At least one step has not been trained.",
+      "i" = "Please run {.fun recipes::prep}."
+    ))
   }
 
   if (!any(composition == formats)) {
-    rlang::abort(
-      paste0(
-        "`composition` should be one of: ",
-        paste0("'", formats, "'", collapse = ",")
-      )
-    )
+    cli::cli_abort(c(
+      "x" = "{.arg composition} cannot be {.val composition}.",
+      "i" = "Allowed values are {.or formats}."
+    ))
   }
 
   terms <- quos(...)
@@ -636,9 +640,11 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   # In case someone used the deprecated `newdata`:
   if (is.null(new_data) || is.null(ncol(new_data))) {
     if (any(names(terms) == "newdata")) {
-      rlang::abort("Please use `new_data` instead of `newdata` with `bake`.")
+      cli::cli_abort(
+        "Please use {.arg new_data} instead of {.arg newdata} with {.fun bake}."
+      )
     } else {
-      rlang::abort("Please pass a data set to `new_data`.")
+      cli::cli_abort("Please pass a data set to {.arg new_data}.")
     }
   }
 
@@ -669,7 +675,13 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
     new_data <- bake(step, new_data = new_data)
 
     if (!is_tibble(new_data)) {
-      abort("bake() methods should always return tibbles")
+      step_name <- attr(step, "class")[1]
+
+      cli::cli_abort(c(
+        "*" = "{.fun bake} methods should always return tibbles.",
+        "i" = "{.fun {paste0('bake.', step_name)}} returned a \\
+                   {.obj_type_friendly {new_data}}."
+      ))
     }
   }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -197,7 +197,7 @@ recipe.formula <- function(formula, data, ...) {
   f_funcs <- fun_calls(formula)
   if (any(f_funcs == "-")) {
     cli::cli_abort(c(
-      "*" = "{.code -} is not allowed in a recipe formula.",
+      "x" = "{.code -} is not allowed in a recipe formula.",
       "i" = "Use {.fn recipes::step_rm} instead."
     ))
   }
@@ -462,7 +462,7 @@ prep.recipe <-
         )
         if (!is_tibble(training)) {
           cli::cli_abort(c(
-            "*" = "{.fun bake} methods should always return tibbles.",
+            "x" = "{.fun bake} methods should always return tibbles.",
             "i" = "{.fun {paste0('bake.', step_name)}} returned a \\
                    {.obj_type_friendly {training}}."
           ))
@@ -620,7 +620,7 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
 
   if (!fully_trained(object)) {
     cli::cli_abort(c(
-      "*" = "At least one step has not been trained.",
+      "x" = "At least one step has not been trained.",
       "i" = "Please run {.fun recipes::prep}."
     ))
   }
@@ -678,7 +678,7 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
       step_name <- attr(step, "class")[1]
 
       cli::cli_abort(c(
-        "*" = "{.fun bake} methods should always return tibbles.",
+        "x" = "{.fun bake} methods should always return tibbles.",
         "i" = "{.fun {paste0('bake.', step_name)}} returned a \\
                    {.obj_type_friendly {new_data}}."
       ))
@@ -864,7 +864,7 @@ bake_req_tibble <- function(x) {
 juice <- function(object, ..., composition = "tibble") {
   if (!fully_trained(object)) {
     cli::cli_abort(c(
-      "*" = "At least one step has not been trained.",
+      "x" = "At least one step has not been trained.",
       "i" = "Please run {.fun recipes::prep}."
     ))
   }

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -278,7 +278,8 @@ inline_check <- function(x) {
   if (length(funs) > 0) {
     cli::cli_abort(c(
       x = "No in-line functions should be used here.",
-      i = "{cli::qty(length(funs))}The following function{?s} were found:",
+      i = "{cli::qty(length(funs))}The following function{?s} {?no/was/were} \\
+          found:",
       "*" = "{.and {.code {funs}}}",
       i = "Use steps to do transformations instead."
     ))
@@ -435,7 +436,8 @@ prep.recipe <-
       args <- vctrs::vec_split(needs_tuning$arg, needs_tuning$step)
       msg <- c(
         x = "You cannot {.fun prep} a tunable recipe.",
-        i = "{cli::qty(length(args))}The following step{?s} has {.fun tune}:"
+        i = "{cli::qty(nrow(args))}The following step{?s} \\
+             {?no/has/have} {.fun tune}:"
       )
 
       step_msg <- paste0(

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -109,7 +109,7 @@ recipe.data.frame <-
       }
       if (!is.null(roles)) {
         cli::cli_abort(
-          "This {.arg roles} argument will be ignored when a formula is used."
+          "The {.arg roles} argument will be ignored when a formula is used."
         )
       }
 
@@ -131,7 +131,7 @@ recipe.data.frame <-
 
       cli::cli_abort(c(
         x = "{.arg vars} must have unique members.",
-        i = "The following values were duplicate:",
+        i = "The following values were duplicated:",
         "*" = "{.and {offenders}}"
       ))
     }
@@ -278,7 +278,7 @@ inline_check <- function(x) {
   if (length(funs) > 0) {
     cli::cli_abort(c(
       x = "No in-line functions should be used here.",
-      i = "{cli::qty(length(funs))}The following function{?s} {?no/was/were} \\
+      i = "{cli::qty(length(funs))}The following function{?s} {?was/were} \\
           found:",
       "*" = "{.and {.code {funs}}}",
       i = "Use steps to do transformations instead."
@@ -398,7 +398,7 @@ prep.recipe <-
     if (any(skippers) & !retain) {
       cli::cli_warn(
         "Since some operations have {.code skip = TRUE}, using \\
-        {.code retain = TRUE} will allow those steps results to be accessible."
+        {.code retain = TRUE} will allow those step's results to be accessible."
       )
     }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -198,7 +198,7 @@ recipe.formula <- function(formula, data, ...) {
   if (any(f_funcs == "-")) {
     cli::cli_abort(c(
       "x" = "{.code -} is not allowed in a recipe formula.",
-      "i" = "Use {.fn recipes::step_rm} instead."
+      "i" = "Use {.help [{.fun step_rm}](recipes::step_rm)} instead."
     ))
   }
 
@@ -635,7 +635,7 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   if (!fully_trained(object)) {
     cli::cli_abort(c(
       "x" = "At least one step has not been trained.",
-      "i" = "Please run {.fun recipes::prep}."
+      "i" = "Please run {.help [{.fun prep}](recipes::prep)}."
     ))
   }
 
@@ -879,7 +879,7 @@ juice <- function(object, ..., composition = "tibble") {
   if (!fully_trained(object)) {
     cli::cli_abort(c(
       "x" = "At least one step has not been trained.",
-      "i" = "Please run {.fun recipes::prep}."
+      "i" = "Please run {.help [{.fun prep}](recipes::prep)}."
     ))
   }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -641,8 +641,8 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
 
   if (!any(composition == formats)) {
     cli::cli_abort(c(
-      "x" = "{.arg composition} cannot be {.val composition}.",
-      "i" = "Allowed values are {.or formats}."
+      "x" = "{.arg composition} cannot be {.val {composition}}.",
+      "i" = "Allowed values are {.or {formats}}."
     ))
   }
 
@@ -892,8 +892,8 @@ juice <- function(object, ..., composition = "tibble") {
 
   if (!any(composition == formats)) {
     cli::cli_abort(c(
-      "x" = "{.arg composition} cannot be {.val composition}.",
-      "i" = "Allowed values are {.or formats}."
+      "x" = "{.arg composition} cannot be {.val {composition}}.",
+      "i" = "Allowed values are {.or {.val {formats}}}."
     ))
   }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -425,11 +425,14 @@ prep.recipe <-
 
     running_info <- x$term_info %>% mutate(number = 0, skip = FALSE)
 
-    needs_tuning <- purrr::map(x$steps, ~ {
-      res <- map_lgl(.x, is_tune)
+    get_needs_tuning <- function(x) {
+      res <- map_lgl(x, is_tune)
       res <- names(res)[res]
-      tibble(step = class(.x)[[1L]], arg = res)
-    })
+      res <- vctrs::vec_recycle_common(step = class(x)[[1L]], arg = res)
+      tibble::new_tibble(res)
+    }
+
+    needs_tuning <- purrr::map(x$steps, get_needs_tuning)
     needs_tuning <- purrr::list_rbind(needs_tuning)
 
     if (nrow(needs_tuning) > 0) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -130,7 +130,7 @@ recipe.data.frame <-
       offenders <- offenders$key[offenders$count != 1]
 
       cli::cli_abort(c(
-        x = "{.arg vars} must have unique members.",
+        x = "{.arg vars} must have unique values.",
         i = "The following values were duplicated:",
         "*" = "{.and {offenders}}"
       ))

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -863,20 +863,23 @@ bake_req_tibble <- function(x) {
 #' @seealso [recipe()] [prep()] [bake()]
 juice <- function(object, ..., composition = "tibble") {
   if (!fully_trained(object)) {
-    rlang::abort("At least one step has not been trained. Please run `prep()`.")
-  }
-
-  if (!isTRUE(object$retained)) {
-    rlang::abort(paste0(
-      "Use `retain = TRUE` in `prep()` to be able ",
-      "to extract the training set"
+    cli::cli_abort(c(
+      "*" = "At least one step has not been trained.",
+      "i" = "Please run {.fun recipes::prep}."
     ))
   }
 
+  if (!isTRUE(object$retained)) {
+    cli::cli_abort(
+      "Use {.code retain = TRUE} in {.fun prep} to be able to extract the \\
+      training set"
+    )
+  }
+
   if (!any(composition == formats)) {
-    rlang::abort(paste0(
-      "`composition` should be one of: ",
-      paste0("'", formats, "'", collapse = ",")
+    cli::cli_abort(c(
+      "x" = "{.arg composition} cannot be {.val composition}.",
+      "i" = "Allowed values are {.or formats}."
     ))
   }
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -56,7 +56,7 @@
       bake(sp_signed, new_data = biomass_te)
     Condition
       Error in `bake()`:
-      * At least one step has not been trained.
+      x At least one step has not been trained.
       i Please run `recipes::prep()`.
 
 ---
@@ -65,7 +65,7 @@
       juice(sp_signed)
     Condition
       Error in `juice()`:
-      * At least one step has not been trained.
+      x At least one step has not been trained.
       i Please run `recipes::prep()`.
 
 # bake without newdata
@@ -145,7 +145,7 @@
       bake(rec_prepped, new_data = as_tibble(mtcars))
     Condition
       Error in `bake()`:
-      * `bake()` methods should always return tibbles.
+      x `bake()` methods should always return tibbles.
       i `bake.step_testthat_helper()` returned a a data frame.
 
 ---
@@ -154,7 +154,7 @@
       prep(rec_spec)
     Condition
       Error in `prep()`:
-      * `bake()` methods should always return tibbles.
+      x `bake()` methods should always return tibbles.
       i `bake.step_testthat_helper()` returned a a data frame.
 
 # recipe() errors if `data` is missing

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -4,7 +4,10 @@
       recipe(HHV ~ log(nitrogen), data = biomass)
     Condition
       Error in `inline_check()`:
-      ! No in-line functions should be used here; use steps to define baking actions.
+      x No in-line functions should be used here.
+      i The following function were found:
+      * `log`
+      i Instead use steps to do transformations.
 
 ---
 
@@ -12,7 +15,10 @@
       recipe(HHV ~ (.)^2, data = biomass)
     Condition
       Error in `inline_check()`:
-      ! No in-line functions should be used here; use steps to define baking actions.
+      x No in-line functions should be used here.
+      i The following functions were found:
+      * `^` and `(`
+      i Instead use steps to do transformations.
 
 ---
 
@@ -20,7 +26,10 @@
       recipe(HHV ~ nitrogen + sulfur + nitrogen:sulfur, data = biomass)
     Condition
       Error in `inline_check()`:
-      ! No in-line functions should be used here; use steps to define baking actions.
+      x No in-line functions should be used here.
+      i The following function were found:
+      * `:`
+      i Instead use steps to do transformations.
 
 ---
 
@@ -28,7 +37,10 @@
       recipe(HHV ~ nitrogen^2, data = biomass)
     Condition
       Error in `inline_check()`:
-      ! No in-line functions should be used here; use steps to define baking actions.
+      x No in-line functions should be used here.
+      i The following function were found:
+      * `^`
+      i Instead use steps to do transformations.
 
 # Using prepare
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -87,6 +87,20 @@
       i The following steps has `tune()`:
       * step_ns: `deg_free`
 
+---
+
+    Code
+      prep(step_bs(step_kpca(step_pca(recipe(~., data = mtcars), all_predictors(),
+      threshold = .tune()), all_predictors(), num_comp = .tune()), all_predictors(),
+      deg_free = .tune()))
+    Condition
+      Error in `prep()`:
+      x You cannot `prep()` a tuneable recipe.
+      i The following steps has `tune()`:
+      * step_pca: `threshold`
+      * step_kpca: `num_comp`
+      * step_bs: `deg_free`
+
 # logging
 
     Code

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -5,7 +5,7 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function were found:
+      i The following function was found:
       * `log`
       i Use steps to do transformations instead.
 
@@ -27,7 +27,7 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function were found:
+      i The following function was found:
       * `:`
       i Use steps to do transformations instead.
 
@@ -38,7 +38,7 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function were found:
+      i The following function was found:
       * `^`
       i Use steps to do transformations instead.
 
@@ -84,7 +84,7 @@
     Condition
       Error in `prep()`:
       x You cannot `prep()` a tunable recipe.
-      i The following steps has `tune()`:
+      i The following step has `tune()`:
       * step_ns: `deg_free`
 
 ---
@@ -96,7 +96,7 @@
     Condition
       Error in `prep()`:
       x You cannot `prep()` a tunable recipe.
-      i The following steps has `tune()`:
+      i The following steps have `tune()`:
       * step_pca: `threshold`
       * step_kpca: `num_comp`
       * step_bs: `deg_free`

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -65,7 +65,8 @@
       juice(sp_signed)
     Condition
       Error in `juice()`:
-      ! At least one step has not been trained. Please run `prep()`.
+      * At least one step has not been trained.
+      i Please run `recipes::prep()`.
 
 # bake without newdata
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -7,7 +7,7 @@
       x No in-line functions should be used here.
       i The following function were found:
       * `log`
-      i Instead use steps to do transformations.
+      i Use steps to do transformations instead.
 
 ---
 
@@ -18,7 +18,7 @@
       x No in-line functions should be used here.
       i The following functions were found:
       * `^` and `(`
-      i Instead use steps to do transformations.
+      i Use steps to do transformations instead.
 
 ---
 
@@ -29,7 +29,7 @@
       x No in-line functions should be used here.
       i The following function were found:
       * `:`
-      i Instead use steps to do transformations.
+      i Use steps to do transformations instead.
 
 ---
 
@@ -40,7 +40,7 @@
       x No in-line functions should be used here.
       i The following function were found:
       * `^`
-      i Instead use steps to do transformations.
+      i Use steps to do transformations instead.
 
 # Using prepare
 
@@ -83,7 +83,7 @@
         prep()
     Condition
       Error in `prep()`:
-      x You cannot `prep()` a tuneable recipe.
+      x You cannot `prep()` a tunable recipe.
       i The following steps has `tune()`:
       * step_ns: `deg_free`
 
@@ -95,7 +95,7 @@
       deg_free = .tune()))
     Condition
       Error in `prep()`:
-      x You cannot `prep()` a tuneable recipe.
+      x You cannot `prep()` a tunable recipe.
       i The following steps has `tune()`:
       * step_pca: `threshold`
       * step_kpca: `num_comp`

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -151,7 +151,8 @@
       prep(rec_spec)
     Condition
       Error in `prep()`:
-      ! bake() methods should always return tibbles
+      * `bake()` methods should always return tibbles.
+      i `bake.step_testthat_helper()` returned a a data frame.
 
 # recipe() errors if `data` is missing
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -83,7 +83,9 @@
         prep()
     Condition
       Error in `prep()`:
-      ! You cannot `prep()` a tuneable recipe. Argument(s) with `tune()`: 'deg_free'. Do you want to use a tuning function such as `tune_grid()`?
+      x You cannot `prep()` a tuneable recipe.
+      i The following steps has `tune()`:
+      * step_ns: `deg_free`
 
 # logging
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -57,7 +57,7 @@
     Condition
       Error in `bake()`:
       x At least one step has not been trained.
-      i Please run `recipes::prep()`.
+      i Please run `prep()` (`?recipes::prep()`).
 
 ---
 
@@ -66,7 +66,7 @@
     Condition
       Error in `juice()`:
       x At least one step has not been trained.
-      i Please run `recipes::prep()`.
+      i Please run `prep()` (`?recipes::prep()`).
 
 # bake without newdata
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -56,7 +56,8 @@
       bake(sp_signed, new_data = biomass_te)
     Condition
       Error in `bake()`:
-      ! At least one step has not been trained. Please run `prep`.
+      * At least one step has not been trained.
+      i Please run `recipes::prep()`.
 
 ---
 
@@ -72,7 +73,7 @@
       bake(rec, newdata = biomass)
     Condition
       Error in `bake()`:
-      ! 'new_data' must be either a data frame or NULL. No value is not allowed.
+      ! `new_data` must be either a data frame or NULL. No value is not allowed.
 
 # tunable arguments at prep-time
 
@@ -143,7 +144,8 @@
       bake(rec_prepped, new_data = as_tibble(mtcars))
     Condition
       Error in `bake()`:
-      ! bake() methods should always return tibbles
+      * `bake()` methods should always return tibbles.
+      i `bake.step_testthat_helper()` returned a a data frame.
 
 ---
 

--- a/tests/testthat/_snaps/skipping.md
+++ b/tests/testthat/_snaps/skipping.md
@@ -4,7 +4,7 @@
       prepped_2 <- prep(rec_1, training = iris, retain = FALSE)
     Condition
       Warning:
-      Since some operations have `skip = TRUE`, using `retain = TRUE` will allow those steps results to be accessible.
+      Since some operations have `skip = TRUE`, using `retain = TRUE` will allow those step's results to be accessible.
 
 ---
 
@@ -12,7 +12,7 @@
       prep(rec_1, training = iris, retain = FALSE)
     Condition
       Warning:
-      Since some operations have `skip = TRUE`, using `retain = TRUE` will allow those steps results to be accessible.
+      Since some operations have `skip = TRUE`, using `retain = TRUE` will allow those step's results to be accessible.
     Message
       
       -- Recipe ----------------------------------------------------------------------

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -187,6 +187,14 @@ test_that("tunable arguments at prep-time", {
       step_ns(all_predictors(), deg_free = .tune()) %>%
       prep()
   )
+
+  expect_snapshot(error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_pca(all_predictors(), threshold = .tune()) |>
+      step_kpca(all_predictors(), num_comp = .tune()) |>
+      step_bs(all_predictors(), deg_free = .tune()) |>
+      prep()
+  )
 })
 
 test_that("logging", {


### PR DESCRIPTION
ref: https://github.com/tidymodels/recipes/issues/1237

This PR is a little longer, but felt right in the moment. It converts to {cli} in

- `recipe()`
- `prep()`
- `bake()`
- `juice()`

it also does a big improvement, that is best shown in the commit https://github.com/tidymodels/recipes/commit/1c3e0a1b8c17b61e8a14a0e5455ccd4a187e6bfb, where the checking for `tune()` is now done all at once, instead of one step at a time.

# This PR

``` r
library(recipes)
library(hardhat)

recipe(~., data = mtcars) |>
  step_pca(all_predictors(), threshold = tune()) |>
  step_kpca(all_predictors(), num_comp = tune()) |>
  step_bs(all_predictors(), deg_free = tune()) |>
  prep()
#> Error in `prep()`:
#> ✖ You cannot `prep()` a tuneable recipe.
#> ℹ The following steps has `tune()`:
#> • step_pca: `threshold`
#> • step_kpca: `num_comp`
#> • step_bs: `deg_free`
```

# Before

``` r
library(recipes)
library(hardhat)

recipe(~., data = mtcars) |>
  step_pca(all_predictors(), threshold = tune()) |>
  step_kpca(all_predictors(), num_comp = tune()) |>
  step_bs(all_predictors(), deg_free = tune()) |>
  prep()
#> Error in `prep()`:
#> ! You cannot `prep()` a tuneable recipe. Argument(s) with `tune()`: 'threshold'. Do you want to use a tuning function such as `tune_grid()`?
```