### PR TITLE
Fix for legacy recipes in `bake.step_log()` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 ## Bug Fixes
 
+* Fixed bug where `step_log()` breaks legacy recipe objects by indexing `names(object)` in `bake()`. (@stufield, #1284)
+
 * Fixed bug where `step_factor2string()` if `strings_as_factors = TRUE` is set in `prep()`. (#317)
 
 * Fixed bug where `tidy.step_cut()` always returned zero row tibbles for trained recipes. (#1229)

--- a/R/log.R
+++ b/R/log.R
@@ -124,6 +124,7 @@ prep.step_log <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_log <- function(object, new_data, ...) {
+  # For backward compatibility #1284
   col_names <- names(object$columns) %||% object$columns
   check_new_data(col_names, object, new_data)
 

--- a/R/log.R
+++ b/R/log.R
@@ -124,7 +124,7 @@ prep.step_log <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_log <- function(object, new_data, ...) {
-  col_names <- names(object$columns)
+  col_names <- names(object$columns) %||% object$columns
   check_new_data(col_names, object, new_data)
 
   # for backward compat


### PR DESCRIPTION
## Possible Bugfix

- Here is one option to allow legacy objects to still generate `bake()ed` objects in the new `recipes` syntax.
- Not sure if this fits in the larger plan for future upgrades and harmonizing with other steps in the recipe suite, however.
- Feel free to decline if this does not fit with the larger context.

## commit message:
- legacy recipes index the `columns` entry of `object` whereas newer recipes index `names(object$columns)`
- this breaks backward compatibility
- This bugfix prefers the 'new' syntax, but if `names(object)` is `NULL`, reverts to the 'old' syntax
- fixes #1284