### PR TITLE
fix bug in step_ns where knots didn't get passed through

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * `recipe()` will now show better error when columns are misspelled in formula (#1283).
 
+* Fixed bug in `step_ns()` where `knots` field in `options` argument wasn't correctly used. (#1297)
+
 * `add_role()` now errors if a column would simultaneously have roles `"outcome"` and `"predictor"`. (#935)
 
 * Significant speedup in `step_dummy()` when applied to many columns. (#1305)

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 * `recipe()` will now show better error when columns are misspelled in formula (#1283).
 
-* Fixed bug in `step_ns()` where `knots` field in `options` argument wasn't correctly used. (#1297)
+* Fixed bug in `step_ns()` and `step_bs()` where `knots` field in `options` argument wasn't correctly used. (#1297)
 
 * `add_role()` now errors if a column would simultaneously have roles `"outcome"` and `"predictor"`. (#935)
 

--- a/R/bs.R
+++ b/R/bs.R
@@ -20,7 +20,7 @@
 #' @details `step_bs` can create new features from a single variable
 #'  that enable fitting routines to model this variable in a
 #'  nonlinear manner. The extent of the possible nonlinearity is
-#'  determined by the `df`, `degree`, or `knot` arguments of
+#'  determined by the `df`, `degree`, or `knots` arguments of
 #'  [splines::bs()]. The original variables are removed
 #'  from the data and new columns are added. The naming convention
 #'  for the new variables is `varname_bs_1` and so on.
@@ -121,12 +121,17 @@ bs_statistics <- function(x, args) {
     ok <- !is.na(x) & x >= boundary[1L] & x <= boundary[2L]
     knots <- unname(quantile(x[ok], seq_len(num_knots) / (num_knots + 1L)))
   } else {
-    knots <- numeric()
+    if (is.null(args$knots)) {
+      knots <- numeric()
+    } else {
+      knots <- args$knots
+    }
   }
 
   # Only construct the data necessary for splines_predict
   out <- matrix(NA, ncol = degree + length(knots) + intercept, nrow = 1L)
   class(out) <- c("bs", "basis", "matrix")
+  attr(out, "degree") <- 3L
   attr(out, "knots") <- knots
   attr(out, "Boundary.knots") <- boundary
   attr(out, "intercept") <- intercept

--- a/R/bs.R
+++ b/R/bs.R
@@ -131,7 +131,6 @@ bs_statistics <- function(x, args) {
   # Only construct the data necessary for splines_predict
   out <- matrix(NA, ncol = degree + length(knots) + intercept, nrow = 1L)
   class(out) <- c("bs", "basis", "matrix")
-  attr(out, "degree") <- 3L
   attr(out, "knots") <- knots
   attr(out, "Boundary.knots") <- boundary
   attr(out, "intercept") <- intercept

--- a/R/ns.R
+++ b/R/ns.R
@@ -19,7 +19,7 @@
 #' @details `step_ns` can create new features from a single variable
 #'  that enable fitting routines to model this variable in a
 #'  nonlinear manner. The extent of the possible nonlinearity is
-#'  determined by the `df` or `knot` arguments of
+#'  determined by the `df` or `knots` arguments of
 #'  [splines::ns()]. The original variables are removed
 #'  from the data and new columns are added. The naming convention
 #'  for the new variables is `varname_ns_1` and so on.
@@ -117,12 +117,17 @@ ns_statistics <- function(x, args) {
     ok <- !is.na(x) & x >= boundary[1L] & x <= boundary[2L]
     knots <- unname(quantile(x[ok], seq_len(num_knots) / (num_knots + 1L)))
   } else {
-    knots <- numeric()
+    if (is.null(args$knots)) {
+      knots <- numeric()
+    } else {
+      knots <- args$knots
+    }
   }
 
   # Only construct the data necessary for splines_predict
   out <- matrix(NA, ncol = degree + length(knots) + intercept, nrow = 1L)
   class(out) <- c("ns", "basis", "matrix")
+  attr(out, "degree") <- 3L
   attr(out, "knots") <- knots
   attr(out, "Boundary.knots") <- boundary
   attr(out, "intercept") <- intercept

--- a/man/step_ns.Rd
+++ b/man/step_ns.Rd
@@ -66,7 +66,7 @@ columns that are basis expansions of variables using natural splines.
 \code{step_ns} can create new features from a single variable
 that enable fitting routines to model this variable in a
 nonlinear manner. The extent of the possible nonlinearity is
-determined by the \code{df} or \code{knot} arguments of
+determined by the \code{df} or \code{knots} arguments of
 \code{\link[splines:ns]{splines::ns()}}. The original variables are removed
 from the data and new columns are added. The naming convention
 for the new variables is \code{varname_ns_1} and so on.

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -69,6 +69,30 @@ test_that("correct basis functions", {
   expect_equal(hydrogen_bs_te_res, hydrogen_bs_te_exp)
 })
 
+test_that("options(knots) works correctly (#1297)", {
+  exmaple_data <- tibble(x = seq(-2, 2, 0.01))
+
+  rec_res <- recipe(~., data = exmaple_data) %>% 
+    step_bs(x, options = list(knots = seq(-1, 1, 0.125), 
+                              Boundary.knots = c(-2.5, 2.5))) %>% 
+    prep() %>% 
+    bake(new_data = NULL)
+
+  mm_res <- model.matrix(
+    ~ splines::bs(
+      x, 
+      knots = seq(-1, 1, 0.125), 
+      Boundary.knots = c(-2.5, 2.5)
+    ) - 1, 
+    data = exmaple_data
+  )
+
+  attr(mm_res, "assign") <- NULL
+  mm_res <- setNames(as_tibble(mm_res), names(rec_res))
+
+  expect_identical(rec_res, mm_res)
+})
+
 test_that("check_name() is used", {
   dat <- mtcars
   dat$mpg_bs_1 <- dat$mpg

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -71,6 +71,30 @@ test_that("correct basis functions", {
   expect_equal(hydrogen_ns_te_res, hydrogen_ns_te_exp)
 })
 
+test_that("options(knots) works correctly (#1297)", {
+  exmaple_data <- tibble(x = seq(-2, 2, 0.01))
+
+  rec_res <- recipe(~., data = exmaple_data) %>% 
+    step_ns(x, options = list(knots = seq(-1, 1, 0.125), 
+                              Boundary.knots = c(-1.5, 1.5))) %>% 
+    prep() %>% 
+    bake(new_data = NULL)
+
+  mm_res <- model.matrix(
+    ~ splines::ns(
+      x, 
+      knots = seq(-1, 1, 0.125), 
+      Boundary.knots = c(-1.5, 1.5)
+    ) - 1, 
+    data = exmaple_data
+  )
+
+  attr(mm_res, "assign") <- NULL
+  mm_res <- setNames(as_tibble(mm_res), names(rec_res))
+
+  expect_identical(rec_res, mm_res)
+})
+
 test_that("check_name() is used", {
   dat <- mtcars
   dat$mpg_ns_1 <- dat$mpg


### PR DESCRIPTION
to close #1297 and close https://github.com/tidymodels/recipes/issues/1050.

The main problem was that `knots` wasn't passed through if it was set in `options` argument

``` r
library(recipes)
d <- tibble(x = seq(-2, 2, 0.01))

rec_res <- recipe(~., data = d) %>% 
  step_ns(x, options = list(knots = seq(-1, 1, 0.125), 
                            Boundary.knots = c(-1.5, 1.5))) %>% 
  prep() %>% 
  bake(new_data = d)

# -1 in `model.matrix()` to avoid intercept
mm_res <- model.matrix(~splines::ns(x, 
                          knots = seq(-1, 1, 0.125), 
                          Boundary.knots = c(-1.5, 1.5)) - 1, data = d)

attr(mm_res, "assign") <- NULL

identical(
  rec_res,
  setNames(as_tibble(mm_res), names(rec_res))
)
#> [1] TRUE
```