### PR TITLE
Add warning message when scaling steps return NaN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 * When errors are thrown about wrongly typed input to steps, the offending variables and their types are now listed. (#1217)
 
-* Added warnings when `step_scale()`, `step_normalise()`, `step_center()` or `step_range()` result in `NaN` columns.
+* Added warnings when `step_scale()`, `step_normalise()`, `step_center()` or `step_range()` result in `NaN` columns. (@mastoffel, #1221)
 
 # recipes 1.0.8
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * When errors are thrown about wrongly typed input to steps, the offending variables and their types are now listed. (#1217)
 
+* Added warnings when `step_scale()`, `step_normalise()`, `step_center()` or `step_range()` result in `NaN` columns.
+
 # recipes 1.0.8
 
 ## Improvements

--- a/R/center.R
+++ b/R/center.R
@@ -121,6 +121,13 @@ prep.step_center <- function(x, training, info = NULL, ...) {
 
   means <- averages(training[, col_names], wts, na_rm = x$na_rm)
 
+  inf_cols <- col_names[is.infinite(means)]
+  if (length(inf_cols) > 0) {
+    cli::cli_warn(
+      "Column{?s} {.var {inf_cols}} returned NaN. \\
+      Consider avoiding `Inf` values before normalising.")
+  }
+
   step_center_new(
     terms = x$terms,
     role = x$role,

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -122,6 +122,21 @@ sd_check <- function(x) {
     )
     x[zero_sd] <- 1
   }
+
+  na_sd <- which(is.na(x))
+  if (length(na_sd) > 0) {
+    glue_cols <- glue::glue_collapse(
+      glue("`{names(na_sd)}`"), sep = ", ", last = " and "
+    )
+    rlang::warn(
+      glue(
+        "Column(s) {glue_cols} returned NaN, because variance cannot be ",
+        "calculated and scaling cannot be used. ",
+        "Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` ",
+        "before normalizing."
+      )
+    )
+  }
   x
 }
 

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -127,8 +127,9 @@ sd_check <- function(x) {
   if (length(na_sd) > 0) {
     cli::cli_warn(
         "Column{?s} {.var {names(na_sd)}} returned NaN, because variance \\
-         cannot be calculated and scaling cannot be used. Consider avoiding \\
-         `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing."
+        cannot be calculated and scaling cannot be used. Consider avoiding \\
+        `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before \\
+        normalizing."
     )
   }
   x

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -125,16 +125,10 @@ sd_check <- function(x) {
 
   na_sd <- which(is.na(x))
   if (length(na_sd) > 0) {
-    glue_cols <- glue::glue_collapse(
-      glue("`{names(na_sd)}`"), sep = ", ", last = " and "
-    )
-    rlang::warn(
-      glue(
-        "Column(s) {glue_cols} returned NaN, because variance cannot be ",
-        "calculated and scaling cannot be used. ",
-        "Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` ",
-        "before normalizing."
-      )
+    cli::cli_warn(
+        "Column{?s} {.var {names(na_sd)}} returned NaN, because variance \\
+         cannot be calculated and scaling cannot be used. Consider avoiding \\
+         `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing."
     )
   }
   x

--- a/R/range.R
+++ b/R/range.R
@@ -111,6 +111,21 @@ prep.step_range <- function(x, training, info = NULL, ...) {
     vapply(training[, col_names], min, c(min = 0), na.rm = TRUE)
   maxs <-
     vapply(training[, col_names], max, c(max = 0), na.rm = TRUE)
+
+  inf_cols <- col_names[is.infinite(mins) | is.infinite(maxs)]
+  if (length(inf_cols) > 0) {
+    cli::cli_warn(
+      "Column{?s} {.var {inf_cols}} returned NaN. \\
+      Consider avoiding `Inf` values before normalising.")
+  }
+  zero_range_cols <- col_names[maxs - mins == 0]
+  if (length(zero_range_cols) > 0) {
+    cli::cli_warn(
+      "Column{?s} {.var {zero_range_cols}} returned NaN. Consider using \\
+       `step_zv()` to remove variables containing only a single value."
+    )
+  }
+
   step_range_new(
     terms = x$terms,
     role = x$role,

--- a/tests/testthat/_snaps/center.md
+++ b/tests/testthat/_snaps/center.md
@@ -39,6 +39,48 @@
       -- Operations 
       * Centering for: cyl, disp, hp, drat, qsec, vs, ... | Trained, ignored weights
 
+# warns when NaN is returned due to Inf or -Inf
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN. Consider avoiding `Inf` values before normalising.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Centering for: x | Trained
+
+---
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN. Consider avoiding `Inf` values before normalising.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Centering for: x | Trained
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/normalize.md
+++ b/tests/testthat/_snaps/normalize.md
@@ -1,3 +1,12 @@
+# na_rm argument works for step_normalize
+
+    Code
+      rec_no_na_rm <- recipe(~., data = mtcars_na) %>% step_normalize(all_predictors(),
+      na_rm = FALSE) %>% prep()
+    Condition
+      Warning:
+      Columns `mpg`, `cyl`, `disp`, and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
+
 # warns on zv
 
     Code

--- a/tests/testthat/_snaps/normalize.md
+++ b/tests/testthat/_snaps/normalize.md
@@ -70,6 +70,48 @@
       * Centering and scaling for: cyl, disp, hp, drat, ... | Trained, ignored
         weights
 
+# warns when NaN is returned due to Inf or -Inf
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Centering and scaling for: x | Trained
+
+---
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Centering and scaling for: x | Trained
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/range.md
+++ b/tests/testthat/_snaps/range.md
@@ -1,3 +1,66 @@
+# warns when NaN is returned due to zero variance
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN. Consider using `step_zv()` to remove variables containing only a single value.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 10 data points and no incomplete rows.
+      
+      -- Operations 
+      * Range scaling to [0,1] for: x | Trained
+
+# warns when NaN is returned due to Inf or -Inf
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN. Consider avoiding `Inf` values before normalising.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Range scaling to [0,1] for: x | Trained
+
+---
+
+    Code
+      prep(rec)
+    Condition
+      Warning:
+      Column `x` returned NaN. Consider avoiding `Inf` values before normalising.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      predictor: 1
+      
+      -- Training information 
+      Training data contained 4 data points and no incomplete rows.
+      
+      -- Operations 
+      * Range scaling to [0,1] for: x | Trained
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/scale.md
+++ b/tests/testthat/_snaps/scale.md
@@ -14,7 +14,7 @@
       na_rm = FALSE) %>% prep()
     Condition
       Warning:
-      Column(s) `mpg`, `cyl`, `disp` and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+      Columns `mpg`, `cyl`, `disp`, and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
 
 # warns on zv
 
@@ -44,7 +44,7 @@
       prep(rec1)
     Condition
       Warning:
-      Column(s) `sulfur` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+      Column `sulfur` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
     Message
       
       -- Recipe ----------------------------------------------------------------------

--- a/tests/testthat/_snaps/scale.md
+++ b/tests/testthat/_snaps/scale.md
@@ -14,7 +14,7 @@
       na_rm = FALSE) %>% prep()
     Condition
       Warning:
-      Columns `mpg`, `cyl`, `disp`, and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+      Columns `mpg`, `cyl`, `disp`, and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
 
 # warns on zv
 
@@ -44,7 +44,7 @@
       prep(rec1)
     Condition
       Warning:
-      Column `sulfur` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+      Column `sulfur` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
     Message
       
       -- Recipe ----------------------------------------------------------------------

--- a/tests/testthat/_snaps/scale.md
+++ b/tests/testthat/_snaps/scale.md
@@ -7,6 +7,15 @@
       Warning:
       Scaling `factor` should take either a value of 1 or 2
 
+# na_rm argument works for step_scale
+
+    Code
+      rec_no_na_rm <- recipe(~., data = mtcars_na) %>% step_scale(all_predictors(),
+      na_rm = FALSE) %>% prep()
+    Condition
+      Warning:
+      Column(s) `mpg`, `cyl`, `disp` and `hp` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+
 # warns on zv
 
     Code
@@ -28,6 +37,29 @@
       
       -- Operations 
       * Scaling for: carbon, hydrogen, oxygen, nitrogen, sulfur, ... | Trained
+
+# warns when NaN is returned
+
+    Code
+      prep(rec1)
+    Condition
+      Warning:
+      Column(s) `sulfur` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm=TRUE` before normalizing.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:   1
+      predictor: 5
+      
+      -- Training information 
+      Training data contained 536 data points and no incomplete rows.
+      
+      -- Operations 
+      * Log transformation on: sulfur | Trained
+      * Scaling for: sulfur | Trained
 
 # scaling with case weights
 

--- a/tests/testthat/_snaps/update-role-requirements.md
+++ b/tests/testthat/_snaps/update-role-requirements.md
@@ -41,6 +41,14 @@
       ! Can't update the `bake` requirement of the "outcome" role.
       i The "outcome" role is never required at `bake()` time.
 
+# will still error if a step actually used a role that set `bake = FALSE`
+
+    Code
+      rec <- prep(rec, df)
+    Condition
+      Warning:
+      Column `x` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
+
 # can update `bake` requirements after prepping
 
     Code

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -109,6 +109,15 @@ test_that("centering with case weights", {
   expect_snapshot(rec)
 })
 
+test_that("warns when NaN is returned due to Inf or -Inf",{
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, Inf))) |>
+    step_center(x)
+  expect_snapshot(prep(rec))
+
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, -Inf))) |>
+    step_center(x)
+  expect_snapshot(prep(rec))
+})
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -142,6 +142,16 @@ test_that("normalizing with case weights", {
   expect_snapshot(rec)
 })
 
+test_that("warns when NaN is returned due to Inf or -Inf",{
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, Inf))) |>
+    step_normalize(x)
+  expect_snapshot(prep(rec))
+
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, -Inf))) |>
+    step_normalize(x)
+  expect_snapshot(prep(rec))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -65,9 +65,11 @@ test_that("na_rm argument works for step_normalize", {
   mtcars_na <- mtcars
   mtcars_na[1, 1:4] <- NA
 
-  rec_no_na_rm <- recipe(~., data = mtcars_na) %>%
-    step_normalize(all_predictors(), na_rm = FALSE) %>%
-    prep()
+  expect_snapshot(
+    rec_no_na_rm <- recipe(~., data = mtcars_na) %>%
+      step_normalize(all_predictors(), na_rm = FALSE) %>%
+      prep()
+  )
 
   rec_na_rm <- recipe(~., data = mtcars_na) %>%
     step_normalize(all_predictors(), na_rm = TRUE) %>%

--- a/tests/testthat/test-range.R
+++ b/tests/testthat/test-range.R
@@ -176,6 +176,22 @@ test_that("backwards compatibility for before clipping <= 1.0.2 (#1090)", {
   expect_equal(exp_pred, obs_pred)
 })
 
+test_that("warns when NaN is returned due to zero variance",{
+  rec <- recipe(~., data = data.frame(x = rep(1, 10))) |>
+    step_range(x)
+  expect_snapshot(prep(rec))
+})
+
+test_that("warns when NaN is returned due to Inf or -Inf",{
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, Inf))) |>
+    step_range(x)
+  expect_snapshot(prep(rec))
+
+  rec <- recipe(~., data = data.frame(x = c(2, 3, 4, -Inf))) |>
+    step_range(x)
+  expect_snapshot(prep(rec))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-scale.R
+++ b/tests/testthat/test-scale.R
@@ -88,9 +88,11 @@ test_that("na_rm argument works for step_scale", {
   mtcars_na <- mtcars
   mtcars_na[1, 1:4] <- NA
 
+  expect_warning({
   rec_no_na_rm <- recipe(~., data = mtcars_na) %>%
     step_scale(all_predictors(), na_rm = FALSE) %>%
     prep()
+  })
 
   rec_na_rm <- recipe(~., data = mtcars_na) %>%
     step_scale(all_predictors(), na_rm = TRUE) %>%
@@ -113,6 +115,13 @@ test_that("na_rm argument works for step_scale", {
 test_that("warns on zv",{
   rec1 <- step_scale(rec_zv, all_numeric_predictors())
   expect_snapshot(prep(rec1))
+})
+
+test_that("warns when NaN is returned",{
+  rec1 <- rec %>%
+    step_log(sulfur) %>%
+    step_scale(sulfur)
+  expect_warning(prep(rec1))
 })
 
 test_that("scaling with case weights", {

--- a/tests/testthat/test-scale.R
+++ b/tests/testthat/test-scale.R
@@ -88,7 +88,7 @@ test_that("na_rm argument works for step_scale", {
   mtcars_na <- mtcars
   mtcars_na[1, 1:4] <- NA
 
-  expect_warning({
+  expect_snapshot({
   rec_no_na_rm <- recipe(~., data = mtcars_na) %>%
     step_scale(all_predictors(), na_rm = FALSE) %>%
     prep()
@@ -121,7 +121,7 @@ test_that("warns when NaN is returned",{
   rec1 <- rec %>%
     step_log(sulfur) %>%
     step_scale(sulfur)
-  expect_warning(prep(rec1))
+  expect_snapshot(prep(rec1))
 })
 
 test_that("scaling with case weights", {

--- a/tests/testthat/test-update-role-requirements.R
+++ b/tests/testthat/test-update-role-requirements.R
@@ -74,8 +74,9 @@ test_that("will still error if a step actually used a role that set `bake = FALS
   rec <- update_role(rec, x, new_role = "id")
   rec <- update_role_requirements(rec, "id", bake = FALSE)
   rec <- step_scale(rec, x)
-  rec <- prep(rec, df)
-
+  expect_snapshot(
+    rec <- prep(rec, df)
+  )
   df$x <- NULL
 
   # Error is specific to details of `step_scale()`


### PR DESCRIPTION
Adds warning when `step_scale()` returns NaN columns due to `Inf` or `na_rm=False` 

Closes #1221