### PR TITLE
link to info on model formulas in error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
     kernlab,
     knitr,
     modeldata (>= 0.1.1),
-    parsnip (>= 0.1.7),
+    parsnip (>= 1.1.1.9001),
     RANN,
     RcppRoll,
     rmarkdown,
@@ -72,3 +72,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes:
+    tidymodels/parsnip

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -279,9 +279,11 @@ inline_check <- function(x) {
     cli::cli_abort(c(
       x = "No in-line functions should be used here.",
       i = "{cli::qty(length(funs))}The following function{?s} {?was/were} \\
-          found:",
-      "*" = "{.and {.code {funs}}}",
-      i = "Use steps to do transformations instead."
+          found: {.and {.code {funs}}}.",
+      i = "Use steps to do transformations instead.",
+      i = "If your modeling engine uses special terms in formulas, pass \\
+          that formula to workflows as a \\
+          {.help [model formula](parsnip::model_formula)}."
     ))
   }
 

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -80,8 +80,8 @@ added to a recipe.
 \itemize{
 \item \strong{Steps} can include operations like scaling a variable, creating
 dummy variables or interactions, and so on. More computationally
-complex actions such as dimension reduction or imputation can also
-be specified.
+complex actions such as dimension reduction or imputation can also be
+specified.
 \item \strong{Checks} are operations that conduct specific tests of the data.
 When the test is satisfied, the data are returned without issue or
 modification. Otherwise, an error is thrown.
@@ -300,12 +300,12 @@ applies the estimated steps to any data set.
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 6 x 6
 ##     HHV    PC1    PC2     PC3     PC4     PC5
 ##   <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>
-## 1  18.3 0.730   0.412  0.495   0.333   0.253 
-## 2  17.6 0.617  -1.41  -0.118  -0.466   0.815 
-## 3  17.2 0.761  -1.10   0.0550 -0.397   0.747 
-## 4  18.9 0.0400 -0.950 -0.158   0.405  -0.143 
-## 5  20.5 0.792   0.732 -0.204   0.465  -0.148 
-## 6  18.5 0.433   0.127  0.354  -0.0168 -0.0888
+## 1  18.3 0.730  -0.412 -0.495   0.333   0.253 
+## 2  17.6 0.617   1.41   0.118  -0.466   0.815 
+## 3  17.2 0.761   1.10  -0.0550 -0.397   0.747 
+## 4  18.9 0.0400  0.950  0.158   0.405  -0.143 
+## 5  20.5 0.792  -0.732  0.204   0.465  -0.148 
+## 6  18.5 0.433  -0.127 -0.354  -0.0168 -0.0888
 }\if{html}{\out{</div>}}
 
 In general, the workflow interface to recipes is recommended for most

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -111,20 +111,20 @@ will not work.
 
 When creating variable selections:
 \itemize{
-\item If you are using column filtering steps, such as \code{step_corr()}, try
-to avoid hardcoding specific variable names in downstream steps in
-case those columns are removed by the filter. Instead, use
+\item If you are using column filtering steps, such as \code{step_corr()}, try to
+avoid hardcoding specific variable names in downstream steps in case
+those columns are removed by the filter. Instead, use
 \code{\link[dplyr:reexports]{dplyr::any_of()}} and
 \code{\link[dplyr:reexports]{dplyr::all_of()}}.
 \itemize{
-\item \code{\link[dplyr:reexports]{dplyr::any_of()}} will be tolerant if a
-column has been removed.
+\item \code{\link[dplyr:reexports]{dplyr::any_of()}} will be tolerant if a column
+has been removed.
 \item \code{\link[dplyr:reexports]{dplyr::all_of()}} will fail unless all of the
 columns are present in the data.
 }
-\item For both of these functions, if you are going to save the recipe as
-a binary object to use in another R session, try to avoid referring
-to a vector in your workspace.
+\item For both of these functions, if you are going to save the recipe as a
+binary object to use in another R session, try to avoid referring to a
+vector in your workspace.
 \itemize{
 \item Preferred: \code{any_of(!!var_names)}
 \item Avoid: \code{any_of(var_names)}
@@ -155,7 +155,7 @@ recipe(mpg ~ ., data = mtcars)  \%>\%
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Error in `step_log()`:
-## Caused by error in `prep()` at recipes/R/recipe.R:437:8:
+## Caused by error in `prep()` at recipes/R/recipe.R:473:8:
 ## ! Can't subset columns that don't exist.
 ## x Column `wt` doesn't exist.
 }\if{html}{\out{</div>}}

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -5,9 +5,9 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function was found:
-      * `log`
+      i The following function was found: `log`.
       i Use steps to do transformations instead.
+      i If your modeling engine uses special terms in formulas, pass that formula to workflows as a model formula (`?parsnip::model_formula()`).
 
 ---
 
@@ -16,9 +16,9 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following functions were found:
-      * `^` and `(`
+      i The following functions were found: `^` and `(`.
       i Use steps to do transformations instead.
+      i If your modeling engine uses special terms in formulas, pass that formula to workflows as a model formula (`?parsnip::model_formula()`).
 
 ---
 
@@ -27,9 +27,9 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function was found:
-      * `:`
+      i The following function was found: `:`.
       i Use steps to do transformations instead.
+      i If your modeling engine uses special terms in formulas, pass that formula to workflows as a model formula (`?parsnip::model_formula()`).
 
 ---
 
@@ -38,9 +38,9 @@
     Condition
       Error in `inline_check()`:
       x No in-line functions should be used here.
-      i The following function was found:
-      * `^`
+      i The following function was found: `^`.
       i Use steps to do transformations instead.
+      i If your modeling engine uses special terms in formulas, pass that formula to workflows as a model formula (`?parsnip::model_formula()`).
 
 # Using prepare
 


### PR DESCRIPTION
This PR follows up on https://github.com/tidymodels/parsnip/pull/1015, where I put together a help-page on model formulas that we could link to throughout tidymodels errors and docs. I think this check would be a great place to spot folks who need this information but haven't found it yet.

Made sure to think through the "cascade" when putting these PRs together. With merging this PR as-is, this would put as at:

* tune, then yardstick

and, independently, 

* parsnip, then recipes