### PR TITLE
move from rlang::abort to cli::cli_abort in steps - first batch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     magrittr,
     Matrix,
     purrr (>= 1.0.0),
-    rlang (>= 1.0.3),
+    rlang (>= 1.1.0),
     stats,
     tibble,
     tidyr (>= 1.0.0),

--- a/R/YeoJohnson.R
+++ b/R/YeoJohnson.R
@@ -238,8 +238,11 @@ estimate_yj <- function(dat,
     if (na_rm) {
       dat <- dat[-na_rows]
     } else {
-      rlang::abort(
-        "Missing values are not allowed for the YJ transformation. See `na_rm` option",
+      cli::cli_abort(
+        c(
+          x = "Missing values are not allowed for the YJ transformation.",
+          i = "See {.arg na_rm} option."
+        ),
         call = call
       )
     }

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -60,18 +60,18 @@ step_bin2factor <-
            skip = FALSE,
            id = rand_id("bin2factor")) {
     if (length(levels) != 2 || !is.character(levels)) {
-      msg <- c(x = "{.arg levels} should be a two element character string.")
+      msg <- c(x = "{.arg levels} should be a 2-element character string.")
 
       if (length(levels) != 2) {
         msg <- c(
           msg,
-          i = "{length(levels)} elements were supplied."
+          i = "{length(levels)} element{?s} were supplied."
         )
       }
       if (!is.character(levels)) {
         msg <- c(
           msg,
-          i = "It was a {.obj_type_friendly {levels}}."
+          i = "It was {.obj_type_friendly {levels}}."
         )
       }
       cli::cli_abort(msg)

--- a/R/bin2factor.R
+++ b/R/bin2factor.R
@@ -59,8 +59,22 @@ step_bin2factor <-
            columns = NULL,
            skip = FALSE,
            id = rand_id("bin2factor")) {
-    if (length(levels) != 2 | !is.character(levels)) {
-      rlang::abort("`levels` should be a two element character string")
+    if (length(levels) != 2 || !is.character(levels)) {
+      msg <- c(x = "{.arg levels} should be a two element character string.")
+
+      if (length(levels) != 2) {
+        msg <- c(
+          msg,
+          i = "{length(levels)} elements were supplied."
+        )
+      }
+      if (!is.character(levels)) {
+        msg <- c(
+          msg,
+          i = "It was a {.obj_type_friendly {levels}}."
+        )
+      }
+      cli::cli_abort(msg)
     }
     add_step(
       recipe,

--- a/R/class.R
+++ b/R/class.R
@@ -157,16 +157,16 @@ bake_check_class_core <- function(x,
   missing <- setdiff(class_nm, classes)
   if (length(missing) > 0) {
     cli::cli_abort(
-      "{.var {var_nm}} should have the class{?es} {.cls {class_nm}}} but
-      only has the class{?es} {.and {.val {classes}}}."
+      "{.var {var_nm}} should have the class{?es} {.cls {class_nm}} but
+      has the class{?es} {.and {.cls {classes}}}."
     )
   }
 
   extra <- setdiff(classes, class_nm)
   if (length(extra) > 0 && !aa) {
     cli::cli_abort(c(
-        x = "{.var {var_nm}} has class{?es} {.and {.val {classes}}} but only \\
-            the following {?is/are} asked {.and {.val {class_nm}}}.",
+        x = "{.var {var_nm}} has class{?es} {.and {.cls {classes}}} but only \\
+            the following {?is/are} asked: {.and {.cls {class_nm}}}.",
         i = "This error is shown because {.arg allow_additional} is set to \\
             {.val FALSE}."
     ))

--- a/R/class.R
+++ b/R/class.R
@@ -156,30 +156,20 @@ bake_check_class_core <- function(x,
   classes <- class(x)
   missing <- setdiff(class_nm, classes)
   if (length(missing) > 0) {
-    rlang::abort(
-      paste0(
-        var_nm,
-        " should have the class(es) ",
-        paste(class_nm, collapse = ", "),
-        " but has the class(es) ",
-        paste(classes, collapse = ", "),
-        "."
-      )
+    cli::cli_abort(
+      "{.var {var_nm}} should have the class{?es} {.and {.val {class_nm}}} but
+      only has the class{?es} {.and {.val {classes}}}."
     )
   }
 
   extra <- setdiff(classes, class_nm)
   if (length(extra) > 0 && !aa) {
-    rlang::abort(
-      paste0(
-        var_nm,
-        " has the class(es) ",
-        paste(classes, collapse = ", "),
-        ", but only the following is/are asked ",
-        paste(class_nm, collapse = ", "),
-        ", allow_additional is FALSE."
-      )
-    )
+    cli::cli_abort(c(
+        x = "{.var {var_nm}} has class{?es} {.and {.val {classes}}} but only \\
+            the following {?is/are} asked {.and {.val {class_nm}}}.",
+        i = "This error is shown because {.arg allow_additional} is set to \\
+            {.val FALSE}."
+    ))
   }
 }
 

--- a/R/class.R
+++ b/R/class.R
@@ -157,7 +157,7 @@ bake_check_class_core <- function(x,
   missing <- setdiff(class_nm, classes)
   if (length(missing) > 0) {
     cli::cli_abort(
-      "{.var {var_nm}} should have the class{?es} {.and {.val {class_nm}}} but
+      "{.var {var_nm}} should have the class{?es} {.cls {class_nm}}} but
       only has the class{?es} {.and {.val {classes}}}."
     )
   }

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -100,23 +100,7 @@ step_classdist <- function(recipe,
                            keep_original_cols = TRUE,
                            skip = FALSE,
                            id = rand_id("classdist")) {
-  if (!is.character(class) || length(class) != 1) {
-    msg <- c(x = "{.arg class} should be a single character value.")
-
-    if (length(class) != 1) {
-      msg <- c(
-        msg,
-        i = "{length(class)} elements were supplied."
-      )
-    }
-    if (!is.character(class)) {
-      msg <- c(
-        msg,
-        i = "It was a {.obj_type_friendly {class}}."
-      )
-    }
-    cli::cli_abort(msg)
-  }
+  check_string(class)
 
   add_step(
     recipe,

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -101,8 +101,23 @@ step_classdist <- function(recipe,
                            skip = FALSE,
                            id = rand_id("classdist")) {
   if (!is.character(class) || length(class) != 1) {
-    rlang::abort("`class` should be a single character value.")
+    msg <- c(x = "{.arg class} should be a single character value.")
+
+    if (length(class) != 1) {
+      msg <- c(
+        msg,
+        i = "{length(class)} elements were supplied."
+      )
+    }
+    if (!is.character(class)) {
+      msg <- c(
+        msg,
+        i = "It was a {.obj_type_friendly {class}}."
+      )
+    }
+    cli::cli_abort(msg)
   }
+
   add_step(
     recipe,
     step_classdist_new(
@@ -148,7 +163,9 @@ step_classdist_new <-
 
 get_center <- function(x, wts = NULL, mfun = mean) {
   if (!is.null(wts) & !identical(mfun, mean)) {
-    rlang::abort("The centering function requested cannot be used with case weights.")
+    cli::cli_abort(
+      "The centering function requested cannot be used with case weights."
+    )
   }
   x <- tibble::as_tibble(x)
   if (is.null(wts)) {
@@ -161,10 +178,14 @@ get_center <- function(x, wts = NULL, mfun = mean) {
 
 get_both <- function(x, wts = NULL, mfun = mean, cfun = cov) {
   if (!is.null(wts) & !identical(mfun, mean)) {
-    rlang::abort("The centering function requested cannot be used with case weights.")
+    cli::cli_abort(
+      "The centering function requested cannot be used with case weights."
+    )
   }
   if (!is.null(wts) & !identical(cfun, cov)) {
-    rlang::abort("The variance function requested cannot be used with case weights.")
+    cli::cli_abort(
+      "The variance function requested cannot be used with case weights."
+    )
   }
 
   if (is.null(wts)) {

--- a/R/colcheck.R
+++ b/R/colcheck.R
@@ -81,14 +81,11 @@ bake.check_cols <- function(object, new_data, ...) {
   new_cols <- names(new_data)
   missing <- setdiff(original_cols, new_cols)
   if (length(missing) > 0) {
-    mis_cols <- paste(paste0("`", missing, "`"), collapse = ", ")
-    rlang::abort(
-      paste0(
-        "The following cols are missing from `new_data`: ",
-        mis_cols,
-        "."
-      )
-    )
+    cli::cli_abort(c(
+      x = "{cli::qty(length(missing))}The following column{?s} {?is/are} \\
+      missing from {.arg new_data}:",
+      "*" = "{.and {.var {missing}}}."
+    ))
   }
   new_data
 }

--- a/R/count.R
+++ b/R/count.R
@@ -72,8 +72,8 @@ step_count <- function(recipe,
   if (any(!(names(options) %in% valid_args))) {
     cli::cli_abort(c(
       "x" = "The following elements of {.arg options} are not allowed:",
-      "*" = "{.and {.val {setdiff(names(options), valid_args)}}}.",
-      "i" = "Valid options are: {.and {.val {valid_args}}}."
+      "*" = "{.val {setdiff(names(options), valid_args)}}.",
+      "i" = "Valid options are: {.val {valid_args}}."
     ))
   }
 
@@ -81,8 +81,8 @@ step_count <- function(recipe,
   if (length(terms) > 1) {
     cli::cli_abort(c(
       x = "For this step, only a single selector can be used.",
-      i = "The following {length(terms)} selectors were used:\\
-          {.and {.var {as.character(terms)}}}."
+      i = "The following {length(terms)} selectors were used: \\
+          {.var {as.character(terms)}}."
     ))
   }
 
@@ -131,7 +131,7 @@ prep.step_count <- function(x, training, info = NULL, ...) {
   if (length(col_name) > 1) {
     cli::cli_abort(c(
       x = "The selector should select at most a single variable.",
-      i = "The following {length(col_name)} were selected:\\
+      i = "The following {length(col_name)} were selected: \\
           {.and {.var {col_name}}}."
     ))
   }

--- a/R/count.R
+++ b/R/count.R
@@ -96,7 +96,7 @@ step_count <- function(recipe,
   if (length(terms) > 1) {
     cli::cli_abort(c(
       x = "For this step, only a single selector can be used.",
-      i = "The following {length(col_name)} selectors were used:\\
+      i = "The following {length(terms)} selectors were used:\\
           {.and {.var {as.character(terms)}}}."
     ))
   }

--- a/R/count.R
+++ b/R/count.R
@@ -66,23 +66,8 @@ step_count <- function(recipe,
                        keep_original_cols = TRUE,
                        skip = FALSE,
                        id = rand_id("count")) {
-  if (length(pattern) != 1 || !is.character(pattern)) {
-    msg <- c(x = "{.arg pattern} should be a single character string.")
+  check_string(pattern)
 
-    if (length(pattern) != 1) {
-      msg <- c(
-        msg,
-        i = "{length(pattern)} elements were supplied."
-      )
-    }
-    if (!is.character(pattern)) {
-      msg <- c(
-        msg,
-        i = "It was a {.obj_type_friendly {pattern}}."
-      )
-    }
-    cli::cli_abort(msg)
-  }
   valid_args <- names(formals(grepl))[-(1:2)]
   if (any(!(names(options) %in% valid_args))) {
     cli::cli_abort(c(

--- a/R/count.R
+++ b/R/count.R
@@ -66,23 +66,39 @@ step_count <- function(recipe,
                        keep_original_cols = TRUE,
                        skip = FALSE,
                        id = rand_id("count")) {
-  if (!is.character(pattern)) {
-    rlang::abort("`pattern` should be a character string")
-  }
-  if (length(pattern) != 1) {
-    rlang::abort("`pattern` should be a single pattern")
+  if (length(pattern) != 1 || !is.character(pattern)) {
+    msg <- c(x = "{.arg pattern} should be a single character string.")
+
+    if (length(pattern) != 1) {
+      msg <- c(
+        msg,
+        i = "{length(pattern)} elements were supplied."
+      )
+    }
+    if (!is.character(pattern)) {
+      msg <- c(
+        msg,
+        i = "It was a {.obj_type_friendly {pattern}}."
+      )
+    }
+    cli::cli_abort(msg)
   }
   valid_args <- names(formals(grepl))[-(1:2)]
   if (any(!(names(options) %in% valid_args))) {
-    rlang::abort(paste0(
-      "Valid options are: ",
-      paste0(valid_args, collapse = ", ")
+    cli::cli_abort(c(
+      "x" = "The following elements of {.arg options} are not allowed:",
+      "*" = "{.and {.val {setdiff(names(options), valid_args)}}}.",
+      "i" = "Valid options are: {.and {.val {valid_args}}}."
     ))
   }
 
   terms <- enquos(...)
   if (length(terms) > 1) {
-    rlang::abort("For this step, only a single selector can be used.")
+    cli::cli_abort(c(
+      x = "For this step, only a single selector can be used.",
+      i = "The following {length(col_name)} selectors were used:\\
+          {.and {.var {as.character(terms)}}}."
+    ))
   }
 
   add_step(
@@ -128,7 +144,11 @@ prep.step_count <- function(x, training, info = NULL, ...) {
   check_type(training[, col_name], types = c("string", "factor", "ordered"))
 
   if (length(col_name) > 1) {
-    rlang::abort("The selector should select at most a single variable")
+    cli::cli_abort(c(
+      x = "The selector should select at most a single variable.",
+      i = "The following {length(col_name)} were selected:\\
+          {.and {.var {col_name}}}."
+    ))
   }
 
   step_count_new(

--- a/R/date.R
+++ b/R/date.R
@@ -112,7 +112,7 @@ step_date <-
         cli::cli_abort(c(
           x = "Possible values of {.arg features} should include:",
           "*" = "{.or {.val {feat}}}.",
-          i = "Invalid values were: {.and {.val {offenders}}}."
+          i = "Invalid values were: {.val {offenders}}."
         ))
       }
     }

--- a/R/date.R
+++ b/R/date.R
@@ -107,9 +107,12 @@ step_date <-
       )
     if (!is_tune(features)) {
       if (!all(features %in% feat)) {
-        rlang::abort(paste0(
-          "Possible values of `features` should include: ",
-          paste0("'", feat, "'", collapse = ", ")
+        offenders <- features[!features %in% feat]
+
+        cli::cli_abort(c(
+          x = "Possible values of {.arg features} should include:",
+          "*" = "{.or {.val {feat}}}.",
+          i = "Invalid values were: {.and {.val {offenders}}}."
         ))
       }
     }

--- a/R/depth.R
+++ b/R/depth.R
@@ -98,25 +98,8 @@ step_depth <-
            keep_original_cols = TRUE,
            skip = FALSE,
            id = rand_id("depth")) {
-    if (!is.character(class) || length(class) != 1) {
-      msg <- c(x = "{.arg class} should be a single character value.")
 
-      if (length(class) != 1) {
-        msg <- c(
-          msg,
-          i = "{length(class)} elements were supplied."
-        )
-      }
-      if (!is.character(class)) {
-        msg <- c(
-          msg,
-          i = "It was a {.obj_type_friendly {class}}."
-        )
-      }
-      cli::cli_abort(msg)
-    }
-
-
+    check_string(class)
     recipes_pkg_check(required_pkgs.step_depth())
 
     add_step(

--- a/R/depth.R
+++ b/R/depth.R
@@ -99,8 +99,23 @@ step_depth <-
            skip = FALSE,
            id = rand_id("depth")) {
     if (!is.character(class) || length(class) != 1) {
-      rlang::abort("`class` should be a single character value.")
+      msg <- c(x = "{.arg class} should be a single character value.")
+
+      if (length(class) != 1) {
+        msg <- c(
+          msg,
+          i = "{length(class)} elements were supplied."
+        )
+      }
+      if (!is.character(class)) {
+        msg <- c(
+          msg,
+          i = "It was a {.obj_type_friendly {class}}."
+        )
+      }
+      cli::cli_abort(msg)
     }
+
 
     recipes_pkg_check(required_pkgs.step_depth())
 

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -15,7 +15,7 @@ discretize <- function(x, ...) {
 discretize.default <- function(x, ...) {
   cli::cli_abort(c(
     x = "Only numeric {.arg x} is accepted.",
-    i = "{.obj_type_friendly {x}} was passed."
+    i = "The {.arg x} was passed {.obj_type_friendly {x}}."
   ))
 }
 

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -15,7 +15,7 @@ discretize <- function(x, ...) {
 discretize.default <- function(x, ...) {
   cli::cli_abort(c(
     x = "Only numeric {.arg x} is accepted.",
-    i = "A {.obj_type_friendly {x}} was passed."
+    i = "{.obj_type_friendly {x}} was passed."
   ))
 }
 

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -93,7 +93,7 @@ discretize.numeric <-
 
     if (cuts < 2) {
       cli::cli_abort(
-        "{.arg cuts} must be at least 2, not {.val {cuts}}."
+        "There should be at least 2 {.arg cuts} but {.val {cuts}} was supplied."
       )
     }
 

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -13,7 +13,10 @@ discretize <- function(x, ...) {
 #' @export
 #' @rdname discretize
 discretize.default <- function(x, ...) {
-  rlang::abort("Only numeric `x` is accepted")
+  cli::cli_abort(c(
+    x = "Only numeric {.arg x} is accepted.",
+    i = "A {.obj_type_friendly {x}} was passed."
+  ))
 }
 
 #' @rdname discretize
@@ -89,7 +92,9 @@ discretize.numeric <-
     missing_lab <- "_missing"
 
     if (cuts < 2) {
-      rlang::abort("There should be at least 2 cuts")
+      cli::cli_abort(
+        "{.arg cuts} must be at least 2, not {.val {cuts}}."
+      )
     }
 
     dots <- list(...)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -258,14 +258,12 @@ bake.step_dummy <- function(object, new_data, ...) {
     is_ordered <- attr(levels, "dataClasses") == "ordered"
 
     if (is.null(levels_values)) {
-      rlang::abort("Factor level values not recorded")
+      cli::cli_abort("Factor level values not recorded in {.var col_name}.")
     }
 
     if (length(levels_values) == 1) {
-      rlang::abort(
-        paste0(
-          "Only one factor level in ", col_name, ": ", levels_values
-        )
+      cli::cli_abort(
+        "Only one factor level in {.var col_name}: {levels_values}."
       )
     }
 

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -106,14 +106,12 @@ step_dummy_extract <-
            keep_original_cols = FALSE,
            skip = FALSE,
            id = rand_id("dummy_extract")) {
+
     if (!is_tune(threshold)) {
-      if (threshold < 0) {
-        cli::cli_abort("{.arg threshold} should not be negative.")
-      }
-      if (threshold >= 1 && !is_integerish(threshold)) {
-        cli::cli_abort(
-          "If {.arg threshold} is greater than one it should be an integer."
-        )
+      if (threshold >= 1) {
+        check_number_whole(threshold)
+      } else {
+        check_number_decimal(threshold, min = 0)
       }
     }
 

--- a/R/dummy_extract.R
+++ b/R/dummy_extract.R
@@ -108,10 +108,12 @@ step_dummy_extract <-
            id = rand_id("dummy_extract")) {
     if (!is_tune(threshold)) {
       if (threshold < 0) {
-        rlang::abort("`threshold` should not be negative.")
+        cli::cli_abort("{.arg threshold} should not be negative.")
       }
       if (threshold >= 1 && !is_integerish(threshold)) {
-        rlang::abort("If `threshold` is greater than one it should be an integer.")
+        cli::cli_abort(
+          "If {.arg threshold} is greater than one it should be an integer."
+        )
       }
     }
 
@@ -272,7 +274,7 @@ dummy_extract <- function(x, sep = NULL, pattern = NULL, call = caller_env()) {
     matches <- gregexpr(pattern = pattern, text = x, perl = TRUE)
     return(regmatches(x, m = matches))
   }
-  rlang::abort("`sep` or `pattern` must be specified.", call = call)
+  cli::cli_abort("{.arg sep} or {.arg pattern} must be specified.", call = call)
 }
 
 list_to_dummies <- function(x, dict, other = "other") {

--- a/R/dummy_multi_choice.R
+++ b/R/dummy_multi_choice.R
@@ -81,12 +81,12 @@ step_dummy_multi_choice <- function(recipe,
                                     keep_original_cols = FALSE,
                                     skip = FALSE,
                                     id = rand_id("dummy_multi_choice")) {
+
   if (!is_tune(threshold)) {
-    if (threshold < 0) {
-      cli::cli_abort("{.arg threshold} should be non-negative.")
-    }
-    if (threshold > 1) {
-      cli::cli_abort("{.arg threshold} should be less then or equal to 1.")
+    if (threshold >= 1) {
+      check_number_whole(threshold)
+    } else {
+      check_number_decimal(threshold, min = 0)
     }
   }
 

--- a/R/dummy_multi_choice.R
+++ b/R/dummy_multi_choice.R
@@ -168,7 +168,7 @@ multi_dummy_check_type <- function(dat, call = rlang::caller_env()) {
     cli::cli_abort(c(
       "x" = "All columns selected for the step should be \\
             factor, character, or NA. The following were not:",
-      "*" = "{.and {.var {offenders}}}."
+      "*" = "{.var {offenders}}."
     ), call = call)
   }
   invisible(all_good)

--- a/R/dummy_multi_choice.R
+++ b/R/dummy_multi_choice.R
@@ -83,10 +83,10 @@ step_dummy_multi_choice <- function(recipe,
                                     id = rand_id("dummy_multi_choice")) {
   if (!is_tune(threshold)) {
     if (threshold < 0) {
-      rlang::abort("`threshold` should be non-negative.")
+      cli::cli_abort("{.arg threshold} should be non-negative.")
     }
     if (threshold > 1) {
-      rlang::abort("`threshold` should be less then or equal to 1.")
+      cli::cli_abort("{.arg threshold} should be less then or equal to 1.")
     }
   }
 
@@ -157,16 +157,19 @@ prep.step_dummy_multi_choice <- function(x, training, info = NULL, ...) {
   )
 }
 
-multi_dummy_check_type <- function(dat) {
+multi_dummy_check_type <- function(dat, call = rlang::caller_env()) {
   is_good <- function(x) {
     is.factor(x) | is.character(x) | all(is.na(x))
   }
 
   all_good <- vapply(dat, is_good, logical(1))
   if (!all(all_good)) {
-    rlang::abort(
-      "All columns selected for the step should be factor, character, or NA"
-    )
+    offenders <- names(dat)[!all_good]
+    cli::cli_abort(c(
+      "x" = "All columns selected for the step should be \\
+            factor, character, or NA. The following were not:",
+      "*" = "{.and {.var {offenders}}}."
+    ), call = call)
   }
   invisible(all_good)
 }

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -147,7 +147,7 @@ prep.step_geodist <- function(x, training, info = NULL, ...) {
   if (length(lon_name) > 1) {
     cli::cli_abort(c(
       x = "The {.arg lon} selector should select at most a single variable.",
-      i = "The following {length(lon_name)} were selected:\\
+      i = "The following {length(lon_name)} were selected: \\
           {.and {.var {lon_name}}}."
     ))
   }
@@ -156,7 +156,7 @@ prep.step_geodist <- function(x, training, info = NULL, ...) {
   if (length(lat_name) > 1) {
     cli::cli_abort(c(
       x = "The {.arg lat} selector should select at most a single variable.",
-      i = "The following {length(lat_name)} were selected:\\
+      i = "The following {length(lat_name)} were selected: \\
           {.and {.var {lat_name}}}."
     ))
   }

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -171,15 +171,31 @@ step_harmonic <-
            columns = NULL,
            skip = FALSE,
            id = rand_id("harmonic")) {
-    if (!all(is.numeric(cycle_size)) | all(is.na(cycle_size))) {
-      rlang::abort("cycle_size must have at least one non-NA numeric value.")
+
+    if (!all(is.numeric(cycle_size)) || all(is.na(cycle_size))) {
+      msg <- c(
+        x = "{.arg cycle_size} must have at least one non-NA numeric value."
+      )
+
+      if (!all(is.numeric(cycle_size))) {
+        msg <- c(msg, i = "It was {.obj_type_friendly {cycle_size}}.")
+      }
+
+      if (all(is.na(cycle_size))) {
+        msg <- c(msg, i = "Only missing values were present.")
+      }
+
+      cli::cli_abort(msg)
     }
 
     if (!all(is.na(starting_val)) &
       !all(is.numeric(starting_val)) &
       !all(inherits(starting_val, "Date")) &
       !all(inherits(starting_val, "POSIXt"))) {
-      rlang::abort("starting_val must be NA, numeric, Date or POSIXt")
+      cli::cli_abort(
+        "starting_val must be NA, numeric, Date or POSIXt. \\
+        Not {.obj_type_friendly {starting_val}}.",
+      )
     }
 
     add_step(
@@ -231,10 +247,10 @@ prep.step_harmonic <- function(x, training, info = NULL, ...) {
   } else if (length(x$cycle_size) == length(col_names)) {
     cycle_sizes <- x$cycle_size
   } else {
-    rlang::abort(paste0(
-      "`cycle_size` must be length 1 or the same  ",
-      "length as the input columns"
-    ))
+    cli::cli_abort(
+      "{.arg cycle_sizes} must be length 1 or the same length as the input \\
+      columns."
+    )
   }
 
 
@@ -246,10 +262,10 @@ prep.step_harmonic <- function(x, training, info = NULL, ...) {
   } else if (length(x$starting_val) == length(col_names)) {
     starting_vals <- x$starting_val
   } else {
-    rlang::abort(paste0(
-      "`starting_val` must be length 1 or the same  ",
-      "length as the input columns"
-    ))
+    cli::cli_abort(
+      "{.arg starting_val} must be length 1 or the same length as the input \\
+      columns."
+    )
   }
 
   frequencies <- sort(unique(na.omit(x$frequency)))
@@ -278,7 +294,7 @@ sin_cos <- function(x,
                     starting_val,
                     cycle_size, call = caller_env()) {
   if (all(is.na(x))) {
-    rlang::abort("variable must have at least one non-NA value", call = call)
+    cli::cli_abort("Variable must have at least one non-NA value.", call = call)
   }
 
   nc <- length(frequency)

--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -181,10 +181,6 @@ step_harmonic <-
         msg <- c(msg, i = "It was {.obj_type_friendly {cycle_size}}.")
       }
 
-      if (all(is.na(cycle_size))) {
-        msg <- c(msg, i = "Only missing values were present.")
-      }
-
       cli::cli_abort(msg)
     }
 
@@ -193,8 +189,8 @@ step_harmonic <-
       !all(inherits(starting_val, "Date")) &
       !all(inherits(starting_val, "POSIXt"))) {
       cli::cli_abort(
-        "starting_val must be NA, numeric, Date or POSIXt. \\
-        Not {.obj_type_friendly {starting_val}}.",
+        "starting_val must be NA, numeric, Date or POSIXt, \\
+        not {.obj_type_friendly {starting_val}}.",
       )
     }
 
@@ -248,7 +244,7 @@ prep.step_harmonic <- function(x, training, info = NULL, ...) {
     cycle_sizes <- x$cycle_size
   } else {
     cli::cli_abort(
-      "{.arg cycle_sizes} must be length 1 or the same length as the input \\
+      "{.arg cycle_size} must be length 1 or the same length as the input \\
       columns."
     )
   }

--- a/R/holiday.R
+++ b/R/holiday.R
@@ -54,7 +54,10 @@ step_holiday <-
     if (!is_tune(holidays)) {
       all_days <- listHolidays()
       if (!all(holidays %in% all_days)) {
-        rlang::abort("Invalid `holidays` value. See timeDate::listHolidays")
+        cli::cli_abort(c(
+          "Invalid {.arg holidays} value. \\
+          See {.fn timeDate::listHolidays} for possible values."
+        ))
       }
     }
 

--- a/R/ica.R
+++ b/R/ica.R
@@ -161,11 +161,14 @@ prep.step_ica <- function(x, training, info = NULL, ...) {
     indc <- try(withr::with_seed(x$seed, rlang::eval_tidy(cl)), silent = TRUE)
 
     if (inherits(indc, "try-error")) {
-      rlang::abort(paste0("`step_ica` failed with error:\n", as.character(indc)))
-    } else {
-      indc <- indc[c("K", "W")]
-      indc$means <- colMeans(training[, col_names])
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(indc)
+      ))
     }
+
+    indc <- indc[c("K", "W")]
+    indc$means <- colMeans(training[, col_names])
   } else {
     indc <- NULL
   }

--- a/R/import-standalone-obj-type.R
+++ b/R/import-standalone-obj-type.R
@@ -1,0 +1,360 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-obj-type.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-obj-type.R
+# last-updated: 2023-05-01
+# license: https://unlicense.org
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-05-01:
+# - `obj_type_friendly()` now only displays the first class of S3 objects.
+#
+# 2023-03-30:
+# - `stop_input_type()` now handles `I()` input literally in `arg`.
+#
+# 2022-10-04:
+# - `obj_type_friendly(value = TRUE)` now shows numeric scalars
+#   literally.
+# - `stop_friendly_type()` now takes `show_value`, passed to
+#   `obj_type_friendly()` as the `value` argument.
+#
+# 2022-10-03:
+# - Added `allow_na` and `allow_null` arguments.
+# - `NULL` is now backticked.
+# - Better friendly type for infinities and `NaN`.
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Prefixed usage of rlang functions with `rlang::`.
+#
+# 2022-06-22:
+# - `friendly_type_of()` is now `obj_type_friendly()`.
+# - Added `obj_type_oo()`.
+#
+# 2021-12-20:
+# - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
+#
+# 2021-06-30:
+# - Added support for missing arguments.
+#
+# 2021-04-19:
+# - Added support for matrices and arrays (#141).
+# - Added documentation.
+# - Added changelog.
+#
+# nocov start
+
+#' Return English-friendly type
+#' @param x Any R object.
+#' @param value Whether to describe the value of `x`. Special values
+#'   like `NA` or `""` are always described.
+#' @param length Whether to mention the length of vectors and lists.
+#' @return A string describing the type. Starts with an indefinite
+#'   article, e.g. "an integer vector".
+#' @noRd
+obj_type_friendly <- function(x, value = TRUE) {
+  if (is_missing(x)) {
+    return("absent")
+  }
+
+  if (is.object(x)) {
+    if (inherits(x, "quosure")) {
+      type <- "quosure"
+    } else {
+      type <- class(x)[[1L]]
+    }
+    return(sprintf("a <%s> object", type))
+  }
+
+  if (!is_vector(x)) {
+    return(.rlang_as_friendly_type(typeof(x)))
+  }
+
+  n_dim <- length(dim(x))
+
+  if (!n_dim) {
+    if (!is_list(x) && length(x) == 1) {
+      if (is_na(x)) {
+        return(switch(
+          typeof(x),
+          logical = "`NA`",
+          integer = "an integer `NA`",
+          double =
+            if (is.nan(x)) {
+              "`NaN`"
+            } else {
+              "a numeric `NA`"
+            },
+          complex = "a complex `NA`",
+          character = "a character `NA`",
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      show_infinites <- function(x) {
+        if (x > 0) {
+          "`Inf`"
+        } else {
+          "`-Inf`"
+        }
+      }
+      str_encode <- function(x, width = 30, ...) {
+        if (nchar(x) > width) {
+          x <- substr(x, 1, width - 3)
+          x <- paste0(x, "...")
+        }
+        encodeString(x, ...)
+      }
+
+      if (value) {
+        if (is.numeric(x) && is.infinite(x)) {
+          return(show_infinites(x))
+        }
+
+        if (is.numeric(x) || is.complex(x)) {
+          number <- as.character(round(x, 2))
+          what <- if (is.complex(x)) "the complex number" else "the number"
+          return(paste(what, number))
+        }
+
+        return(switch(
+          typeof(x),
+          logical = if (x) "`TRUE`" else "`FALSE`",
+          character = {
+            what <- if (nzchar(x)) "the string" else "the empty string"
+            paste(what, str_encode(x, quote = "\""))
+          },
+          raw = paste("the raw value", as.character(x)),
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      return(switch(
+        typeof(x),
+        logical = "a logical value",
+        integer = "an integer",
+        double = if (is.infinite(x)) show_infinites(x) else "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "\"\"",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+  }
+
+  vec_type_friendly(x)
+}
+
+vec_type_friendly <- function(x, length = FALSE) {
+  if (!is_vector(x)) {
+    abort("`x` must be a vector.")
+  }
+  type <- typeof(x)
+  n_dim <- length(dim(x))
+
+  add_length <- function(type) {
+    if (length && !n_dim) {
+      paste0(type, sprintf(" of length %s", length(x)))
+    } else {
+      type
+    }
+  }
+
+  if (type == "list") {
+    if (n_dim < 2) {
+      return(add_length("a list"))
+    } else if (is.data.frame(x)) {
+      return("a data frame")
+    } else if (n_dim == 2) {
+      return("a list matrix")
+    } else {
+      return("a list array")
+    }
+  }
+
+  type <- switch(
+    type,
+    logical = "a logical %s",
+    integer = "an integer %s",
+    numeric = ,
+    double = "a double %s",
+    complex = "a complex %s",
+    character = "a character %s",
+    raw = "a raw %s",
+    type = paste0("a ", type, " %s")
+  )
+
+  if (n_dim < 2) {
+    kind <- "vector"
+  } else if (n_dim == 2) {
+    kind <- "matrix"
+  } else {
+    kind <- "array"
+  }
+  out <- sprintf(type, kind)
+
+  if (n_dim >= 2) {
+    out
+  } else {
+    add_length(out)
+  }
+}
+
+.rlang_as_friendly_type <- function(type) {
+  switch(
+    type,
+
+    list = "a list",
+
+    NULL = "`NULL`",
+    environment = "an environment",
+    externalptr = "a pointer",
+    weakref = "a weak reference",
+    S4 = "an S4 object",
+
+    name = ,
+    symbol = "a symbol",
+    language = "a call",
+    pairlist = "a pairlist node",
+    expression = "an expression vector",
+
+    char = "an internal string",
+    promise = "an internal promise",
+    ... = "an internal dots object",
+    any = "an internal `any` object",
+    bytecode = "an internal bytecode object",
+
+    primitive = ,
+    builtin = ,
+    special = "a primitive function",
+    closure = "a function",
+
+    type
+  )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = caller_env()) {
+  abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
+  )
+}
+
+#' Return OO type
+#' @param x Any R object.
+#' @return One of `"bare"` (for non-OO objects), `"S3"`, `"S4"`,
+#'   `"R6"`, or `"R7"`.
+#' @noRd
+obj_type_oo <- function(x) {
+  if (!is.object(x)) {
+    return("bare")
+  }
+
+  class <- inherits(x, c("R6", "R7_object"), which = TRUE)
+
+  if (class[[1]]) {
+    "R6"
+  } else if (class[[2]]) {
+    "R7"
+  } else if (isS4(x)) {
+    "S4"
+  } else {
+    "S3"
+  }
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `obj_type_friendly()` is taken and mentioned in the error message.
+#' @param what The friendly expected type as a string. Can be a
+#'   character vector of expected types, in which case the error
+#'   message mentions all of them in an "or" enumeration.
+#' @param show_value Passed to `value` argument of `obj_type_friendly()`.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            allow_na = FALSE,
+                            allow_null = FALSE,
+                            show_value = TRUE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  # From standalone-cli.R
+  cli <- env_get_list(
+    nms = c("format_arg", "format_code"),
+    last = topenv(),
+    default = function(x) sprintf("`%s`", x),
+    inherit = TRUE
+  )
+
+  if (allow_na) {
+    what <- c(what, cli$format_code("NA"))
+  }
+  if (allow_null) {
+    what <- c(what, cli$format_code("NULL"))
+  }
+  if (length(what)) {
+    what <- oxford_comma(what)
+  }
+  if (inherits(arg, "AsIs")) {
+    format_arg <- identity
+  } else {
+    format_arg <- cli$format_arg
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    obj_type_friendly(x, value = show_value)
+  )
+
+  abort(message, ..., call = call, arg = arg)
+}
+
+oxford_comma <- function(chr, sep = ", ", final = "or") {
+  n <- length(chr)
+
+  if (n < 2) {
+    return(chr)
+  }
+
+  head <- chr[seq_len(n - 1)]
+  last <- chr[n]
+
+  head <- paste(head, collapse = sep)
+
+  # Write a or b. But a, b, or c.
+  if (n > 2) {
+    paste0(head, sep, final, " ", last)
+  } else {
+    paste0(head, " ", final, " ", last)
+  }
+}
+
+# nocov end

--- a/R/import-standalone-types-check.R
+++ b/R/import-standalone-types-check.R
@@ -1,0 +1,538 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-types-check.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-types-check.R
+# last-updated: 2023-03-13
+# license: https://unlicense.org
+# dependencies: standalone-obj-type.R
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-03-13:
+# - Improved error messages of number checkers (@teunbrand)
+# - Added `allow_infinite` argument to `check_number_whole()` (@mgirlich).
+# - Added `check_data_frame()` (@mgirlich).
+#
+# 2023-03-07:
+# - Added dependency on rlang (>= 1.1.0).
+#
+# 2023-02-15:
+# - Added `check_logical()`.
+#
+# - `check_bool()`, `check_number_whole()`, and
+#   `check_number_decimal()` are now implemented in C.
+#
+# - For efficiency, `check_number_whole()` and
+#   `check_number_decimal()` now take a `NULL` default for `min` and
+#   `max`. This makes it possible to bypass unnecessary type-checking
+#   and comparisons in the default case of no bounds checks.
+#
+# 2022-10-07:
+# - `check_number_whole()` and `_decimal()` no longer treat
+#   non-numeric types such as factors or dates as numbers.  Numeric
+#   types are detected with `is.numeric()`.
+#
+# 2022-10-04:
+# - Added `check_name()` that forbids the empty string.
+#   `check_string()` allows the empty string by default.
+#
+# 2022-09-28:
+# - Removed `what` arguments.
+# - Added `allow_na` and `allow_null` arguments.
+# - Added `allow_decimal` and `allow_infinite` arguments.
+# - Improved errors with absent arguments.
+#
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Added changelog.
+#
+# nocov start
+
+# Scalars -----------------------------------------------------------------
+
+.standalone_types_check_dot_call <- .Call
+
+check_bool <- function(x,
+                       ...,
+                       allow_na = FALSE,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x) && .standalone_types_check_dot_call(ffi_standalone_is_bool_1.0.7, x, allow_na, allow_null)) {
+    return(invisible(NULL))
+  }
+
+  stop_input_type(
+    x,
+    c("`TRUE`", "`FALSE`"),
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_string <- function(x,
+                         ...,
+                         allow_empty = TRUE,
+                         allow_na = FALSE,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = allow_empty,
+      allow_na = allow_na,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a single string",
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.rlang_check_is_string <- function(x,
+                                   allow_empty,
+                                   allow_na,
+                                   allow_null) {
+  if (is_string(x)) {
+    if (allow_empty || !is_string(x, "")) {
+      return(TRUE)
+    }
+  }
+
+  if (allow_null && is_null(x)) {
+    return(TRUE)
+  }
+
+  if (allow_na && (identical(x, NA) || identical(x, na_chr))) {
+    return(TRUE)
+  }
+
+  FALSE
+}
+
+check_name <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = FALSE,
+      allow_na = FALSE,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a valid name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+IS_NUMBER_true <- 0
+IS_NUMBER_false <- 1
+IS_NUMBER_oob <- 2
+
+check_number_decimal <- function(x,
+                                 ...,
+                                 min = NULL,
+                                 max = NULL,
+                                 allow_infinite = TRUE,
+                                 allow_na = FALSE,
+                                 allow_null = FALSE,
+                                 arg = caller_arg(x),
+                                 call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = TRUE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = TRUE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_number_whole <- function(x,
+                               ...,
+                               min = NULL,
+                               max = NULL,
+                               allow_infinite = FALSE,
+                               allow_na = FALSE,
+                               allow_null = FALSE,
+                               arg = caller_arg(x),
+                               call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = FALSE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = FALSE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.stop_not_number <- function(x,
+                             ...,
+                             exit_code,
+                             allow_decimal,
+                             min,
+                             max,
+                             allow_na,
+                             allow_null,
+                             arg,
+                             call) {
+  if (allow_decimal) {
+    what <- "a number"
+  } else {
+    what <- "a whole number"
+  }
+
+  if (exit_code == IS_NUMBER_oob) {
+    min <- min %||% -Inf
+    max <- max %||% Inf
+
+    if (min > -Inf && max < Inf) {
+      what <- sprintf("%s between %s and %s", what, min, max)
+    } else if (x < min) {
+      what <- sprintf("%s larger than or equal to %s", what, min)
+    } else if (x > max) {
+      what <- sprintf("%s smaller than or equal to %s", what, max)
+    } else {
+      abort("Unexpected state in OOB check", .internal = TRUE)
+    }
+  }
+
+  stop_input_type(
+    x,
+    what,
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_symbol <- function(x,
+                         ...,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a symbol",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_arg <- function(x,
+                      ...,
+                      allow_null = FALSE,
+                      arg = caller_arg(x),
+                      call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an argument name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_call <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    if (is_call(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a defused call",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_environment <- function(x,
+                              ...,
+                              allow_null = FALSE,
+                              arg = caller_arg(x),
+                              call = caller_env()) {
+  if (!missing(x)) {
+    if (is_environment(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an environment",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_function <- function(x,
+                           ...,
+                           allow_null = FALSE,
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!missing(x)) {
+    if (is_function(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_closure <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_closure(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an R function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_formula <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_formula(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a formula",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+
+# Vectors -----------------------------------------------------------------
+
+check_character <- function(x,
+                            ...,
+                            allow_null = FALSE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  if (!missing(x)) {
+    if (is_character(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a character vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_logical <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_logical(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a logical vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_data_frame <- function(x,
+                             ...,
+                             allow_null = FALSE,
+                             arg = caller_arg(x),
+                             call = caller_env()) {
+  if (!missing(x)) {
+    if (is.data.frame(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a data frame",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+# nocov end

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -128,8 +128,9 @@ step_impute_bag <-
            skip = FALSE,
            id = rand_id("impute_bag")) {
     if (is.null(impute_with)) {
-      rlang::abort("Please list some variables in `impute_with`")
+      cli::cli_abort("{.arg impute_with} must not be empty.")
     }
+
     add_step(
       recipe,
       step_impute_bag_new(

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -108,16 +108,18 @@ step_impute_knn <-
            skip = FALSE,
            id = rand_id("impute_knn")) {
     if (is.null(impute_with)) {
-      rlang::abort("Please list some variables in `impute_with`")
+      cli::cli_abort("{.arg impute_with} must not be empty.")
     }
 
     if (!is.list(options)) {
-      rlang::abort("`options` should be a named list.")
+      cli::cli_abort("{.arg options} should be a named list.")
     }
     opt_nms <- names(options)
     if (length(options) > 0) {
       if (any(!(opt_nms %in% c("eps", "nthread")))) {
-        rlang::abort("Availible options are 'eps', and 'nthread'.")
+        cli::cli_abort(
+          "Valid values for {.arg options} are {.val eps}, and {.val nthread}."
+        )
       }
       if (all(opt_nms != "nthread")) {
         options$nthread <- 1

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -79,7 +79,7 @@ step_impute_linear <-
            skip = FALSE,
            id = rand_id("impute_linear")) {
     if (is.null(impute_with)) {
-      rlang::abort("Please provide some variables to `impute_with`.")
+      cli::cli_abort("{.arg impute_with} must not be empty.")
     }
 
     add_step(
@@ -119,21 +119,17 @@ lm_wrap <- function(vars, dat, wts = NULL, call = caller_env(2)) {
   dat <- dat[complete, ]
   wts <- wts[complete]
   if (nrow(dat) == 0) {
-    rlang::abort(
-      paste(
-        "The data used by step_impute_linear() did not have any rows",
-        "where the imputation values were all complete."
-      ),
+    cli::cli_abort(
+      "The data did not have any rows where the imputation values were all \\
+      complete. Is is thus unable to fit the linear regression model.",
       call = call
     )
   }
 
   if (!is.numeric(dat[[vars$y]])) {
-    rlang::abort(
-      glue(
-        "Variable '{vars$y}' chosen for linear regression imputation ",
-        "must be of type numeric."
-      ),
+    cli::cli_abort(
+      "Variable {.var {vars$y}} chosen for linear regression imputation \\
+      must be of type numeric. Not {.obj_type_friendly {vars$y}}.",
       call = call
     )
   }

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -129,16 +129,17 @@ prep.step_impute_lower <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
   check_type(training[, col_names], types = c("double", "integer"))
 
-  threshold <-
-    vapply(training[, col_names], min, numeric(1), na.rm = TRUE)
+  threshold <- vapply(training[, col_names], min, numeric(1), na.rm = TRUE)
   if (any(threshold < 0)) {
-    rlang::abort(
-      paste0(
-        "Some columns have negative values. Lower bound ",
-        "imputation is intended for data bounded at zero."
-      )
-    )
+    offenders <- col_names[threshold < 0]
+
+    cli::cli_abort(c(
+      x = "The following columns negative values. Lower bound imputation is \\
+          intended for data bounded at zero.",
+      "*" = "{offenders}."
+    ))
   }
+
   step_impute_lower_new(
     terms = x$terms,
     role = x$role,

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -134,9 +134,8 @@ prep.step_impute_lower <- function(x, training, info = NULL, ...) {
     offenders <- col_names[threshold < 0]
 
     cli::cli_abort(c(
-      x = "The following columns negative values. Lower bound imputation is \\
-          intended for data bounded at zero.",
-      "*" = "{offenders}."
+      x = "The following columns negative values: {offenders}.",
+      i = "Lower bound imputation is intended for data bounded at zero."
     ))
   }
 

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -203,8 +203,9 @@ print.step_modeimpute <- print.step_impute_mode
 
 mode_est <- function(x, wts = NULL, call = caller_env(2)) {
   if (!is.character(x) & !is.factor(x))
-    rlang::abort(
-      "The data should be character or factor to compute the mode.",
+    cli::cli_abort(
+      "The data should be character or factor to compute the mode. \\
+      Not {.obj_type_friendly {x}}.",
       call = call
     )
   tab <- weighted_table(x, wts = wts)

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -90,7 +90,7 @@ step_impute_roll <-
            id = rand_id("impute_roll")) {
     if (!is_tune(window)) {
       if (window < 3 | window %% 2 != 1) {
-        rlang::abort("`window` should be an odd integer >= 3")
+        cli::cli_abort("{.arg window} should be an odd integer >= 3.")
       }
       window <- as.integer(floor(window))
     }

--- a/R/interact.R
+++ b/R/interact.R
@@ -156,7 +156,9 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
     } else {
       tmp_terms <- rlang::eval_tidy(x$terms[[1]])
       if (!is_formula(tmp_terms)) {
-        rlang::abort("`term` must be a formula.")
+        cli::cli_abort(
+          "{.arg term} must be a formula. Not {.obj_type_friendly {term}}."
+        )
       }
     }
 
@@ -399,7 +401,7 @@ find_selectors <- function(f) {
     list()
   } else {
     # User supplied incorrect input
-    rlang::abort(paste0("Don't know how to handle type ", typeof(f), "."))
+    cli::cli_abort("Don't know how to handle type {typeof(f)}.")
   }
 }
 
@@ -416,7 +418,7 @@ replace_selectors <- function(x, elem, value) {
     map_pairlist(x, replace_selectors, elem, value)
   } else {
     # User supplied incorrect input
-    rlang::abort(paste0("Don't know how to handle type ", typeof(x), "."))
+    cli::cli_abort("Don't know how to handle type {typeof(f)}.")
   }
 }
 

--- a/R/intercept.R
+++ b/R/intercept.R
@@ -57,12 +57,10 @@ step_intercept <- function(recipe, ..., role = "predictor",
   if (length(list(...)) > 0) {
     rlang::warn("Selectors are not used for this step.")
   }
-  if (!is.numeric(value)) {
-    rlang::abort("Intercept value must be numeric.")
-  }
-  if (!is.character(name) | length(name) != 1) {
-    rlang::abort("Intercept/constant column name must be a character value.")
-  }
+
+  check_number_decimal(value)
+  check_string(name)
+
   add_step(
     recipe,
     step_intercept_new(

--- a/R/isomap.R
+++ b/R/isomap.R
@@ -173,7 +173,10 @@ prep.step_isomap <- function(x, training, info = NULL, ...) {
         silent = TRUE
       )
     if (inherits(iso_map, "try-error")) {
-      rlang::abort(paste0("`step_isomap` failed with error:\n", as.character(iso_map)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(iso_map)
+      ))
     }
   } else {
     iso_map <- NULL

--- a/R/kpca.R
+++ b/R/kpca.R
@@ -138,7 +138,10 @@ prep.step_kpca <- function(x, training, info = NULL, ...) {
     cl <- call_modify(cl, !!!x$options)
     kprc <- try(rlang::eval_tidy(cl), silent = TRUE)
     if (inherits(kprc, "try-error")) {
-      rlang::abort(paste0("`step_kpca` failed with error:\n", as.character(kprc)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(kprc)
+      ))
     }
   } else {
     kprc <- NULL

--- a/R/kpca_poly.R
+++ b/R/kpca_poly.R
@@ -141,7 +141,10 @@ prep.step_kpca_poly <- function(x, training, info = NULL, ...) {
       )
     kprc <- try(rlang::eval_tidy(cl), silent = TRUE)
     if (inherits(kprc, "try-error")) {
-      rlang::abort(paste0("`step_kpca_poly` failed with error:\n", as.character(kprc)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(kprc)
+      ))
     }
   } else {
     kprc <- NULL

--- a/R/kpca_rbf.R
+++ b/R/kpca_rbf.R
@@ -131,7 +131,10 @@ prep.step_kpca_rbf <- function(x, training, info = NULL, ...) {
       )
     kprc <- try(rlang::eval_tidy(cl), silent = TRUE)
     if (inherits(kprc, "try-error")) {
-      rlang::abort(paste0("`step_kpca_rbf` failed with error:\n", as.character(kprc)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(kprc)
+      ))
     }
   } else {
     kprc <- NULL

--- a/R/lag.R
+++ b/R/lag.R
@@ -97,7 +97,10 @@ step_lag_new <-
 #' @export
 prep.step_lag <- function(x, training, info = NULL, ...) {
   if (!all(x$lag == as.integer(x$lag))) {
-    rlang::abort("step_lag() requires 'lag' argument to be integer-valued.")
+    cli::cli_abort(
+      "{.arg lag} argument must be integer-valued, \\
+      not {.obj_type_friendly {lag}}."
+    )
   }
 
   step_lag_new(

--- a/R/lincomb.R
+++ b/R/lincomb.R
@@ -140,9 +140,6 @@ recommend_rm <- function(x, eps = 1e-6, ...) {
   if (!is.matrix(x)) {
     x <- as.matrix(x)
   }
-  if (is.null(colnames(x))) {
-    rlang::abort("`x` should have column names")
-  }
 
   qr_decomp <- qr(x)
   qr_decomp_R <- qr.R(qr_decomp) # extract R matrix
@@ -182,10 +179,6 @@ iter_lc_rm <- function(x,
   if (ncol(x) == 0L) {
     # Empty selection
     return(character())
-  }
-
-  if (is.null(colnames(x))) {
-    rlang::abort("`x` should have column names")
   }
 
   orig_names <- colnames(x)

--- a/R/missing.R
+++ b/R/missing.R
@@ -119,11 +119,9 @@ bake.check_missing <- function(object, new_data, ...) {
   nr_na <- colSums(is.na(subset_to_check))
   if (any(nr_na > 0)) {
     with_na <- names(nr_na[nr_na > 0])
-    with_na_str <- paste(paste0("`", with_na, "`"), collapse = ", ")
-    rlang::abort(paste0(
-      "The following columns contain missing values: ",
-      with_na_str, "."
-    ))
+    cli::cli_abort(
+      "The following columns contains missing values: {with_na}."
+    )
   }
   new_data
 }

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -107,11 +107,10 @@ new_values_func <- function(x,
     return()
   }
   if (ignore_NA) new_vals <- new_vals[!is.na(new_vals)]
-  rlang::abort(paste0(
-    colname,
-    " contains the new value(s): ",
-    paste(new_vals, collapse = ",")
-  ))
+  cli::cli_abort(
+    "{cli::qty(length(new_vals))} {.var {colname}} contains the new value{?s}\\
+    {new_vals}."
+  )
 }
 
 #' @export

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -108,8 +108,8 @@ new_values_func <- function(x,
   }
   if (ignore_NA) new_vals <- new_vals[!is.na(new_vals)]
   cli::cli_abort(
-    "{cli::qty(length(new_vals))} {.var {colname}} contains the new value{?s}\\
-    {new_vals}."
+    "{.var {colname}} contains the new \\
+    {cli::qty(length(new_vals))}value{?s}: {.val {new_vals}}."
   )
 }
 

--- a/R/nnmf.R
+++ b/R/nnmf.R
@@ -154,7 +154,10 @@ prep.step_nnmf <- function(x, training, info = NULL, ...) {
       silent = TRUE
     )
     if (inherits(nnm, "try-error")) {
-      rlang::abort(paste0("`step_nnmf` failed with error:\n", as.character(nnm)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(nnm)
+      ))
     }
   } else {
     nnm <- NULL

--- a/R/nnmf_sparse.R
+++ b/R/nnmf_sparse.R
@@ -163,11 +163,16 @@ prep.step_nnmf_sparse <- function(x, training, info = NULL, ...) {
     nnm <- try(rlang::eval_tidy(cl), silent = TRUE)
 
     if (inherits(nnm, "try-error")) {
-      rlang::abort(paste0("`step_nnmf_sparse` failed with error:\n", as.character(nnm)))
+      cli::cli_abort(c(
+        x = "Failed with error:",
+        i = as.character(nnm)
+      ))
     } else {
       na_w <- sum(is.na(nnm$w))
       if (na_w > 0) {
-        rlang::abort("The NNMF loadings are missing. The penalty may have been to high.")
+        cli::cli_abort(
+          "The NNMF loadings are missing. The penalty may have been to high."
+        )
       } else {
         nnm <- list(x_vars = col_names, w = nnm$w)
         rownames(nnm$w) <- col_names

--- a/R/novel.R
+++ b/R/novel.R
@@ -107,8 +107,6 @@ get_existing_values <- function(x) {
     if (is.factor(x)) {
       out <- levels(x)
       attr(out, "is_ordered") <- is.ordered(x)
-    } else {
-      rlang::abort("Data should be either character or factor")
     }
   }
   out
@@ -122,14 +120,11 @@ prep.step_novel <- function(x, training, info = NULL, ...) {
   # Get existing levels and their factor type (i.e. ordered)
   objects <- lapply(training[, col_names], get_existing_values)
   # Check to make sure that there are not duplicate levels
-  level_check <-
-    map_lgl(objects, function(x, y) y %in% x, y = x$new_level)
+  level_check <- map_lgl(objects, function(x, y) y %in% x, y = x$new_level)
   if (any(level_check)) {
-    rlang::abort(
-      paste0(
-        "Columns already contain the new level: ",
-        paste0(names(level_check)[level_check], collapse = ", ")
-      )
+    offenders <- names(level_check)[level_check]
+    cli::cli_abort(
+      "Columns already contain the new level: {offenders}."
     )
   }
 

--- a/R/num2factor.R
+++ b/R/num2factor.R
@@ -98,13 +98,14 @@ step_num2factor <-
            skip = FALSE,
            id = rand_id("num2factor")) {
     if (!is_tune(ordered)) {
-      if (!is.logical(ordered) || length(ordered) != 1) {
-        rlang::abort("`ordered` should be a single logical variable")
-      }
+      check_bool(ordered)
     }
 
     if (rlang::is_missing(levels) || !is.character(levels)) {
-      rlang::abort("Please provide a character vector of appropriate length for `levels`.")
+      cli::cli_abort(
+        "Please provide a character vector of appropriate length for \\
+        {.arg levels}."
+      )
     }
 
     add_step(

--- a/R/other.R
+++ b/R/other.R
@@ -108,11 +108,10 @@ step_other <-
            skip = FALSE,
            id = rand_id("other")) {
     if (!is_tune(threshold)) {
-      if (threshold < 0) {
-        rlang::abort("`threshold` should be non-negative.")
-      }
-      if (threshold >= 1 && !is_integerish(threshold)) {
-        rlang::abort("If `threshold` is greater than one it should be an integer.")
+      if (threshold >= 1) {
+        check_number_whole(threshold)
+      } else {
+        check_number_decimal(threshold, min = 0)
       }
     }
     add_step(
@@ -257,13 +256,9 @@ keep_levels <- function(x, threshold = .1, other = "other", wts = NULL,
   }
 
   if (other %in% keepers) {
-    rlang::abort(
-      paste0(
-        "The level ",
-        other,
-        " is already a factor level that will be retained. ",
-        "Please choose a different value."
-      ),
+    cli::cli_abort(
+      "The level {other} is already a factor level that will be retained. \\
+      Please choose a different value.",
       call = call
     )
   }

--- a/R/pca.R
+++ b/R/pca.R
@@ -128,9 +128,7 @@ step_pca <- function(recipe,
                      skip = FALSE,
                      id = rand_id("pca")) {
   if (!is_tune(threshold)) {
-    if (!is.na(threshold) && (threshold > 1 | threshold <= 0)) {
-      rlang::abort("`threshold` should be on (0, 1].")
-    }
+    check_number_decimal(threshold, min = 0, max = 1, allow_na = TRUE)
   }
 
   add_step(

--- a/R/pls.R
+++ b/R/pls.R
@@ -132,7 +132,7 @@ step_pls <-
            skip = FALSE,
            id = rand_id("pls")) {
     if (is.null(outcome)) {
-      rlang::abort("`outcome` should select at least one column.")
+      cli::cli_abort("{.arg outcome} should select at least one column.")
     }
 
     if (lifecycle::is_present(preserve)) {
@@ -329,8 +329,8 @@ prep.step_pls <- function(x, training, info = NULL, ...) {
   check_type(training[, x_names], types = c("double", "integer"))
 
   if (length(y_names) > 1 && any(!map_lgl(training[y_names], is.numeric))) {
-    rlang::abort(
-      "`step_pls()` only supports multivariate models for numeric outcomes."
+    cli::cli_abort(
+      "Only multivariate models for numeric outcomes are supports."
     )
   }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -14,7 +14,7 @@ recipe <- function(x, ...) {
 recipe.default <- function(x, ...) {
   cli::cli_abort(c(
     x = "{.arg x} should be a data frame, matrix, formula, or tibble.",
-    i = "{.arg x} is a {.obj_type_friendly {x}}."
+    i = "{.arg x} is {.obj_type_friendly {x}}."
   ))
 }
 
@@ -482,7 +482,7 @@ prep.recipe <-
         if (!is_tibble(training)) {
           cli::cli_abort(c(
             "x" = "{.fun bake} methods should always return tibbles.",
-            "i" = "{.fun {paste0('bake.', step_name)}} returned a \\
+            "i" = "{.fun {paste0('bake.', step_name)}} returned \\
                    {.obj_type_friendly {training}}."
           ))
         }
@@ -698,7 +698,7 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
 
       cli::cli_abort(c(
         "x" = "{.fun bake} methods should always return tibbles.",
-        "i" = "{.fun {paste0('bake.', step_name)}} returned a \\
+        "i" = "{.fun {paste0('bake.', step_name)}} returned \\
                    {.obj_type_friendly {new_data}}."
       ))
     }

--- a/R/roles.R
+++ b/R/roles.R
@@ -133,7 +133,7 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
   if (!is.character(new_type) && !is.null(new_type)) {
     cli::cli_abort(
       "{.arg new_type} must be a character vector, or {.code NULL} \\
-      not a {.obj_type_friendly {new_type}}."
+      not {.obj_type_friendly {new_type}}."
     )
   }
 

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -80,8 +80,8 @@ added to a recipe.
 \itemize{
 \item \strong{Steps} can include operations like scaling a variable, creating
 dummy variables or interactions, and so on. More computationally
-complex actions such as dimension reduction or imputation can also
-be specified.
+complex actions such as dimension reduction or imputation can also be
+specified.
 \item \strong{Checks} are operations that conduct specific tests of the data.
 When the test is satisfied, the data are returned without issue or
 modification. Otherwise, an error is thrown.
@@ -300,12 +300,12 @@ applies the estimated steps to any data set.
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 6 x 6
 ##     HHV    PC1    PC2     PC3     PC4     PC5
 ##   <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>
-## 1  18.3 0.730   0.412  0.495   0.333   0.253 
-## 2  17.6 0.617  -1.41  -0.118  -0.466   0.815 
-## 3  17.2 0.761  -1.10   0.0550 -0.397   0.747 
-## 4  18.9 0.0400 -0.950 -0.158   0.405  -0.143 
-## 5  20.5 0.792   0.732 -0.204   0.465  -0.148 
-## 6  18.5 0.433   0.127  0.354  -0.0168 -0.0888
+## 1  18.3 0.730  -0.412 -0.495   0.333   0.253 
+## 2  17.6 0.617   1.41   0.118  -0.466   0.815 
+## 3  17.2 0.761   1.10  -0.0550 -0.397   0.747 
+## 4  18.9 0.0400  0.950  0.158   0.405  -0.143 
+## 5  20.5 0.792  -0.732  0.204   0.465  -0.148 
+## 6  18.5 0.433  -0.127 -0.354  -0.0168 -0.0888
 }\if{html}{\out{</div>}}
 
 In general, the workflow interface to recipes is recommended for most

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -111,20 +111,20 @@ will not work.
 
 When creating variable selections:
 \itemize{
-\item If you are using column filtering steps, such as \code{step_corr()}, try
-to avoid hardcoding specific variable names in downstream steps in
-case those columns are removed by the filter. Instead, use
+\item If you are using column filtering steps, such as \code{step_corr()}, try to
+avoid hardcoding specific variable names in downstream steps in case
+those columns are removed by the filter. Instead, use
 \code{\link[dplyr:reexports]{dplyr::any_of()}} and
 \code{\link[dplyr:reexports]{dplyr::all_of()}}.
 \itemize{
-\item \code{\link[dplyr:reexports]{dplyr::any_of()}} will be tolerant if a
-column has been removed.
+\item \code{\link[dplyr:reexports]{dplyr::any_of()}} will be tolerant if a column
+has been removed.
 \item \code{\link[dplyr:reexports]{dplyr::all_of()}} will fail unless all of the
 columns are present in the data.
 }
-\item For both of these functions, if you are going to save the recipe as
-a binary object to use in another R session, try to avoid referring
-to a vector in your workspace.
+\item For both of these functions, if you are going to save the recipe as a
+binary object to use in another R session, try to avoid referring to a
+vector in your workspace.
 \itemize{
 \item Preferred: \code{any_of(!!var_names)}
 \item Avoid: \code{any_of(var_names)}
@@ -155,7 +155,7 @@ recipe(mpg ~ ., data = mtcars)  \%>\%
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Error in `step_log()`:
-## Caused by error in `prep()` at recipes/R/recipe.R:437:8:
+## Caused by error in `prep()` at recipes/R/recipe.R:471:8:
 ## ! Can't subset columns that don't exist.
 ## x Column `wt` doesn't exist.
 }\if{html}{\out{</div>}}

--- a/tests/testthat/_snaps/YeoJohnson.md
+++ b/tests/testthat/_snaps/YeoJohnson.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_YeoJohnson()`:
       Caused by error in `prep()`:
-      ! Missing values are not allowed for the YJ transformation. See `na_rm` option
+      x Missing values are not allowed for the YJ transformation.
+      i See `na_rm` option.
 
 # empty printing
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -162,7 +162,7 @@
     Condition
       Error in `bake()`:
       x `bake()` methods should always return tibbles.
-      i `bake.step_testthat_helper()` returned a a data frame.
+      i `bake.step_testthat_helper()` returned a data frame.
 
 ---
 
@@ -171,7 +171,7 @@
     Condition
       Error in `prep()`:
       x `bake()` methods should always return tibbles.
-      i `bake.step_testthat_helper()` returned a a data frame.
+      i `bake.step_testthat_helper()` returned a data frame.
 
 # recipe() errors if `data` is missing
 

--- a/tests/testthat/_snaps/bin2factor.md
+++ b/tests/testthat/_snaps/bin2factor.md
@@ -14,7 +14,8 @@
       rec %>% step_bin2factor(rocks, levels = letters[1:5])
     Condition
       Error in `step_bin2factor()`:
-      ! `levels` should be a two element character string
+      x `levels` should be a two element character string.
+      i 5 elements were supplied.
 
 ---
 
@@ -22,7 +23,8 @@
       rec %>% step_bin2factor(rocks, levels = 1:2)
     Condition
       Error in `step_bin2factor()`:
-      ! `levels` should be a two element character string
+      x `levels` should be a two element character string.
+      i It was a an integer vector.
 
 # empty printing
 

--- a/tests/testthat/_snaps/bin2factor.md
+++ b/tests/testthat/_snaps/bin2factor.md
@@ -14,7 +14,7 @@
       rec %>% step_bin2factor(rocks, levels = letters[1:5])
     Condition
       Error in `step_bin2factor()`:
-      x `levels` should be a two element character string.
+      x `levels` should be a 2-element character string.
       i 5 elements were supplied.
 
 ---
@@ -23,8 +23,8 @@
       rec %>% step_bin2factor(rocks, levels = 1:2)
     Condition
       Error in `step_bin2factor()`:
-      x `levels` should be a two element character string.
-      i It was a an integer vector.
+      x `levels` should be a 2-element character string.
+      i It was an integer vector.
 
 # empty printing
 

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -4,7 +4,7 @@
       bake_check_class_core(x1, "character", "x1")
     Condition
       Error in `bake_check_class_core()`:
-      ! `x1` should have the class "character" but only has the class "numeric".
+      ! `x1` should have the class <character> but has the class <numeric>.
 
 ---
 
@@ -12,7 +12,7 @@
       bake_check_class_core(x2, c("POSIXct", "Julian"), "x2")
     Condition
       Error in `bake_check_class_core()`:
-      ! `x2` should have the class "POSIXct" and "Julian" but only has the classes "POSIXct" and "POSIXt".
+      ! `x2` should have the class <POSIXct/Julian> but has the classes <POSIXct/POSIXt>.
 
 ---
 
@@ -20,7 +20,7 @@
       bake_check_class_core(x2, "POSIXct", "x2")
     Condition
       Error in `bake_check_class_core()`:
-      x `x2` has class "POSIXct" and "POSIXt" but only the following are asked "POSIXct".
+      x `x2` has class <POSIXct/POSIXt> but only the following are asked: <POSIXct>.
       i This error is shown because `allow_additional` is set to "FALSE".
 
 # check_class works when class is learned
@@ -29,7 +29,7 @@
       bake(rec1, x_newdata)
     Condition
       Error:
-      ! `x1` should have the class "numeric" but only has the class "character".
+      ! `x1` should have the class <numeric> but has the class <character>.
 
 ---
 
@@ -37,7 +37,7 @@
       bake(rec1, x_newdata_2)
     Condition
       Error:
-      x `x2` has class "POSIXct", "POSIXt", and "Julian" but only the following are asked "POSIXct" and "POSIXt".
+      x `x2` has class <POSIXct/POSIXt/Julian> but only the following are asked: <POSIXct/POSIXt>.
       i This error is shown because `allow_additional` is set to "FALSE".
 
 # check_class works when class is provided
@@ -46,7 +46,7 @@
       bake(rec2, x_newdata)
     Condition
       Error:
-      ! `x1` should have the class "numeric" but only has the class "character".
+      ! `x1` should have the class <numeric> but has the class <character>.
 
 ---
 
@@ -54,7 +54,7 @@
       bake(rec3, x_newdata_2)
     Condition
       Error:
-      x `x2` has class "POSIXct", "POSIXt", and "Julian" but only the following are asked "POSIXct" and "POSIXt".
+      x `x2` has class <POSIXct/POSIXt/Julian> but only the following are asked: <POSIXct/POSIXt>.
       i This error is shown because `allow_additional` is set to "FALSE".
 
 # characters are handled correctly
@@ -63,7 +63,7 @@
       bake(rec6_NULL, sacr_fac[11:20, ])
     Condition
       Error:
-      ! `city` should have the class "factor" but only has the class "character".
+      ! `city` should have the class <factor> but has the class <character>.
 
 ---
 
@@ -71,7 +71,7 @@
       bake(rec6_man, sacr_fac[11:20, ])
     Condition
       Error:
-      ! `type` should have the class "factor" but only has the class "character".
+      ! `type` should have the class <factor> but has the class <character>.
 
 # empty printing
 

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -4,7 +4,7 @@
       bake_check_class_core(x1, "character", "x1")
     Condition
       Error in `bake_check_class_core()`:
-      ! x1 should have the class(es) character but has the class(es) numeric.
+      ! `x1` should have the class "character" but only has the class "numeric".
 
 ---
 
@@ -12,7 +12,7 @@
       bake_check_class_core(x2, c("POSIXct", "Julian"), "x2")
     Condition
       Error in `bake_check_class_core()`:
-      ! x2 should have the class(es) POSIXct, Julian but has the class(es) POSIXct, POSIXt.
+      ! `x2` should have the class "POSIXct" and "Julian" but only has the classes "POSIXct" and "POSIXt".
 
 ---
 
@@ -20,7 +20,8 @@
       bake_check_class_core(x2, "POSIXct", "x2")
     Condition
       Error in `bake_check_class_core()`:
-      ! x2 has the class(es) POSIXct, POSIXt, but only the following is/are asked POSIXct, allow_additional is FALSE.
+      x `x2` has class "POSIXct" and "POSIXt" but only the following are asked "POSIXct".
+      i This error is shown because `allow_additional` is set to "FALSE".
 
 # check_class works when class is learned
 
@@ -28,7 +29,7 @@
       bake(rec1, x_newdata)
     Condition
       Error:
-      ! x1 should have the class(es) numeric but has the class(es) character.
+      ! `x1` should have the class "numeric" but only has the class "character".
 
 ---
 
@@ -36,7 +37,8 @@
       bake(rec1, x_newdata_2)
     Condition
       Error:
-      ! x2 has the class(es) POSIXct, POSIXt, Julian, but only the following is/are asked POSIXct, POSIXt, allow_additional is FALSE.
+      x `x2` has class "POSIXct", "POSIXt", and "Julian" but only the following are asked "POSIXct" and "POSIXt".
+      i This error is shown because `allow_additional` is set to "FALSE".
 
 # check_class works when class is provided
 
@@ -44,7 +46,7 @@
       bake(rec2, x_newdata)
     Condition
       Error:
-      ! x1 should have the class(es) numeric but has the class(es) character.
+      ! `x1` should have the class "numeric" but only has the class "character".
 
 ---
 
@@ -52,7 +54,8 @@
       bake(rec3, x_newdata_2)
     Condition
       Error:
-      ! x2 has the class(es) POSIXct, POSIXt, Julian, but only the following is/are asked POSIXct, POSIXt, allow_additional is FALSE.
+      x `x2` has class "POSIXct", "POSIXt", and "Julian" but only the following are asked "POSIXct" and "POSIXt".
+      i This error is shown because `allow_additional` is set to "FALSE".
 
 # characters are handled correctly
 
@@ -60,7 +63,7 @@
       bake(rec6_NULL, sacr_fac[11:20, ])
     Condition
       Error:
-      ! city should have the class(es) factor but has the class(es) character.
+      ! `city` should have the class "factor" but only has the class "character".
 
 ---
 
@@ -68,7 +71,7 @@
       bake(rec6_man, sacr_fac[11:20, ])
     Condition
       Error:
-      ! type should have the class(es) factor but has the class(es) character.
+      ! `type` should have the class "factor" but only has the class "character".
 
 # empty printing
 

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_count()`:
       x For this step, only a single selector can be used.
-      i The following 2 selectors were used:`~description` and `~rows`.
+      i The following 2 selectors were used: `~description` and `~rows`.
 
 ---
 

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -4,7 +4,8 @@
       rec %>% step_count(description, rows, pattern = "(rock|stony)")
     Condition
       Error in `step_count()`:
-      ! For this step, only a single selector can be used.
+      x For this step, only a single selector can be used.
+      i The following 2 selectors were used:`~description` and `~rows`.
 
 ---
 

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -74,7 +74,7 @@
     Condition
       Error in `step_discretize()`:
       Caused by error in `recipes::discretize()`:
-      ! `cuts` must be at least 2, not 1.
+      ! There should be at least 2 `cuts` but 1 was supplied.
 
 ---
 

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -5,7 +5,7 @@
     Condition
       Error in `discretize()`:
       x Only numeric `x` is accepted.
-      i A a character vector was passed.
+      i a character vector was passed.
 
 # printing of discretize()
 

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -4,7 +4,8 @@
       discretize(letters)
     Condition
       Error in `discretize()`:
-      ! Only numeric `x` is accepted
+      x Only numeric `x` is accepted.
+      i A a character vector was passed.
 
 # printing of discretize()
 
@@ -73,7 +74,7 @@
     Condition
       Error in `step_discretize()`:
       Caused by error in `recipes::discretize()`:
-      ! There should be at least 2 cuts
+      ! `cuts` must be at least 2, not 1.
 
 ---
 

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -5,7 +5,7 @@
     Condition
       Error in `discretize()`:
       x Only numeric `x` is accepted.
-      i a character vector was passed.
+      i The `x` was passed a character vector.
 
 # printing of discretize()
 

--- a/tests/testthat/_snaps/geodist.md
+++ b/tests/testthat/_snaps/geodist.md
@@ -97,7 +97,7 @@
       Error in `step_geodist()`:
       Caused by error in `prep()`:
       x The `lat` selector should select at most a single variable.
-      i The following 2 were selected:`x` and `x1`.
+      i The following 2 were selected: `x` and `x1`.
 
 ---
 
@@ -108,7 +108,7 @@
       Error in `step_geodist()`:
       Caused by error in `prep()`:
       x The `lon` selector should select at most a single variable.
-      i The following 2 were selected:`y` and `y1`.
+      i The following 2 were selected: `y` and `y1`.
 
 ---
 

--- a/tests/testthat/_snaps/geodist.md
+++ b/tests/testthat/_snaps/geodist.md
@@ -5,7 +5,7 @@
         log = FALSE, ref_lat = 100, ref_lon = 100, is_lat_lon = TRUE) %>% prep()
     Condition
       Error in `step_geodist()`:
-      ! `ref_lat` should be between -90 and 90
+      ! `ref_lat` must be a number between -90 and 90, not the number 100.
 
 ---
 
@@ -14,7 +14,7 @@
         log = FALSE, ref_lat = 0, ref_lon = 190, is_lat_lon = TRUE) %>% prep()
     Condition
       Error in `step_geodist()`:
-      ! `ref_lon` should be between -180 and 180
+      ! `ref_lon` must be a number between -180 and 180, not the number 190.
 
 ---
 
@@ -23,7 +23,7 @@
         log = FALSE, ref_lat = -100, ref_lon = 0, is_lat_lon = TRUE) %>% prep()
     Condition
       Error in `step_geodist()`:
-      ! `ref_lat` should be between -90 and 90
+      ! `ref_lat` must be a number between -90 and 90, not the number -100.
 
 ---
 
@@ -32,7 +32,7 @@
         log = FALSE, ref_lat = 0, ref_lon = -190, is_lat_lon = TRUE) %>% prep()
     Condition
       Error in `step_geodist()`:
-      ! `ref_lon` should be between -180 and 180
+      ! `ref_lon` must be a number between -180 and 180, not the number -190.
 
 ---
 
@@ -43,7 +43,7 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `bake()`:
-      ! All `lat` values should be between -90 and 90
+      ! All `lat` values should be between -90 and 90.
 
 ---
 
@@ -54,7 +54,7 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `bake()`:
-      ! All `lon` values should be between -180 and 180
+      ! All `lon` values should be between -180 and 180.
 
 ---
 
@@ -65,7 +65,7 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `bake()`:
-      ! All `lat` values should be between -90 and 90
+      ! All `lat` values should be between -90 and 90.
 
 ---
 
@@ -76,7 +76,7 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `bake()`:
-      ! All `lon` values should be between -180 and 180
+      ! All `lon` values should be between -180 and 180.
 
 # check_name() is used
 
@@ -96,7 +96,8 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `prep()`:
-      ! `lat` should resolve to a single column name.
+      x The `lat` selector should select at most a single variable.
+      i The following 2 were selected:`x` and `x1`.
 
 ---
 
@@ -106,7 +107,8 @@
     Condition
       Error in `step_geodist()`:
       Caused by error in `prep()`:
-      ! `lon` should resolve to a single column name.
+      x The `lon` selector should select at most a single variable.
+      i The following 2 were selected:`y` and `y1`.
 
 ---
 
@@ -115,7 +117,7 @@
         training = rand_data_2)
     Condition
       Error in `step_geodist()`:
-      ! `ref_lat` should be a single numeric value.
+      ! `ref_lat` must be a number, not a character vector.
 
 ---
 
@@ -124,7 +126,7 @@
         training = rand_data_2)
     Condition
       Error in `step_geodist()`:
-      ! `ref_lon` should be a single numeric value.
+      ! `ref_lon` must be a number, not a character vector.
 
 ---
 
@@ -133,7 +135,7 @@
         training = rand_data_2)
     Condition
       Error in `step_geodist()`:
-      ! `name` should be a single character value.
+      ! `name` must be a single string, not the number 1.
 
 ---
 
@@ -142,7 +144,7 @@
         prep(training = rand_data_2)
     Condition
       Error in `step_geodist()`:
-      ! `log` should be a single logical value.
+      ! `log` must be `TRUE` or `FALSE`, not the number 2.72.
 
 ---
 
@@ -151,7 +153,7 @@
         ref_lon = 0.25, is_lat_lon = "no", log = FALSE) %>% prep(training = rand_data)
     Condition
       Error in `step_geodist()`:
-      ! `is_lat_lon` should be a single logical value.
+      ! `is_lat_lon` must be `TRUE` or `FALSE`, not the string "no".
 
 ---
 
@@ -160,7 +162,7 @@
         ref_lon = 0.25, is_lat_lon = c(TRUE, TRUE), log = FALSE) %>% prep(training = rand_data)
     Condition
       Error in `step_geodist()`:
-      ! `is_lat_lon` should be a single logical value.
+      ! `is_lat_lon` must be `TRUE` or `FALSE`, not a logical vector.
 
 # empty printing
 

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -5,7 +5,9 @@
         frequency = 1, cycle_size = NA)
     Condition
       Error in `step_harmonic()`:
-      ! cycle_size must have at least one non-NA numeric value.
+      x `cycle_size` must have at least one non-NA numeric value.
+      i It was `NA`.
+      i Only missing values were present.
 
 ---
 
@@ -14,7 +16,9 @@
         frequency = 1, starting_val = 0, cycle_size = NA)
     Condition
       Error in `step_harmonic()`:
-      ! cycle_size must have at least one non-NA numeric value.
+      x `cycle_size` must have at least one non-NA numeric value.
+      i It was `NA`.
+      i Only missing values were present.
 
 ---
 
@@ -23,7 +27,8 @@
         frequency = 1, starting_val = 0, cycle_size = "a")
     Condition
       Error in `step_harmonic()`:
-      ! cycle_size must have at least one non-NA numeric value.
+      x `cycle_size` must have at least one non-NA numeric value.
+      i It was a string.
 
 ---
 
@@ -32,7 +37,7 @@
         frequency = 1, starting_val = "a", cycle_size = 86400)
     Condition
       Error in `step_harmonic()`:
-      ! starting_val must be NA, numeric, Date or POSIXt
+      ! starting_val must be NA, numeric, Date or POSIXt. Not a string.
 
 ---
 
@@ -41,7 +46,7 @@
         frequency = 1, starting_val = factor("a"), cycle_size = 86400)
     Condition
       Error in `step_harmonic()`:
-      ! starting_val must be NA, numeric, Date or POSIXt
+      ! starting_val must be NA, numeric, Date or POSIXt. Not a <factor> object.
 
 # harmonic NA in term
 
@@ -51,7 +56,7 @@
     Condition
       Error in `step_harmonic()`:
       Caused by error in `bake()`:
-      ! variable must have at least one non-NA value
+      ! Variable must have at least one non-NA value.
 
 # harmonic character in term
 
@@ -73,7 +78,7 @@
     Condition
       Error in `step_harmonic()`:
       Caused by error in `prep()`:
-      ! `cycle_size` must be length 1 or the same  length as the input columns
+      ! `cycle_sizes` must be length 1 or the same length as the input columns.
 
 # harmonic starting_val length
 
@@ -84,7 +89,7 @@
     Condition
       Error in `step_harmonic()`:
       Caused by error in `prep()`:
-      ! `starting_val` must be length 1 or the same  length as the input columns
+      ! `starting_val` must be length 1 or the same length as the input columns.
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -7,7 +7,6 @@
       Error in `step_harmonic()`:
       x `cycle_size` must have at least one non-NA numeric value.
       i It was `NA`.
-      i Only missing values were present.
 
 ---
 
@@ -18,7 +17,6 @@
       Error in `step_harmonic()`:
       x `cycle_size` must have at least one non-NA numeric value.
       i It was `NA`.
-      i Only missing values were present.
 
 ---
 
@@ -37,7 +35,7 @@
         frequency = 1, starting_val = "a", cycle_size = 86400)
     Condition
       Error in `step_harmonic()`:
-      ! starting_val must be NA, numeric, Date or POSIXt. Not a string.
+      ! starting_val must be NA, numeric, Date or POSIXt, not a string.
 
 ---
 
@@ -46,7 +44,7 @@
         frequency = 1, starting_val = factor("a"), cycle_size = 86400)
     Condition
       Error in `step_harmonic()`:
-      ! starting_val must be NA, numeric, Date or POSIXt. Not a <factor> object.
+      ! starting_val must be NA, numeric, Date or POSIXt, not a <factor> object.
 
 # harmonic NA in term
 
@@ -78,7 +76,7 @@
     Condition
       Error in `step_harmonic()`:
       Caused by error in `prep()`:
-      ! `cycle_sizes` must be length 1 or the same length as the input columns.
+      ! `cycle_size` must be length 1 or the same length as the input columns.
 
 # harmonic starting_val length
 

--- a/tests/testthat/_snaps/impute_linear.md
+++ b/tests/testthat/_snaps/impute_linear.md
@@ -6,7 +6,7 @@
     Condition
       Error in `step_impute_linear()`:
       Caused by error in `prep()`:
-      ! Variable 'supp' chosen for linear regression imputation must be of type numeric.
+      ! Variable `supp` chosen for linear regression imputation must be of type numeric. Not a string.
 
 ---
 
@@ -16,7 +16,7 @@
     Condition
       Error in `step_impute_linear()`:
       Caused by error in `prep()`:
-      ! Variable 'supp' chosen for linear regression imputation must be of type numeric.
+      ! Variable `supp` chosen for linear regression imputation must be of type numeric. Not a string.
 
 # case weights
 

--- a/tests/testthat/_snaps/impute_lower.md
+++ b/tests/testthat/_snaps/impute_lower.md
@@ -5,7 +5,8 @@
     Condition
       Error in `step_impute_lower()`:
       Caused by error in `prep()`:
-      ! Some columns have negative values. Lower bound imputation is intended for data bounded at zero.
+      x The following columns negative values. Lower bound imputation is intended for data bounded at zero.
+      * has_neg.
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/impute_lower.md
+++ b/tests/testthat/_snaps/impute_lower.md
@@ -5,8 +5,8 @@
     Condition
       Error in `step_impute_lower()`:
       Caused by error in `prep()`:
-      x The following columns negative values. Lower bound imputation is intended for data bounded at zero.
-      * has_neg.
+      x The following columns negative values: has_neg.
+      i Lower bound imputation is intended for data bounded at zero.
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/impute_mode.md
+++ b/tests/testthat/_snaps/impute_mode.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_impute_mode()`:
       Caused by error in `prep()`:
-      ! The data should be character or factor to compute the mode.
+      ! The data should be character or factor to compute the mode. Not an integer vector.
 
 # can bake recipes with no ptype
 

--- a/tests/testthat/_snaps/impute_roll.md
+++ b/tests/testthat/_snaps/impute_roll.md
@@ -16,7 +16,7 @@
         step_impute_roll(all_predictors(), window = 4) %>% prep(training = example_data)
     Condition
       Error in `step_impute_roll()`:
-      ! `window` should be an odd integer >= 3
+      ! `window` should be an odd integer >= 3.
 
 ---
 

--- a/tests/testthat/_snaps/intercept.md
+++ b/tests/testthat/_snaps/intercept.md
@@ -4,7 +4,7 @@
       recipe(~., data = ex_dat) %>% step_intercept(value = "Pie") %>% prep()
     Condition
       Error in `step_intercept()`:
-      ! Intercept value must be numeric.
+      ! `value` must be a number, not the string "Pie".
 
 ---
 
@@ -12,7 +12,7 @@
       recipe(~., data = ex_dat) %>% step_intercept(name = 4) %>% prep()
     Condition
       Error in `step_intercept()`:
-      ! Intercept/constant column name must be a character value.
+      ! `name` must be a single string, not the number 4.
 
 ---
 

--- a/tests/testthat/_snaps/isomap.md
+++ b/tests/testthat/_snaps/isomap.md
@@ -27,8 +27,8 @@
     Condition
       Error in `step_isomap()`:
       Caused by error in `prep()`:
-      ! `step_isomap` failed with error:
-      Error : TridiagEigen: eigen decomposition failed
+      x Failed with error:
+      i Error : TridiagEigen: eigen decomposition failed
 
 # check_name() is used
 

--- a/tests/testthat/_snaps/lag.md
+++ b/tests/testthat/_snaps/lag.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_lag()`:
       Caused by error in `prep()`:
-      ! step_lag() requires 'lag' argument to be integer-valued.
+      ! `lag` argument must be integer-valued, not a function.
 
 # empty printing
 

--- a/tests/testthat/_snaps/missing.md
+++ b/tests/testthat/_snaps/missing.md
@@ -5,7 +5,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `a`.
+      ! The following columns contains missing values: a.
 
 ---
 
@@ -14,7 +14,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `b`.
+      ! The following columns contains missing values: b.
 
 ---
 
@@ -23,7 +23,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `d`.
+      ! The following columns contains missing values: d.
 
 ---
 
@@ -32,7 +32,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `e`.
+      ! The following columns contains missing values: e.
 
 # check_missing works on multiple columns simultaneously
 
@@ -41,7 +41,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `a`, `e`.
+      ! The following columns contains missing values: a and e.
 
 ---
 
@@ -50,7 +50,7 @@
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:
-      ! The following columns contain missing values: `a`, `b`, `d`, `e`.
+      ! The following columns contains missing values: a, b, d, and e.
 
 # check_missing on a new set
 
@@ -58,7 +58,7 @@
       bake(rp, na)
     Condition
       Error in `bake()`:
-      ! The following columns contain missing values: `a`.
+      ! The following columns contains missing values: a.
 
 # empty printing
 

--- a/tests/testthat/_snaps/newvalues.md
+++ b/tests/testthat/_snaps/newvalues.md
@@ -4,7 +4,7 @@
       new_values_func(x, allowed_values[-3], colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! MacGyver contains the new value(s): c
+      ! `MacGyver` contains the new valuec.
 
 # new_values_func correctly prints multiple new values
 
@@ -12,7 +12,7 @@
       new_values_func(x, allowed_values[-c(2:3)], colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! MacGyver contains the new value(s): b,c
+      ! `MacGyver` contains the new valueb and c.
 
 # new_values_func breaks when NA is new value and ignore_NA is FALSE
 
@@ -20,7 +20,7 @@
       new_values_func(x_na, allowed_values, ignore_NA = FALSE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! MacGyver contains the new value(s): NA
+      ! `MacGyver` contains the new valueNA.
 
 # new_values_func correctly prints multiple new values with NA
 
@@ -28,7 +28,7 @@
       new_values_func(x_na, allowed_values[-3], ignore_NA = FALSE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! MacGyver contains the new value(s): c,NA
+      ! `MacGyver` contains the new valuec and NA.
 
 # new_values_func correctly prints only non na-values when also NA as new value and ignore_NA is TRUE
 
@@ -36,7 +36,7 @@
       new_values_func(x_na, allowed_values[-3], ignore_NA = TRUE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! MacGyver contains the new value(s): c
+      ! `MacGyver` contains the new valuec.
 
 # check_new_values breaks with new values
 
@@ -44,7 +44,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2[1:4, , drop = FALSE])
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): d
+      ! `a` contains the new valued.
 
 ---
 
@@ -52,7 +52,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): d,e
+      ! `a` contains the new valued and e.
 
 # check_new_values ignores NA by default
 
@@ -60,7 +60,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): d
+      ! `a` contains the new valued.
 
 # check_new_values not ignoring NA argument
 
@@ -69,7 +69,7 @@
         , drop = FALSE])
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): NA
+      ! `a` contains the new valueNA.
 
 ---
 
@@ -77,7 +77,7 @@
       recipe(x1) %>% check_new_values(a, ignore_NA = FALSE) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): d,NA
+      ! `a` contains the new valued and NA.
 
 # check_new_values works on doubles
 
@@ -85,7 +85,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): 1.3
+      ! `a` contains the new value1.3.
 
 # check_new_values works on integers
 
@@ -93,7 +93,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): 3
+      ! `a` contains the new value3.
 
 # check_new_values works on factors
 
@@ -101,7 +101,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): c
+      ! `a` contains the new valuec.
 
 # check_new_values works on characters
 
@@ -109,7 +109,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): c
+      ! `a` contains the new valuec.
 
 # check_new_values works on logicals
 
@@ -117,7 +117,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! a contains the new value(s): FALSE
+      ! `a` contains the new valueFALSE.
 
 # empty printing
 

--- a/tests/testthat/_snaps/newvalues.md
+++ b/tests/testthat/_snaps/newvalues.md
@@ -4,7 +4,7 @@
       new_values_func(x, allowed_values[-3], colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! `MacGyver` contains the new valuec.
+      ! `MacGyver` contains the new value: "c".
 
 # new_values_func correctly prints multiple new values
 
@@ -12,7 +12,7 @@
       new_values_func(x, allowed_values[-c(2:3)], colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! `MacGyver` contains the new valueb and c.
+      ! `MacGyver` contains the new values: "b" and "c".
 
 # new_values_func breaks when NA is new value and ignore_NA is FALSE
 
@@ -20,7 +20,7 @@
       new_values_func(x_na, allowed_values, ignore_NA = FALSE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! `MacGyver` contains the new valueNA.
+      ! `MacGyver` contains the new value: NA.
 
 # new_values_func correctly prints multiple new values with NA
 
@@ -28,7 +28,7 @@
       new_values_func(x_na, allowed_values[-3], ignore_NA = FALSE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! `MacGyver` contains the new valuec and NA.
+      ! `MacGyver` contains the new values: "c" and NA.
 
 # new_values_func correctly prints only non na-values when also NA as new value and ignore_NA is TRUE
 
@@ -36,7 +36,7 @@
       new_values_func(x_na, allowed_values[-3], ignore_NA = TRUE, colname = "MacGyver")
     Condition
       Error in `new_values_func()`:
-      ! `MacGyver` contains the new valuec.
+      ! `MacGyver` contains the new value: "c".
 
 # check_new_values breaks with new values
 
@@ -44,7 +44,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2[1:4, , drop = FALSE])
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valued.
+      ! `a` contains the new value: "d".
 
 ---
 
@@ -52,7 +52,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valued and e.
+      ! `a` contains the new values: "d" and "e".
 
 # check_new_values ignores NA by default
 
@@ -60,7 +60,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valued.
+      ! `a` contains the new value: "d".
 
 # check_new_values not ignoring NA argument
 
@@ -69,7 +69,7 @@
         , drop = FALSE])
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valueNA.
+      ! `a` contains the new value: NA.
 
 ---
 
@@ -77,7 +77,7 @@
       recipe(x1) %>% check_new_values(a, ignore_NA = FALSE) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valued and NA.
+      ! `a` contains the new values: "d" and NA.
 
 # check_new_values works on doubles
 
@@ -85,7 +85,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new value1.3.
+      ! `a` contains the new value: "1.3".
 
 # check_new_values works on integers
 
@@ -93,7 +93,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new value3.
+      ! `a` contains the new value: "3".
 
 # check_new_values works on factors
 
@@ -101,7 +101,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valuec.
+      ! `a` contains the new value: "c".
 
 # check_new_values works on characters
 
@@ -109,7 +109,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valuec.
+      ! `a` contains the new value: "c".
 
 # check_new_values works on logicals
 
@@ -117,7 +117,7 @@
       recipe(x1) %>% check_new_values(a) %>% prep() %>% bake(x2)
     Condition
       Error in `new_values_func()`:
-      ! `a` contains the new valueFALSE.
+      ! `a` contains the new value: "FALSE".
 
 # empty printing
 

--- a/tests/testthat/_snaps/novel.md
+++ b/tests/testthat/_snaps/novel.md
@@ -15,7 +15,7 @@
     Condition
       Error in `step_novel()`:
       Caused by error in `prep()`:
-      ! Columns already contain the new level: x
+      ! Columns already contain the new level: x.
 
 # empty printing
 

--- a/tests/testthat/_snaps/other.md
+++ b/tests/testthat/_snaps/other.md
@@ -13,7 +13,7 @@
       rec %>% step_other(city, zip, threshold = 3.14)
     Condition
       Error in `step_other()`:
-      ! If `threshold` is greater than one it should be an integer.
+      ! `threshold` must be a whole number, not the number 3.14.
 
 # othering with case weights
 

--- a/tests/testthat/_snaps/pls.md
+++ b/tests/testthat/_snaps/pls.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_pls()`:
       Caused by error in `prep()`:
-      ! `step_pls()` only supports multivariate models for numeric outcomes.
+      ! Only multivariate models for numeric outcomes are supports.
 
 # PLS-DA, sparse loadings, multiple outcomes
 
@@ -14,7 +14,7 @@
     Condition
       Error in `step_pls()`:
       Caused by error in `prep()`:
-      ! `step_pls()` only supports multivariate models for numeric outcomes.
+      ! Only multivariate models for numeric outcomes are supports.
 
 # check_name() is used
 

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -64,8 +64,6 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_logical"]
   step_check <- step_check[step_check != "check_data_frame"]
 
-
-
   has_skip_arg <- function(x) {
     x_code <- getFromNamespace(x, "recipes")
     x_args <- names(formals(x_code))

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -47,6 +47,25 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_role_requirements"]
   step_check <- step_check[step_check != "check_bake_role_requirements"]
 
+  # R/import-standalone-types-check.R
+  step_check <- step_check[step_check != "check_bool"]
+  step_check <- step_check[step_check != "check_string"]
+  step_check <- step_check[step_check != "check_name"]
+  step_check <- step_check[step_check != "check_number_decimal"]
+  step_check <- step_check[step_check != "check_number_whole"]
+  step_check <- step_check[step_check != "check_symbol"]
+  step_check <- step_check[step_check != "check_arg"]
+  step_check <- step_check[step_check != "check_call"]
+  step_check <- step_check[step_check != "check_environment"]
+  step_check <- step_check[step_check != "check_function"]
+  step_check <- step_check[step_check != "check_closure"]
+  step_check <- step_check[step_check != "check_formula"]
+  step_check <- step_check[step_check != "check_character"]
+  step_check <- step_check[step_check != "check_logical"]
+  step_check <- step_check[step_check != "check_data_frame"]
+
+
+
   has_skip_arg <- function(x) {
     x_code <- getFromNamespace(x, "recipes")
     x_args <- names(formals(x_code))


### PR DESCRIPTION
Ref: https://github.com/tidymodels/recipes/issues/1237

This is the first batch of moving towards {cli} in the step functions. I did around 1/4 of the `rlang::abort()` calls in this PR.

I realized I badly needed the rlang standalone checkers for many use-cases so I pulled them in midway through.