### PR TITLE
rewrite fun_calls() to not use recursion

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -136,24 +136,9 @@ dummy_extract_names <- function(var, lvl, ordinal = FALSE, sep = "_") {
   nms
 }
 
-
-## As suggested by HW, brought in from the `pryr` package
-## https://github.com/hadley/pryr
-fun_calls <- function(f) {
-  if (is.function(f)) {
-    fun_calls(body(f))
-  } else if (is_quosure(f)) {
-    fun_calls(quo_get_expr(f))
-  } else if (is.call(f)) {
-    fname <- as.character(f[[1]])
-    # Calls inside .Internal are special and shouldn't be included
-    if (identical(fname, ".Internal")) {
-      return(fname)
-    }
-    unique(c(fname, unlist(lapply(f[-1], fun_calls), use.names = FALSE)))
-  }
+fun_calls <- function(f, data) {
+  setdiff(all.names(f), colnames(data))
 }
-
 
 get_levels <- function(x) {
   if (!is.factor(x) & !is.character(x)) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -194,7 +194,7 @@ recipe.data.frame <-
 #' @export
 recipe.formula <- function(formula, data, ...) {
   # check for minus:
-  f_funcs <- fun_calls(formula)
+  f_funcs <- fun_calls(formula, data)
   if (any(f_funcs == "-")) {
     cli::cli_abort(c(
       "x" = "{.code -} is not allowed in a recipe formula.",
@@ -230,7 +230,7 @@ form2args <- function(formula, data, ..., call = rlang::caller_env()) {
   }
 
   ## check for in-line formulas
-  inline_check(formula)
+  inline_check(formula, data)
 
   if (!is_tibble(data)) {
     data <- as_tibble(data)
@@ -271,9 +271,9 @@ form2args <- function(formula, data, ..., call = rlang::caller_env()) {
   list(x = data, vars = vars, roles = roles)
 }
 
-inline_check <- function(x) {
-  funs <- fun_calls(x)
-  funs <- funs[!(funs %in% c("~", "+", "-"))]
+inline_check <- function(x, data) {
+  funs <- fun_calls(x, data)
+  funs <- funs[!(funs %in% c("~", "+", "-", "."))]
 
   if (length(funs) > 0) {
     cli::cli_abort(c(


### PR DESCRIPTION
I learned about `all.names()` a couple of days ago. And it works wonders in recipes!

The previous issues we had with long formulas was that `fun_calls()` was recursive, and it just couldn't handle that large formulas. People were seeing issues with as low as 200 columns.

``` r
df <- matrix(rnorm(10 * 10001), ncol = 10001)
df <- as.data.frame(df)
names(df) <- c("y", paste0("x", 1:10000))

library(recipes)

rec <- recipe(DF2formula(df), df)

rec |> prep() |> bake(df)
#> # A tibble: 10 × 10,001
#>        x1     x2     x3      x4      x5      x6      x7     x8       x9     x10
#>     <dbl>  <dbl>  <dbl>   <dbl>   <dbl>   <dbl>   <dbl>  <dbl>    <dbl>   <dbl>
#>  1 -0.697  0.294  0.223  0.314   1.91    0.420  -0.652   2.04  -0.00553 -1.97  
#>  2  0.529  0.845  0.725  1.68    0.0474 -1.35    0.251  -1.51  -0.128   -0.0383
#>  3 -1.10   0.932 -0.642 -1.01    0.497  -0.227   0.170  -1.48  -1.11     0.462 
#>  4  0.152 -0.989  1.26   0.477   2.93   -0.908  -0.503   1.06  -1.38     0.363 
#>  5 -1.37   1.86  -0.887 -0.746  -0.624  -0.621  -0.504   2.15  -1.34    -1.74  
#>  6 -0.919  0.739  1.30   0.0830 -1.43   -0.589   0.0628  0.825  0.0854   0.768 
#>  7  0.561  0.636 -0.565 -0.308   0.738   0.0233 -1.10    0.994  0.504    0.0450
#>  8 -0.859  0.320  0.270  0.179  -0.821   2.39   -0.374  -1.51  -0.145    1.41  
#>  9 -0.366  0.650 -0.665  2.44    0.823   0.0493 -0.0434 -0.504  0.707    0.403 
#> 10  0.391 -0.819 -1.00   0.407  -1.81   -0.340   0.0638 -0.334  1.04    -1.50  
#> # ℹ 9,991 more variables: x11 <dbl>, x12 <dbl>, x13 <dbl>, x14 <dbl>,
#> #   x15 <dbl>, x16 <dbl>, x17 <dbl>, x18 <dbl>, x19 <dbl>, x20 <dbl>,
#> #   x21 <dbl>, x22 <dbl>, x23 <dbl>, x24 <dbl>, x25 <dbl>, x26 <dbl>,
#> #   x27 <dbl>, x28 <dbl>, x29 <dbl>, x30 <dbl>, x31 <dbl>, x32 <dbl>,
#> #   x33 <dbl>, x34 <dbl>, x35 <dbl>, x36 <dbl>, x37 <dbl>, x38 <dbl>,
#> #   x39 <dbl>, x40 <dbl>, x41 <dbl>, x42 <dbl>, x43 <dbl>, x44 <dbl>,
#> #   x45 <dbl>, x46 <dbl>, x47 <dbl>, x48 <dbl>, x49 <dbl>, x50 <dbl>, …
```