### PR TITLE
Better warn on unseed levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,6 @@
 
 * `add_role()` now errors if a column would simultaneously have roles `"outcome"` and `"predictor"`. (#935)
 
-* `step_dummy()` now give an informative error if it tried to generate too many columns to fit in memory. (#828)
-
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)
 
 * `recipe()` can now take data.frames with list-columns or sf data.frames as input to `data`. (#1283)

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 
 * `step_dummy()` and `step_unknown()` now throw more informative warnings for unseen levels. (#450)
 
-* `step_dummy()` now throw more informative warnings for `NA` values. (#450)
+* `step_dummy()` now throws more informative warnings for `NA` values. (#450)
 
 * Fixed documentation mistake where default value of `keep_original_cols` argument were wrong. (#1314)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `add_role()` now errors if a column would simultaneously have roles `"outcome"` and `"predictor"`. (#935)
 
+* `step_dummy()` now give an informative error if it tried to generate too many columns to fit in memory. (#828)
+
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)
 
 * `recipe()` can now take data.frames with list-columns or sf data.frames as input to `data`. (#1283)

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 * `recipe()` can now take data.frames with list-columns or sf data.frames as input to `data`. (#1283)
 
+* `step_dummy()` and `step_unknown()` now throw more informative warnings for unseen levels. (#450)
+
+* `step_dummy()` now throw more informative warnings for `NA` values. (#450)
+
 * Fixed documentation mistake where default value of `keep_original_cols` argument were wrong. (#1314)
 
 * `step_mutate()` gained `.pkgs` argument to specify what packages need to be loaded for step to work. (#1282)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -222,14 +222,28 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   )
 }
 
-warn_new_levels <- function(dat, lvl, details = NULL) {
+warn_new_levels <- function(dat, lvl, column, step, details = NULL) {
   ind <- which(!(dat %in% lvl))
   if (length(ind) > 0) {
     lvl2 <- unique(dat[ind])
-    cli::cli_warn(c(
-      "!" = "There are new levels in a factor: {.var {lvl2}}.",
-      details
-    ))
+    msg <- c("!" = "There are new levels in {.var {column}}: {.val {lvl2}}.")
+    if (any(is.na(lvl2))) {
+      msg <- c(
+        msg, 
+        "i" = "Consider using {.fn recipes::step_unknown} before \\
+        {.fn {step}} to handle missing values."
+      )
+    }
+    if (!all(is.na(lvl2))) {
+      msg <- c(
+        msg, 
+        "i" = "Consider using {.fn recipes::step_novel} before \\
+        {.fn {step}} to handle unseen values."
+      )
+    }
+    msg <- c(msg, details)
+
+    cli::cli_warn(msg)
   }
   invisible(NULL)
 }
@@ -267,7 +281,12 @@ bake.step_dummy <- function(object, new_data, ...) {
       )
     }
 
-    warn_new_levels(new_data[[col_name]], levels_values)
+    warn_new_levels(
+      new_data[[col_name]], 
+      levels_values, 
+      col_name, 
+      step = "step_dummy"
+    )
 
     new_data[, col_name] <-
       factor(

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -230,15 +230,15 @@ warn_new_levels <- function(dat, lvl, column, step, details = NULL) {
     if (any(is.na(lvl2))) {
       msg <- c(
         msg, 
-        "i" = "Consider using {.fn recipes::step_unknown} before \\
-        {.fn {step}} to handle missing values."
+        "i" = "Consider using {.help [step_unknown()](recipes::step_unknown)} \\
+        before {.fn {step}} to handle missing values."
       )
     }
     if (!all(is.na(lvl2))) {
       msg <- c(
         msg, 
-        "i" = "Consider using {.fn recipes::step_novel} before \\
-        {.fn {step}} to handle unseen values."
+        "i" = "Consider using {.help [step_novel()](recipes::step_novel)} \\ 
+        before {.fn {step}} to handle unseen values."
       )
     }
     msg <- c(msg, details)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -303,20 +303,11 @@ bake.step_dummy <- function(object, new_data, ...) {
         na.action = na.pass
       )
 
-    indicators <- tryCatch(
-      model.matrix(object = levels, data = indicators),
-      error = function(cnd) {
-        if (grepl("vector memory exhausted", cnd$message)) {
-          n_levels <- length(attr(levels, "values"))
-          cli::cli_abort(
-            "{.var {col_name}} contains too many levels ({n_levels}), \\
-            which would result in a data.frame too large to fit in memory.",
-            call = NULL
-          )
-        }
-        stop(cnd)
-      }
-    )
+    indicators <-
+      model.matrix(
+        object = levels,
+        data = indicators
+      )
 
     if (!object$one_hot) {
       indicators <- indicators[, colnames(indicators) != "(Intercept)", drop = FALSE]

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -135,12 +135,9 @@ bake.step_unknown <- function(object, new_data, ...) {
       warn_new_levels(
         new_data[[col_name]],
         new_levels,
-        c(
-          "*" = "New levels will be coerced to `NA` by {.fn step_unknown}.",
-          "i" = "Consider using {.help [?step_novel](recipes::step_novel)} \\
-                before {.fn step_unknown}."
-        )
-
+        column = col_name,
+        step = "step_unknown",
+        c("*" = "New levels will be coerced to `NA` by {.fn step_unknown}.")
       )
     }
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -25,7 +25,8 @@
       factors <- prep(factors, training = sacr_missing)
     Condition
       Warning:
-      ! There are new levels in a factor: `NA`.
+      ! There are new levels in `city`: NA.
+      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
 
 ---
 
@@ -33,7 +34,8 @@
       factors_data_1 <- bake(factors, new_data = sacr_missing)
     Condition
       Warning:
-      ! There are new levels in a factor: `NA`.
+      ! There are new levels in `city`: NA.
+      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
 
 # tests for NA values in ordered factor
 
@@ -41,7 +43,8 @@
       factors <- prep(factors, training = sacr_ordered)
     Condition
       Warning:
-      ! There are new levels in a factor: `NA`.
+      ! There are new levels in `city`: NA.
+      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
 
 ---
 
@@ -49,15 +52,18 @@
       factors_data_1 <- bake(factors, new_data = sacr_ordered)
     Condition
       Warning:
-      ! There are new levels in a factor: `NA`.
+      ! There are new levels in `city`: NA.
+      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
 
 # new levels
 
     Code
-      recipes:::warn_new_levels(testing$x1, levels(training$x1))
+      recipes:::warn_new_levels(testing$x1, levels(training$x1), "column",
+      "step_dummy")
     Condition
       Warning:
-      ! There are new levels in a factor: `C`.
+      ! There are new levels in `column`: C.
+      i Consider using `recipes::step_novel()` before `step_dummy()` to handle unseen values.
 
 ---
 
@@ -65,7 +71,8 @@
       bake(rec, new_data = testing)
     Condition
       Warning:
-      ! There are new levels in a factor: `C`.
+      ! There are new levels in `x1`: C.
+      i Consider using `recipes::step_novel()` before `step_dummy()` to handle unseen values.
     Output
       # A tibble: 10 x 2
          y      x1_B

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -26,7 +26,7 @@
     Condition
       Warning:
       ! There are new levels in `city`: NA.
-      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+      i Consider using step_unknown() (`?recipes::step_unknown()`) before `step_dummy()` to handle missing values.
 
 ---
 
@@ -35,7 +35,7 @@
     Condition
       Warning:
       ! There are new levels in `city`: NA.
-      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+      i Consider using step_unknown() (`?recipes::step_unknown()`) before `step_dummy()` to handle missing values.
 
 # tests for NA values in ordered factor
 
@@ -44,7 +44,7 @@
     Condition
       Warning:
       ! There are new levels in `city`: NA.
-      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+      i Consider using step_unknown() (`?recipes::step_unknown()`) before `step_dummy()` to handle missing values.
 
 ---
 
@@ -53,7 +53,7 @@
     Condition
       Warning:
       ! There are new levels in `city`: NA.
-      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+      i Consider using step_unknown() (`?recipes::step_unknown()`) before `step_dummy()` to handle missing values.
 
 # new levels
 
@@ -63,7 +63,7 @@
     Condition
       Warning:
       ! There are new levels in `column`: C.
-      i Consider using `recipes::step_novel()` before `step_dummy()` to handle unseen values.
+      i Consider using step_novel() (`?recipes::step_novel()`) \ before `step_dummy()` to handle unseen values.
 
 ---
 
@@ -72,7 +72,7 @@
     Condition
       Warning:
       ! There are new levels in `x1`: C.
-      i Consider using `recipes::step_novel()` before `step_dummy()` to handle unseen values.
+      i Consider using step_novel() (`?recipes::step_novel()`) \ before `step_dummy()` to handle unseen values.
     Output
       # A tibble: 10 x 2
          y      x1_B
@@ -95,7 +95,7 @@
     Condition
       Warning:
       ! There are new levels in `a`: NA.
-      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+      i Consider using step_unknown() (`?recipes::step_unknown()`) before `step_dummy()` to handle missing values.
 
 # Deprecation warning
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -136,15 +136,6 @@
       ! Name collision occurred. The following variable names already exist:
       * `Species_versicolor`
 
-# throws a informative error for too many levels (#828)
-
-    Code
-      prep(rec)
-    Condition
-      Error in `step_dummy()`:
-      Caused by error:
-      ! `x` contains too many levels (123456), which would result in a data.frame too large to fit in memory.
-
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -88,6 +88,15 @@
        9 1        NA
       10 0         0
 
+# warns about NA in column (#450)
+
+    Code
+      tmp <- recipe(~a, data = data) %>% step_dummy(a) %>% prep()
+    Condition
+      Warning:
+      ! There are new levels in `a`: NA.
+      i Consider using `recipes::step_unknown()` before `step_dummy()` to handle missing values.
+
 # Deprecation warning
 
     Code

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -136,6 +136,15 @@
       ! Name collision occurred. The following variable names already exist:
       * `Species_versicolor`
 
+# throws a informative error for too many levels (#828)
+
+    Code
+      prep(rec)
+    Condition
+      Error in `step_dummy()`:
+      Caused by error:
+      ! `x` contains too many levels (123456), which would result in a data.frame too large to fit in memory.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/unknown.md
+++ b/tests/testthat/_snaps/unknown.md
@@ -4,13 +4,13 @@
       te_1 <- bake(rec_1, sacr_te)
     Condition
       Warning:
-      ! There are new levels in a factor: `WEST_SACRAMENTO`.
+      ! There are new levels in `city`: "WEST_SACRAMENTO".
+      i Consider using `recipes::step_novel()` before `step_unknown()` to handle unseen values.
       * New levels will be coerced to `NA` by `step_unknown()`.
-      i Consider using ?step_novel (`?recipes::step_novel()`) before `step_unknown()`.
       Warning:
-      ! There are new levels in a factor: `z95691`.
+      ! There are new levels in `zip`: "z95691".
+      i Consider using `recipes::step_novel()` before `step_unknown()` to handle unseen values.
       * New levels will be coerced to `NA` by `step_unknown()`.
-      i Consider using ?step_novel (`?recipes::step_novel()`) before `step_unknown()`.
 
 # bad args
 

--- a/tests/testthat/_snaps/unknown.md
+++ b/tests/testthat/_snaps/unknown.md
@@ -5,11 +5,11 @@
     Condition
       Warning:
       ! There are new levels in `city`: "WEST_SACRAMENTO".
-      i Consider using `recipes::step_novel()` before `step_unknown()` to handle unseen values.
+      i Consider using step_novel() (`?recipes::step_novel()`) \ before `step_unknown()` to handle unseen values.
       * New levels will be coerced to `NA` by `step_unknown()`.
       Warning:
       ! There are new levels in `zip`: "z95691".
-      i Consider using `recipes::step_novel()` before `step_unknown()` to handle unseen values.
+      i Consider using step_novel() (`?recipes::step_novel()`) \ before `step_unknown()` to handle unseen values.
       * New levels will be coerced to `NA` by `step_unknown()`.
 
 # bad args

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -215,10 +215,10 @@ test_that("new levels", {
   testing$x1 <- as.factor(testing$x1)
 
   expect_snapshot(
-    recipes:::warn_new_levels(testing$x1, levels(training$x1))
+    recipes:::warn_new_levels(testing$x1, levels(training$x1), "column", "step_dummy")
   )
   expect_silent(
-    recipes:::warn_new_levels(training$x1, levels(training$x1))
+    recipes:::warn_new_levels(training$x1, levels(training$x1), "column", "step_dummy")
   )
 
   rec <- recipe(y ~ x1, data = training) %>%

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -332,6 +332,19 @@ test_that("check_name() is used", {
   )
 })
 
+test_that("throws a informative error for too many levels (#828)", {
+  dat <- data.frame(x = as.character(1:123456))
+
+  rec <- recipe(~ ., data = dat) %>%
+    step_dummy(x)
+
+  expect_snapshot(
+    error = TRUE,
+    prep(rec)
+  )
+})
+
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -196,8 +196,6 @@ test_that("tests for NA values in ordered factor", {
   )
 })
 
-
-
 test_that("new levels", {
   df <- data.frame(
     y = c(1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0),
@@ -228,6 +226,16 @@ test_that("new levels", {
   )
   expect_snapshot(
     bake(rec, new_data = testing)
+  )
+})
+
+test_that("warns about NA in column (#450)", {
+  data <- data.frame(a = c(LETTERS, NA))
+
+  expect_snapshot(
+    tmp <- recipe(~ a, data = data) %>%
+      step_dummy(a) %>%
+      prep()
   )
 })
 

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -332,19 +332,6 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("throws a informative error for too many levels (#828)", {
-  dat <- data.frame(x = as.character(1:123456))
-
-  rec <- recipe(~ ., data = dat) %>%
-    step_dummy(x)
-
-  expect_snapshot(
-    error = TRUE,
-    prep(rec)
-  )
-})
-
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
To close #450 

``` r
library(recipes)

data <- data.frame(a = c(LETTERS, NA))

aaa <- recipe(~ a, data = data) %>%
  step_dummy(a) %>%
  prep()
#> Warning: ! There are new levels in `a`: NA.
#> ℹ Consider using `recipes::step_unknown()` before `step_dummy()` to handle
#>   missing values.

data_train <- tibble(x = c("a", "b"))
data_test <- tibble(x = "c")

rec_spec <- recipe(~., data = data_train) %>%
  step_dummy(x) %>%
  prep()

aaa <- rec_spec %>%
  bake(data_test)
#> Warning: ! There are new levels in `x`: "c".
#> ℹ Consider using `recipes::step_novel()` before `step_dummy()` to handle unseen
#>   values.
```
