### PR TITLE
make add_roles() error if result is both predictor and outcome

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * `recipe()` will now show better error when columns are misspelled in formula (#1283).
 
-* `add_role()` now errors if one columns has role `"outcome"` and `"predictor"`. (#935)
+* `add_role()` now errors if a column would simultaneously have roles `"outcome"` and `"predictor"`. (#935)
 
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `recipe()` will now show better error when columns are misspelled in formula (#1283).
 
+* `add_role()` now errors if one columns has role `"outcome"` and `"predictor"`. (#935)
+
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)
 
 * Fixed documentation mistake where default value of `keep_original_cols` argument were wrong. (#1314)

--- a/R/roles.R
+++ b/R/roles.R
@@ -32,9 +32,9 @@
 #' to `recipe()`. See the `role` argument in some step functions to update
 #' roles for columns created by steps.
 #'
-#' Variables can have any arbitrary role (see the examples) but there are two
-#' special standard roles, `"predictor"` and `"outcome"`. These two roles are
-#' typically required when fitting a model.
+#' Variables can have any arbitrary role (see the examples) but there are three
+#' special standard roles, `"predictor"`, `"outcome"`, and `"case_weights"`. 
+#' The first two roles are typically required when fitting a model. 
 #'
 #' `update_role()` should be used when a variable doesn't currently have a role
 #' in the recipe, or to replace an `old_role` with a `new_role`. `add_role()`
@@ -216,6 +216,24 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
     first_row_with_var <- which(recipe$var_info$variable == .x)[1]
     recipe$var_info$source[first_row_with_var]
   })
+
+  for (var in vars) {
+    old_roles <- recipe$var_info$role[recipe$var_info$variable == var]
+
+    if (new_role == "predictor" && any(old_roles == "outcome")) {
+      cli::cli_abort(
+        "{.var {var}} cannot get {.val predictor} role as it is already \\
+          has role {.val outcome}."
+        )
+    }
+    
+    if (new_role == "outcome" && any(old_roles == "predictor")) {
+      cli::cli_abort(
+        "{.var {var}} cannot get {.val outcome} role as it is already \\
+        has role {.val predictor}."
+      )
+    }
+  }
 
   for (i in seq_along(vars)) {
     last_row_with_var <- dplyr::last(which(recipe$var_info$variable == vars[i]))

--- a/R/roles.R
+++ b/R/roles.R
@@ -222,14 +222,14 @@ add_role <- function(recipe, ..., new_role = "predictor", new_type = NULL) {
 
     if (new_role == "predictor" && any(old_roles == "outcome")) {
       cli::cli_abort(
-        "{.var {var}} cannot get {.val predictor} role as it is already \\
+        "{.var {var}} cannot get {.val predictor} role as it already \\
           has role {.val outcome}."
         )
     }
     
     if (new_role == "outcome" && any(old_roles == "predictor")) {
       cli::cli_abort(
-        "{.var {var}} cannot get {.val outcome} role as it is already \\
+        "{.var {var}} cannot get {.val outcome} role as it already \\
         has role {.val predictor}."
       )
     }

--- a/tests/testthat/_snaps/roles.md
+++ b/tests/testthat/_snaps/roles.md
@@ -296,7 +296,7 @@
       recipe(mpg ~ ., data = mtcars) %>% add_role(mpg, new_role = "predictor")
     Condition
       Error in `add_role()`:
-      ! `mpg` cannot get "predictor" role as it is already has role "outcome".
+      ! `mpg` cannot get "predictor" role as it already has role "outcome".
 
 ---
 
@@ -304,5 +304,5 @@
       recipe(mpg ~ ., data = mtcars) %>% add_role(disp, new_role = "outcome")
     Condition
       Error in `add_role()`:
-      ! `disp` cannot get "outcome" role as it is already has role "predictor".
+      ! `disp` cannot get "outcome" role as it already has role "predictor".
 

--- a/tests/testthat/_snaps/roles.md
+++ b/tests/testthat/_snaps/roles.md
@@ -290,3 +290,19 @@
       10 gear     <chr [2]> <NA>      original FALSE           
       11 carb     <chr [2]> other     original TRUE            
 
+# add_roles() error if columns would be both predictor and outcome
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% add_role(mpg, new_role = "predictor")
+    Condition
+      Error in `add_role()`:
+      ! `mpg` cannot get "predictor" role as it is already has role "outcome".
+
+---
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% add_role(disp, new_role = "outcome")
+    Condition
+      Error in `add_role()`:
+      ! `disp` cannot get "outcome" role as it is already has role "predictor".
+

--- a/tests/testthat/test-roles.R
+++ b/tests/testthat/test-roles.R
@@ -590,4 +590,16 @@ test_that("role information from summary()", {
 
 })
 
+test_that("add_roles() error if columns would be both predictor and outcome", {
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~., data = mtcars) %>%
+      add_role(mpg, new_role = "predictor")
+  )
 
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~., data = mtcars) %>%
+      add_role(disp, new_role = "outcome")
+  )
+})


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/935

``` r
library(recipes)

recipe(mpg ~., data = mtcars) %>%
  add_role("mpg", new_role = "predictor")
#> Error in `add_role()`:
#> ! `mpg` cannot get "predictor" role as it is already has role "outcome".
```