### PR TITLE
only have second prep() throw warning if training argument is specified

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -635,7 +635,8 @@ check_training_set <- function(x, rec, fresh, call = rlang::caller_env()) {
   # In case a variable has multiple roles
   vars <- unique(rec$var_info$variable)
 
-  if (is.null(x)) {
+  training_null <- is.null(x)
+  if (training_null) {
     if (fresh) {
       cli::cli_abort(
         "A training set must be supplied to the {.arg training} argument \\
@@ -670,7 +671,7 @@ check_training_set <- function(x, rec, fresh, call = rlang::caller_env()) {
         call = call
       )
     }
-    if (!is.null(rec$template)) {
+    if (!training_null) {
       cli::cli_warn(
         c(
           "!" = "The previous data will be used by {.fn prep}.",

--- a/tests/testthat/_snaps/retraining.md
+++ b/tests/testthat/_snaps/retraining.md
@@ -2,28 +2,16 @@
 
     Code
       no_sulfur_trained <- prep(no_sulfur)
-    Condition
-      Warning in `prep()`:
-      ! The previous data will be used by `prep()`.
-      i The data passed using `training` will be ignored.
 
 ---
 
     Code
       sequentially <- prep(scale_last)
-    Condition
-      Warning in `prep()`:
-      ! The previous data will be used by `prep()`.
-      i The data passed using `training` will be ignored.
 
 ---
 
     Code
       in_stages_trained <- prep(in_stages)
-    Condition
-      Warning in `prep()`:
-      ! The previous data will be used by `prep()`.
-      i The data passed using `training` will be ignored.
 
 ---
 


### PR DESCRIPTION
Both of the following used to throw the warning on main which is too much

``` r
library(recipes)

rec <- recipe(~ ., data = mtcars) |>
  step_center(mpg, disp) |>
  prep()

tmp <- rec |> prep()
tmp <- rec |> prep(training = mtcars)
#> Warning in prep(rec, training = mtcars): 
#> ! The previous data will be used by `prep()`.
#> ℹ The data passed using `training` will be ignored.
```
