### PR TITLE
delete dead code around deprecate_stop()

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -124,13 +124,13 @@ step_dummy <-
            keep_original_cols = FALSE,
            skip = FALSE,
            id = rand_id("dummy")) {
+    
     if (lifecycle::is_present(preserve)) {
       lifecycle::deprecate_stop(
         "0.1.16",
         "step_dummy(preserve = )",
         "step_dummy(keep_original_cols = )"
       )
-      keep_original_cols <- preserve
     }
 
     add_step(

--- a/R/nzv.R
+++ b/R/nzv.R
@@ -93,9 +93,8 @@ step_nzv <-
            skip = FALSE,
            id = rand_id("nzv")) {
     exp_list <- list(freq_cut = 95 / 5, unique_cut = 10)
+    
     if (!isTRUE(all.equal(exp_list, options))) {
-      freq_cut <- options$freq_cut
-      unique_cut <- options$unique_cut
       lifecycle::deprecate_stop(
         "0.1.7",
         "step_nzv(options)",

--- a/R/pls.R
+++ b/R/pls.R
@@ -141,7 +141,6 @@ step_pls <-
         "step_pls(preserve = )",
         "step_pls(keep_original_cols = )"
       )
-      keep_original_cols <- preserve
     }
 
     recipes_pkg_check(required_pkgs.step_pls())


### PR DESCRIPTION
Delete dead code around `lifecycle::deprecate_stop()` since it won't be called

to close #https://github.com/tidymodels/recipes/issues/1307