### PR TITLE
fix: print_step not using width parameter

### DIFF
--- a/R/printing.R
+++ b/R/printing.R
@@ -46,7 +46,7 @@ print_step <- function(tr_obj = NULL,
     )
   )
 
-  width_diff <- cli::console_width() * 1 - width_title
+  width_diff <- width - width_title
 
   if (trained) {
     elements <- tr_obj


### PR DESCRIPTION
Althou variety of `print.step_*()` passes its own `width` to `print_step()`, `print_step()` is not using it.

This PR fixes the problem.

Example of widths defined by `print.step_*()` are below

https://github.com/tidymodels/recipes/blob/17211e6dfc61516adf510cb27a543ce1bef44da9/R/dummy.R#L313-L314

https://github.com/tidymodels/recipes/blob/17211e6dfc61516adf510cb27a543ce1bef44da9/R/inverse.R#L110-L111


