### PR TITLE
fix mistake in documented default value of keep_original_cols

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)
 
+* Fixed documentation mistake where default value of `keep_original_cols` argument were wrong. (#1314)
+
 # recipes 1.0.10
 
 ## Bug Fixes

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -17,6 +17,8 @@
 #'  the natural log function?
 #' @param objects Statistics are stored here once this step has
 #'  been trained by [prep()].
+#' @param keep_original_cols A logical to keep the original variables in the
+#'  output. Defaults to `TRUE`.
 #' @template step-return
 #' @family multivariate transformation steps
 #' @export

--- a/R/count.R
+++ b/R/count.R
@@ -3,6 +3,7 @@
 #' `step_count()` creates a *specification* of a recipe step that will create a
 #' variable that counts instances of a regular expression pattern in text.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... A single selector function to choose which variable

--- a/R/depth.R
+++ b/R/depth.R
@@ -4,6 +4,7 @@
 #' numeric data into a measurement of *data depth*. This is done for each value of
 #' a categorical class variable.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param class A single character string that specifies a single

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -3,6 +3,7 @@
 #' `step_geodist()` creates a *specification* of a recipe step that will
 #' calculate the distance between points on a map to a reference location.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param lon,lat Selector functions to choose which variables are

--- a/R/indicate_na.R
+++ b/R/indicate_na.R
@@ -4,6 +4,7 @@
 #' create and append additional binary columns to the data set to indicate which
 #' observations are missing.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param prefix A character string that will be the prefix to the

--- a/R/interact.R
+++ b/R/interact.R
@@ -3,6 +3,7 @@
 #' `step_interact()` creates a *specification* of a recipe step that will create
 #' new columns that are interaction terms between two or more variables.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param terms A traditional R formula that contains interaction

--- a/R/lag.R
+++ b/R/lag.R
@@ -5,6 +5,7 @@
 #' the lag was induced. These can be removed with [step_naomit()], or you may
 #' specify an alternative filler value with the `default` argument.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param lag A vector of positive integers. Each specified column will be

--- a/R/regex.R
+++ b/R/regex.R
@@ -3,6 +3,7 @@
 #' `step_regex()` creates a *specification* of a recipe step that will create a
 #' new dummy variable based on a regular expression.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @param ... A single selector function to choose which variable

--- a/R/window.R
+++ b/R/window.R
@@ -4,6 +4,7 @@
 #' new columns that are the results of functions that compute statistics across
 #' moving windows.
 #'
+#' @inheritParams step_classdist
 #' @inheritParams step_center
 #' @inheritParams step_pca
 #' @param role For model terms created by this step, what analysis

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -56,7 +56,7 @@ been trained by \code{\link[=prep]{prep()}}.}
 variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_classdist_shrunken.Rd
+++ b/man/step_classdist_shrunken.Rd
@@ -50,7 +50,7 @@ the natural log function?}
 variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{objects}{Statistics are stored here once this step has
 been trained by \code{\link[=prep]{prep()}}.}

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -53,7 +53,7 @@ variable being searched. This is \code{NULL} until computed by
 \code{\link[=prep]{prep()}}.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_depth.Rd
+++ b/man/step_depth.Rd
@@ -57,7 +57,7 @@ depth functions. See \code{\link[ddalpha:depth.halfspace]{ddalpha::depth.halfspa
 variables. See notes below.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_geodist.Rd
+++ b/man/step_geodist.Rd
@@ -54,7 +54,7 @@ issued.}
 is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -37,7 +37,7 @@ is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.
 resulting new variables. Defaults to "na_ind".}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -40,7 +40,7 @@ interaction (e.g. \code{var1_x_var2} instead of the more
 traditional \code{var1:var2}).}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_lag.Rd
+++ b/man/step_lag.Rd
@@ -44,7 +44,7 @@ left by lagging (defaults to NA).}
 is a placeholder and will be populated once \code{\link[=prep]{prep()}} is used.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -49,7 +49,7 @@ variable being searched. This is \code{NULL} until computed by
 \code{\link[=prep]{prep()}}.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -57,7 +57,7 @@ are not sure what columns will be selected, use the
 the names of the new columns created by the step.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
-output. Defaults to \code{FALSE}.}
+output. Defaults to \code{TRUE}.}
 
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[=bake]{bake()}}? While all operations are baked


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/1276 and close https://github.com/tidymodels/recipes/issues/1267

```r
library(tidyverse)
library(recipes)

steps <- ls(getNamespace("recipes")) |>
  stringr::str_subset("^step_") |>
  stringr::str_subset("_new$", negate = TRUE)


get_arg <- function(x) {
  res <- getFromNamespace(x, getNamespace("recipes"))
  res <- formals(res)
  res$keep_original_cols
}

get_doc <- function(x) {
  readLines(paste0("man/", x, ".Rd")) |>
    paste(collapse = " ") |>
    str_extract("\\item\\{keep_original_cols\\}\\{.*?\\item") |>
    str_remove("\\item\\{keep_original_cols\\}\\{") |>
    str_remove("\\} *\\\\item") |>
    str_remove(".*\\{") |>
    str_remove("\\}.*") |>
    as.logical()
}

tibble(
  name = steps
) |>
  mutate(default = purrr::map(steps, get_arg)) |>
  filter(lengths(default) > 0) |>
  mutate(default = unlist(default)) |>
  mutate(doc = map_lgl(name, get_doc)) |>
  filter(default != doc)

#> # A tibble: 10 × 3
#> name                      default doc  
#> <chr>                     <lgl>   <lgl>
#> 1 step_classdist          TRUE    FALSE
#> 2 step_classdist_shrunken TRUE    FALSE
#> 3 step_count              TRUE    FALSE
#> 4 step_depth              TRUE    FALSE
#> 5 step_geodist            TRUE    FALSE
#> 6 step_indicate_na        TRUE    FALSE
#> 7 step_interact           TRUE    FALSE
#> 8 step_lag                TRUE    FALSE
#> 9 step_regex              TRUE    FALSE
#> 10 step_window            TRUE    FALSE
```