### PR TITLE
step_pca  bake speed/memory issue #1265

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # recipes (development version)
 
-* Minor speed-up and reduced memory consumption for `step_pca` in the `bake` stage by reducing unused multiplications (#1265)
+* Minor speed-up and reduced memory consumption for `step_pca()` in the `bake()` stage by reducing unused multiplications (@jkennel, #1265)
 
 * Fixed bug where `step_factor2string()` if `strings_as_factors = TRUE` is set in `prep()`. (#317)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Minor speed-up and reduced memory consumption for `step_pca` in the `bake` stage by reducing unused multiplications (#1265)
+
 * Fixed bug where `step_factor2string()` if `strings_as_factors = TRUE` is set in `prep()`. (#317)
 
 * Document that `update_role()`, `add_role()` and `remove_role()` are applied before steps and checks. (#778)

--- a/R/pca.R
+++ b/R/pca.R
@@ -250,8 +250,7 @@ bake.step_pca <- function(object, new_data, ...) {
 
   pca_vars <- rownames(object$res$rotation)
   comps <- scale(new_data[, pca_vars], object$res$center, object$res$scale) %*%
-    object$res$rotation
-  comps <- comps[, seq_len(object$num_comp), drop = FALSE]
+    object$res$rotation[, seq_len(object$num_comp), drop = FALSE]
   comps <- check_name(comps, new_data, object)
   new_data <- vec_cbind(new_data, as_tibble(comps))
   new_data <- remove_original_cols(new_data, object, pca_vars)


### PR DESCRIPTION
This pull request subsets the rotation matrix before multiplication instead of after. 

to close https://github.com/tidymodels/recipes/issues/1265