### PR TITLE
Remove ellipsis dependency.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Depends:
 Imports: 
     cli,
     clock (>= 0.6.1),
-    ellipsis,
     generics (>= 0.1.2),
     glue,
     gower,

--- a/R/selections.R
+++ b/R/selections.R
@@ -123,7 +123,7 @@ NULL
 #'
 #' This is a developer tool that is only useful for creating new recipes steps.
 #'
-#' @inheritParams ellipsis::dots_empty
+#' @inheritParams rlang::args_dots_empty
 #'
 #' @param quos A list of quosures describing the selection. This is generally
 #'   the `...` argument of your step function, captured with [rlang::enquos()]
@@ -172,7 +172,7 @@ NULL
 #' recipes_eval_select(quos, scat, info)
 recipes_eval_select <- function(quos, data, info, ..., allow_rename = FALSE,
                                 check_case_weights = TRUE, call = caller_env()) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
 
   if (rlang::is_missing(quos)) {
     cli::cli_abort("Argument {.arg quos} is missing, with no default.")


### PR DESCRIPTION
As ellipsis is deprecated (and imports rlang). https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0

No change to commit from documenting.

Since recipes uses `@import rlang`, this will work as is.