### PR TITLE
error if step_dummy produce too big data.frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * The `prefix` argument of `step_dummy_multi_choice()` is not properly documented. (#1298)
 
-* `step_dummy()` now give an informative error if it tried to generate too many columns to fit in memory. (#828)
+* `step_dummy()` now gives an informative error on attempt to generate too many columns to fit in memory. (#828)
 
 * `NA` levels in factors aren't dropped when passed to `recipe()`. (#1291)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The `prefix` argument of `step_dummy_multi_choice()` is not properly documented. (#1298)
 
+* `step_dummy()` now give an informative error if it tried to generate too many columns to fit in memory. (#828)
+
 * `NA` levels in factors aren't dropped when passed to `recipe()`. (#1291)
 
 * `recipe()` no longer crashes when given long formula expression (#1283).

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -287,7 +287,7 @@ bake.step_dummy <- function(object, new_data, ...) {
     indicators <- tryCatch(
       model.matrix(object = levels, data = indicators),
       error = function(cnd) {
-        if (grepl("vector memory", cnd$message)) {
+        if (grepl("(vector memory|cannot allocate)", cnd$message)) {
           n_levels <- length(attr(levels, "values"))
           cli::cli_abort(
             "{.var {col_name}} contains too many levels ({n_levels}), \\

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -284,11 +284,20 @@ bake.step_dummy <- function(object, new_data, ...) {
         na.action = na.pass
       )
 
-    indicators <-
-      model.matrix(
-        object = levels,
-        data = indicators
-      )
+    indicators <- tryCatch(
+      model.matrix(object = levels, data = indicators),
+      error = function(cnd) {
+        if (grepl("vector memory", cnd$message)) {
+          n_levels <- length(attr(levels, "values"))
+          cli::cli_abort(
+            "{.var {col_name}} contains too many levels ({n_levels}), \\
+            which would result in a data.frame too large to fit in memory.",
+            call = NULL
+          )
+        }
+        stop(cnd)
+      }
+    )
 
     if (!object$one_hot) {
       indicators <- indicators[, colnames(indicators) != "(Intercept)", drop = FALSE]

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -120,6 +120,15 @@
       ! Name collision occurred. The following variable names already exist:
       * `Species_versicolor`
 
+# throws a informative error for too many levels (#828)
+
+    Code
+      prep(rec)
+    Condition
+      Error in `step_dummy()`:
+      Caused by error:
+      ! `x` contains too many levels (123456), which would result in a data.frame too large to fit in memory.
+
 # empty printing
 
     Code

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -324,6 +324,18 @@ test_that("check_name() is used", {
   )
 })
 
+test_that("throws a informative error for too many levels (#828)", {
+  dat <- data.frame(x = as.character(1:123456))
+
+  rec <- recipe(~ ., data = dat) %>%
+    step_dummy(x)
+
+  expect_snapshot(
+    error = TRUE,
+    prep(rec)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/828

# This PR

``` r
library(recipes)

dat <- data.frame(x = as.character(1:100000))

recipe(~ ., data = dat) %>%
  step_dummy(x) %>%
  prep()
#> Error in `step_dummy()`:
#> Caused by error:
#> ! `x` contains too many levels (100000), which would result in a
#>   data.frame too large to fit in memory.
```

# Before


``` r
library(recipes)

dat <- data.frame(x = as.character(1:100000))

recipe(~ ., data = dat) %>%
  step_dummy(x) %>%
  prep()
#> Error: vector memory exhausted (limit reached?)
```