### PR TITLE
Work on everything() in recipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Fixed documentation mistake where default value of `keep_original_cols` argument were wrong. (#1314)
 
+* Added more documentation in `?selections` about how `tidyselect::everything()` works in recipes. (#1259)
+
 # recipes 1.0.10
 
 ## Bug Fixes

--- a/R/classdist.R
+++ b/R/classdist.R
@@ -81,7 +81,7 @@
 #'
 #' rec_dists <- prep(rec, training = penguins)
 #'
-#' dists_to_species <- bake(rec_dists, new_data = penguins, everything())
+#' dists_to_species <- bake(rec_dists, new_data = penguins)
 #' ## on log scale:
 #' dist_cols <- grep("classdist", names(dists_to_species), value = TRUE)
 #' dists_to_species[, c("species", dist_cols)]

--- a/R/classdist_shrunken.R
+++ b/R/classdist_shrunken.R
@@ -82,7 +82,7 @@
 #'
 #' rec_dists <- prep(rec, training = penguins)
 #'
-#' dists_to_species <- bake(rec_dists, new_data = penguins, everything())
+#' dists_to_species <- bake(rec_dists, new_data = penguins)
 #' ## on log scale:
 #' dist_cols <- grep("classdist", names(dists_to_species), value = TRUE)
 #' dists_to_species[, c("species", dist_cols)]

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -88,7 +88,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 #'
 #' credit_te[missing_examples, ]
 #' imputed_te[missing_examples, names(credit_te)]
@@ -107,7 +107,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 #'
 #' credit_te[missing_examples, ]
 #' imputed_te[missing_examples, names(credit_te)]

--- a/R/impute_mean.R
+++ b/R/impute_mean.R
@@ -60,7 +60,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 #'
 #' credit_te[missing_examples, ]
 #' imputed_te[missing_examples, names(credit_te)]

--- a/R/impute_median.R
+++ b/R/impute_median.R
@@ -51,7 +51,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 #'
 #' credit_te[missing_examples, ]
 #' imputed_te[missing_examples, names(credit_te)]

--- a/R/impute_mode.R
+++ b/R/impute_mode.R
@@ -54,7 +54,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 #'
 #' table(credit_te$Home, imputed_te$Home, useNA = "always")
 #'

--- a/R/indicate_na.R
+++ b/R/indicate_na.R
@@ -45,7 +45,7 @@
 #'
 #' imp_models <- prep(impute_rec, training = credit_tr)
 #'
-#' imputed_te <- bake(imp_models, new_data = credit_te, everything())
+#' imputed_te <- bake(imp_models, new_data = credit_te)
 step_indicate_na <-
   function(recipe,
            ...,

--- a/R/ordinalscore.R
+++ b/R/ordinalscore.R
@@ -50,7 +50,7 @@
 #'
 #' linear_values <- prep(linear_values, training = ord_data)
 #'
-#' bake(linear_values, new_data = NULL, everything())
+#' bake(linear_values, new_data = NULL)
 #'
 #' custom <- function(x) {
 #'   new_values <- c(1, 3, 7)
@@ -65,7 +65,7 @@
 #'
 #' nonlin_scores <- prep(nonlin_scores, training = ord_data)
 #'
-#' bake(nonlin_scores, new_data = NULL, everything())
+#' bake(nonlin_scores, new_data = NULL)
 #'
 #' tidy(nonlin_scores, number = 2)
 step_ordinalscore <-

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -30,7 +30,7 @@
 #' @examples
 #' library(dplyr)
 #' recipe(~., data = iris) %>%
-#'   step_rename_at(everything(), fn = ~ gsub(".", "_", ., fixed = TRUE)) %>%
+#'   step_rename_at(all_predictors(), fn = ~ gsub(".", "_", ., fixed = TRUE)) %>%
 #'   prep() %>%
 #'   bake(new_data = NULL) %>%
 #'   slice(1:10)

--- a/R/selections.R
+++ b/R/selections.R
@@ -45,6 +45,11 @@
 #'   [tidyselect::one_of()], [tidyselect::all_of()], and
 #'   [tidyselect::any_of()]
 #'
+#' Note that using [tidyselect::everything()] or any of the other `tidyselect`
+#' functions aren't restricted to predictors. They will thus select outcomes,
+#' ID, and predictor columns alike. This is why these functions should be used
+#' with care, and why [tidyselect::everything()] likely isn't what you need.
+#' 
 #' For example:
 #'
 #' \preformatted{

--- a/R/window.R
+++ b/R/window.R
@@ -89,7 +89,7 @@
 #'   )
 #' rec <- prep(rec, training = sim_dat)
 #'
-#' smoothed_dat <- bake(rec, sim_dat, everything())
+#' smoothed_dat <- bake(rec, sim_dat)
 #'
 #' ggplot(data = sim_dat, aes(x = x1, y = y1)) +
 #'   geom_point() +
@@ -106,7 +106,7 @@
 #' rec <- recipe(y1 + y2 + original ~ x1 + x2 + x3, data = sim_dat) %>%
 #'   step_window(starts_with("y"))
 #' rec <- prep(rec, training = sim_dat)
-#' smoothed_dat <- bake(rec, sim_dat, everything())
+#' smoothed_dat <- bake(rec, sim_dat)
 #' ggplot(smoothed_dat, aes(x = original, y = y1)) +
 #'   geom_point() +
 #'   theme_bw()

--- a/man/selections.Rd
+++ b/man/selections.Rd
@@ -44,6 +44,11 @@ Select helpers from the \code{tidyselect} package can also be used:
 \code{\link[tidyselect:one_of]{tidyselect::one_of()}}, \code{\link[tidyselect:all_of]{tidyselect::all_of()}}, and
 \code{\link[tidyselect:all_of]{tidyselect::any_of()}}
 
+Note that using \code{\link[tidyselect:everything]{tidyselect::everything()}} or any of the other \code{tidyselect}
+functions aren't restricted to predictors. They will thus select outcomes,
+ID, and predictor columns alike. This is why these functions should be used
+with care, and why \code{\link[tidyselect:everything]{tidyselect::everything()}} likely isn't what you need.
+
 For example:
 
 \preformatted{
@@ -155,7 +160,7 @@ recipe(mpg ~ ., data = mtcars)  \%>\%
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Error in `step_log()`:
-## Caused by error in `prep()` at recipes/R/recipe.R:476:9:
+## Caused by error in `prep()` at recipes/R/recipe.R:478:9:
 ## ! Can't select columns that don't exist.
 ## x Column `wt` doesn't exist.
 }\if{html}{\out{</div>}}

--- a/man/step_classdist.Rd
+++ b/man/step_classdist.Rd
@@ -144,7 +144,7 @@ rec <- recipe(species ~ ., data = penguins) \%>\%
 
 rec_dists <- prep(rec, training = penguins)
 
-dists_to_species <- bake(rec_dists, new_data = penguins, everything())
+dists_to_species <- bake(rec_dists, new_data = penguins)
 ## on log scale:
 dist_cols <- grep("classdist", names(dists_to_species), value = TRUE)
 dists_to_species[, c("species", dist_cols)]

--- a/man/step_classdist_shrunken.Rd
+++ b/man/step_classdist_shrunken.Rd
@@ -145,7 +145,7 @@ rec <- recipe(species ~ ., data = penguins) \%>\%
 
 rec_dists <- prep(rec, training = penguins)
 
-dists_to_species <- bake(rec_dists, new_data = penguins, everything())
+dists_to_species <- bake(rec_dists, new_data = penguins)
 ## on log scale:
 dist_cols <- grep("classdist", names(dists_to_species), value = TRUE)
 dists_to_species[, c("species", dist_cols)]

--- a/man/step_impute_bag.Rd
+++ b/man/step_impute_bag.Rd
@@ -138,7 +138,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 
 credit_te[missing_examples, ]
 imputed_te[missing_examples, names(credit_te)]
@@ -157,7 +157,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 
 credit_te[missing_examples, ]
 imputed_te[missing_examples, names(credit_te)]

--- a/man/step_impute_mean.Rd
+++ b/man/step_impute_mean.Rd
@@ -110,7 +110,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 
 credit_te[missing_examples, ]
 imputed_te[missing_examples, names(credit_te)]

--- a/man/step_impute_median.Rd
+++ b/man/step_impute_median.Rd
@@ -98,7 +98,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 
 credit_te[missing_examples, ]
 imputed_te[missing_examples, names(credit_te)]

--- a/man/step_impute_mode.Rd
+++ b/man/step_impute_mode.Rd
@@ -103,7 +103,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 
 table(credit_te$Home, imputed_te$Home, useNA = "always")
 

--- a/man/step_indicate_na.Rd
+++ b/man/step_indicate_na.Rd
@@ -93,7 +93,7 @@ impute_rec <- rec \%>\%
 
 imp_models <- prep(impute_rec, training = credit_tr)
 
-imputed_te <- bake(imp_models, new_data = credit_te, everything())
+imputed_te <- bake(imp_models, new_data = credit_te)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/step_ordinalscore.Rd
+++ b/man/step_ordinalscore.Rd
@@ -96,7 +96,7 @@ linear_values <- recipe(~ item + fail_severity, data = ord_data) \%>\%
 
 linear_values <- prep(linear_values, training = ord_data)
 
-bake(linear_values, new_data = NULL, everything())
+bake(linear_values, new_data = NULL)
 
 custom <- function(x) {
   new_values <- c(1, 3, 7)
@@ -111,7 +111,7 @@ tidy(nonlin_scores, number = 2)
 
 nonlin_scores <- prep(nonlin_scores, training = ord_data)
 
-bake(nonlin_scores, new_data = NULL, everything())
+bake(nonlin_scores, new_data = NULL)
 
 tidy(nonlin_scores, number = 2)
 }

--- a/man/step_rename_at.Rd
+++ b/man/step_rename_at.Rd
@@ -72,7 +72,7 @@ The underlying operation does not allow for case weights.
 \examples{
 library(dplyr)
 recipe(~., data = iris) \%>\%
-  step_rename_at(everything(), fn = ~ gsub(".", "_", ., fixed = TRUE)) \%>\%
+  step_rename_at(all_predictors(), fn = ~ gsub(".", "_", ., fixed = TRUE)) \%>\%
   prep() \%>\%
   bake(new_data = NULL) \%>\%
   slice(1:10)

--- a/man/step_window.Rd
+++ b/man/step_window.Rd
@@ -145,7 +145,7 @@ rec <- recipe(y1 + y2 ~ x1 + x2 + x3, data = sim_dat) \%>\%
   )
 rec <- prep(rec, training = sim_dat)
 
-smoothed_dat <- bake(rec, sim_dat, everything())
+smoothed_dat <- bake(rec, sim_dat)
 
 ggplot(data = sim_dat, aes(x = x1, y = y1)) +
   geom_point() +
@@ -162,7 +162,7 @@ sim_dat$original <- sim_dat$y1
 rec <- recipe(y1 + y2 + original ~ x1 + x2 + x3, data = sim_dat) \%>\%
   step_window(starts_with("y"))
 rec <- prep(rec, training = sim_dat)
-smoothed_dat <- bake(rec, sim_dat, everything())
+smoothed_dat <- bake(rec, sim_dat)
 ggplot(smoothed_dat, aes(x = original, y = y1)) +
   geom_point() +
   theme_bw()

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -122,7 +122,7 @@
       predictor: 10
       
       -- Operations 
-      * Checking the class(es) for: everything()
+      * Checking the class(es) for: all_predictors()
 
 ---
 

--- a/tests/testthat/_snaps/colcheck.md
+++ b/tests/testthat/_snaps/colcheck.md
@@ -1,7 +1,7 @@
 # check_col works in the bake stage
 
     Code
-      rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars[-1])
+      rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars[-1])
     Condition
       Error in `bake()`:
       x The following required columns are missing from `new_data`: `mpg`.
@@ -65,7 +65,7 @@
       predictor: 10
       
       -- Operations 
-      * Check if the following columns are present:: everything()
+      * Check if the following columns are present:: all_predictors()
 
 ---
 

--- a/tests/testthat/_snaps/cut.md
+++ b/tests/testthat/_snaps/cut.md
@@ -11,7 +11,7 @@
 ---
 
     Code
-      recipe(x) %>% step_cut(everything(), breaks = 2) %>% prep()
+      recipe(~., x) %>% step_cut(all_predictors(), breaks = 2) %>% prep()
     Condition
       Error in `step_cut()`:
       Caused by error in `prep()`:

--- a/tests/testthat/_snaps/missing.md
+++ b/tests/testthat/_snaps/missing.md
@@ -46,7 +46,7 @@
 ---
 
     Code
-      tst(everything())
+      tst(all_predictors())
     Condition
       Error in `check_missing()`:
       Caused by error in `bake()`:

--- a/tests/testthat/_snaps/profile.md
+++ b/tests/testthat/_snaps/profile.md
@@ -1,7 +1,8 @@
 # bad values
 
     Code
-      sacr_rec %>% step_profile(everything(), profile = vars(sqft)) %>% prep(data = Sacramento)
+      sacr_rec %>% step_profile(all_predictors(), profile = vars(sqft)) %>% prep(
+        data = Sacramento)
     Condition
       Error in `step_profile()`:
       Caused by error in `prep()`:

--- a/tests/testthat/_snaps/shuffle.md
+++ b/tests/testthat/_snaps/shuffle.md
@@ -1,7 +1,7 @@
 # bake a single row
 
     Code
-      dat4 <- bake(rec4, dat[1, ], everything())
+      dat4 <- bake(rec4, dat[1, ])
     Condition
       Warning:
       `new_data` contains a single row; unable to shuffle.
@@ -55,7 +55,7 @@
       predictor: 4
       
       -- Operations 
-      * Shuffled: everything()
+      * Shuffled: all_predictors()
 
 ---
 
@@ -74,5 +74,5 @@
       Training data contained 50 data points and no incomplete rows.
       
       -- Operations 
-      * Shuffled: x1, x2, x3, x4, y | Trained
+      * Shuffled: x1, x2, x3, x4 | Trained
 

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -29,8 +29,8 @@ test_that("bake_check_class helper function gives expected output", {
 })
 
 test_that("check_class works when class is learned", {
-  rec1 <- recipe(x) %>%
-    check_class(everything()) %>%
+  rec1 <- recipe(~ ., x) %>%
+    check_class(all_predictors()) %>%
     prep()
 
   expect_error(bake(rec1, x), NA)
@@ -76,7 +76,7 @@ test_that("check_class works when class is provided", {
 # recipes has internal coercion to character >> factor
 test_that("characters are handled correctly", {
   rec5_NULL <- recipe(Sacramento[1:10, ], sqft ~ .) %>%
-    check_class(everything()) %>%
+    check_class(all_predictors()) %>%
     prep(Sacramento[1:10, ], strings_as_factors = FALSE)
 
   expect_error(bake(rec5_NULL, Sacramento[11:20, ]), NA)
@@ -96,7 +96,7 @@ test_that("characters are handled correctly", {
     )
 
   rec6_NULL <- recipe(sacr_fac[1:10, ], sqft ~ .) %>%
-    check_class(everything()) %>%
+    check_class(all_predictors()) %>%
     prep(sacr_fac[1:10, ], strings_as_factors = TRUE)
 
   expect_snapshot(error = TRUE,
@@ -165,7 +165,7 @@ test_that("empty selection tidy method works", {
 
 test_that("printing", {
   rec7 <- recipe(mpg ~ ., mtcars) %>%
-    check_class(everything())
+    check_class(all_predictors())
 
   expect_snapshot(print(rec7))
   expect_snapshot(prep(rec7))

--- a/tests/testthat/test-colcheck.R
+++ b/tests/testthat/test-colcheck.R
@@ -5,8 +5,8 @@ rp1 <- recipe(mtcars, cyl ~ .)
 rp2 <- recipe(mtcars, cyl ~ mpg + drat)
 
 test_that("check_col works in the prep stage", {
-  expect_error(rp1 %>% check_cols(everything()) %>% prep(), NA)
-  expect_error(rp2 %>% check_cols(everything()) %>% prep(), NA)
+  expect_error(rp1 %>% check_cols(all_predictors()) %>% prep(), NA)
+  expect_error(rp2 %>% check_cols(all_predictors()) %>% prep(), NA)
   expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep(), NA)
   expect_error(rp2 %>% check_cols(cyl, mpg) %>% prep(), NA)
 })
@@ -14,20 +14,20 @@ test_that("check_col works in the prep stage", {
 
 test_that("check_col works in the bake stage", {
 
-  expect_error(rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars),
+  expect_error(rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
                NA)
-  expect_equal(rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars),
+  expect_equal(rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
                tibble(mtcars[ ,c(1, 3:11, 2)]))
   expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep %>% bake(mtcars), NA)
   expect_equal(rp2 %>% check_cols(cyl, mpg, drat) %>% prep %>% bake(mtcars),
                tibble(mtcars[ ,c(1, 5, 2)]))
 
   expect_error(
-    rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars),
+    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
     NA
   )
   expect_equal(
-    rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars),
+    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
     tibble(mtcars[, c(1, 3:11, 2)])
   )
   expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep() %>% bake(mtcars), NA)
@@ -36,7 +36,7 @@ test_that("check_col works in the bake stage", {
     tibble(mtcars[, c(1, 5, 2)])
   )
   expect_snapshot(error = TRUE,
-    rp1 %>% check_cols(everything()) %>% prep() %>% bake(mtcars[-1])
+    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars[-1])
   )
   expect_snapshot(error = TRUE,
     rp2 %>% check_cols(cyl, mpg, drat) %>% prep() %>%
@@ -195,7 +195,7 @@ test_that("empty selection tidy method works", {
 
 test_that("printing", {
   rec <- recipe(mpg ~ ., mtcars) %>%
-    check_cols(everything())
+    check_cols(all_predictors())
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))

--- a/tests/testthat/test-cut.R
+++ b/tests/testthat/test-cut.R
@@ -5,7 +5,7 @@ test_that("step_cut throws error on non-numerics", {
     recipe(x) %>% step_cut(cat_var, breaks = 2) %>% prep()
   )
   expect_snapshot(error = TRUE,
-    recipe(x) %>% step_cut(everything(), breaks = 2) %>% prep()
+    recipe(~., x) %>% step_cut(all_predictors(), breaks = 2) %>% prep()
   )
 })
 

--- a/tests/testthat/test-indicate_na.R
+++ b/tests/testthat/test-indicate_na.R
@@ -43,7 +43,7 @@ test_that("step_indicate_na populates binaries correctly", {
 
 test_that("step_indicate_na on all columns", {
   baked <- recipe(Ozone ~ ., data = airquality) %>%
-    step_indicate_na(everything()) %>%
+    step_indicate_na(all_predictors()) %>%
     prep(airquality, verbose = FALSE, retain = TRUE) %>%
     bake(new_data = NULL)
 
@@ -52,7 +52,7 @@ test_that("step_indicate_na on all columns", {
     c(
       "Solar.R", "Wind", "Temp", "Month", "Day", "Ozone",
       "na_ind_Solar.R", "na_ind_Wind", "na_ind_Temp",
-      "na_ind_Month", "na_ind_Day", "na_ind_Ozone"
+      "na_ind_Month", "na_ind_Day"
     )
   )
 })

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -10,7 +10,7 @@ set_with_na <- tibble(
 
 tst <- function(...) {
   cols <- quos(...)
-  recipe(set_with_na) %>%
+  recipe(~ ., set_with_na) %>%
     check_missing(!!!cols) %>%
     prep() %>%
     bake(set_with_na)
@@ -33,7 +33,7 @@ test_that("check_missing throws error on all types", {
 
 test_that("check_missing works on multiple columns simultaneously", {
   expect_snapshot(error = TRUE, tst(a, e))
-  expect_snapshot(error = TRUE, tst(everything()))
+  expect_snapshot(error = TRUE, tst(all_predictors()))
 })
 
 test_that("check_missing on a new set", {

--- a/tests/testthat/test-naomit.R
+++ b/tests/testthat/test-naomit.R
@@ -2,15 +2,15 @@ library(testthat)
 library(recipes)
 
 test_that("step_naomit on all columns", {
-  baked <- recipe(Ozone ~ ., data = airquality) %>%
-    step_naomit(everything()) %>%
+  baked <- recipe(~ ., data = airquality) %>%
+    step_naomit(all_predictors()) %>%
     prep(airquality, verbose = FALSE) %>%
     bake(new_data = NULL)
 
   na_res <- tibble(na.omit(airquality))
   attributes(na_res)$na.action <- NULL
 
-  expect_equal(baked, na_res[, c(2:6, 1)])
+  expect_equal(baked, na_res)
 })
 
 test_that("step_naomit on subset of columns", {

--- a/tests/testthat/test-ordinalscore.R
+++ b/tests/testthat/test-ordinalscore.R
@@ -65,7 +65,7 @@ test_that("nonlinear scores", {
 
 test_that("bad spec", {
   rec3 <- recipe(~., data = ex_dat) %>%
-    step_ordinalscore(everything())
+    step_ordinalscore(all_predictors())
   expect_snapshot(error = TRUE,
     prep(rec3, training = ex_dat, verbose = FALSE)
   )

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -72,7 +72,7 @@ test_that("character profile", {
 test_that("bad values", {
   expect_snapshot(error = TRUE,
     sacr_rec %>%
-      step_profile(everything(), profile = vars(sqft)) %>%
+      step_profile(all_predictors(), profile = vars(sqft)) %>%
       prep(data = Sacramento)
   )
   expect_snapshot(error = TRUE,

--- a/tests/testthat/test-shuffle.R
+++ b/tests/testthat/test-shuffle.R
@@ -46,7 +46,7 @@ test_that("nominal data", {
 
 test_that("all data", {
   rec3 <- recipe(y ~ ., data = dat) %>%
-    step_shuffle(everything())
+    step_shuffle(all_predictors())
 
   rec3 <- prep(rec3, training = dat, verbose = FALSE)
   set.seed(2516)
@@ -62,10 +62,10 @@ test_that("all data", {
 
 test_that("bake a single row", {
   rec4 <- recipe(y ~ ., data = dat) %>%
-    step_shuffle(everything())
+    step_shuffle(all_predictors())
 
   rec4 <- prep(rec4, training = dat, verbose = FALSE)
-  expect_snapshot(dat4 <- bake(rec4, dat[1, ], everything()))
+  expect_snapshot(dat4 <- bake(rec4, dat[1, ]))
   expect_equal(dat4, tibble(dat[1, ]))
 })
 
@@ -122,7 +122,7 @@ test_that("empty selection tidy method works", {
 
 test_that("printing", {
   rec <- recipe(y ~ ., data = dat) %>%
-    step_shuffle(everything())
+    step_shuffle(all_predictors())
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))


### PR DESCRIPTION
This PR does a couple of this

- documents use of everything() in selections. to close #1259 
- removes use of `everything()` in `bake()`. As it is the default
- removes use of `everything)` in tests. to avoid confusion