### PR TITLE
make step_interact give better erorr if terms ins't a formula

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * `recipe()` no longer crashes when given long formula expression (#1283).
 
+* `step_interact()` now gives better error if `terms` isn't a formula. (#1299)
+
 * `recipe()` will now show better error when columns are misspelled in formula (#1283).
 
 * Fixed bug in `step_ns()` and `step_bs()` where `knots` field in `options` argument wasn't correctly used. (#1297)

--- a/R/interact.R
+++ b/R/interact.R
@@ -151,10 +151,18 @@ prep.step_interact <- function(x, training, info = NULL, ...) {
 
   # make backwards compatible with 1.0.6 (#1138)
   if (!is_formula(x)) {
-    tmp_terms <- rlang::eval_tidy(x$terms[[1]])
+    tmp_terms <- tryCatch(
+      rlang::eval_tidy(x$terms[[1]]),
+      error = function(cnd) {
+        cli::cli_abort(
+          "{.arg terms} must be supplied as a formula.",
+          call = NULL
+        )
+      }
+    )
     if (!is_formula(tmp_terms)) {
       cli::cli_abort(
-        "{.arg term} must be a formula. Not {.obj_type_friendly {term}}."
+        "{.arg terms} must be a formula. Not {.obj_type_friendly {term}}."
       )
     }
 

--- a/tests/testthat/_snaps/interact.md
+++ b/tests/testthat/_snaps/interact.md
@@ -8,6 +8,16 @@
       ! Name collision occurred. The following variable names already exist:
       * `x1ax2`
 
+# gives informative error if terms isn't a formula (#1299)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_interact(terms = starts_with("dis")) %>%
+        prep()
+    Condition
+      Error in `step_interact()`:
+      Caused by error:
+      ! `terms` must be supplied as a formula.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -307,6 +307,16 @@ test_that("works with long formulas (#1231)", {
   expect_identical(res_long, res_short)
 })
 
+test_that("gives informative error if terms isn't a formula (#1299)", {
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>% 
+      step_interact(terms = starts_with("dis")) %>% 
+      prep()
+  )
+})
+
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
to close #1299

``` r
library(tidymodels)

recipe(mpg ~ ., data = mtcars) %>% 
  step_interact(terms = starts_with("dis")) %>% 
  prep() %>% 
  bake(new_data = NULL)
#> Error in `step_interact()`:
#> Caused by error:
#> ! `terms` must be supplied as a formula.
```
