### PR TITLE
clean up check_training_set

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -648,10 +648,7 @@ check_nominal_type <- function(x, lvl) {
   invisible(NULL)
 }
 
-check_training_set <- function(x, rec, fresh, call = rlang::caller_env()) {
-  # In case a variable has multiple roles
-  vars <- unique(rec$var_info$variable)
-
+validate_training_data <- function(x, rec, fresh, call = rlang::caller_env()) {
   training_null <- is.null(x)
   if (training_null) {
     if (fresh) {
@@ -668,6 +665,8 @@ check_training_set <- function(x, rec, fresh, call = rlang::caller_env()) {
     }
     recipes_ptype_validate(rec, new_data = x, stage = "prep", call = call)
 
+    # In case a variable has multiple roles
+    vars <- unique(rec$var_info$variable)
     x <- x[, vars]
   }
 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -383,7 +383,7 @@ prep.recipe <-
            log_changes = FALSE,
            strings_as_factors = TRUE,
            ...) {
-    training <- check_training_set(training, x, fresh)
+    training <- validate_training_data(training, x, fresh)
 
     tr_data <- train_info(training)
 

--- a/man/roles.Rd
+++ b/man/roles.Rd
@@ -93,12 +93,13 @@ If you really aren't using \code{sample} in your recipe, we recommend that you i
 
 bake(rec, biomass_test)
 #> Error in `bake()`:
-#> x The following required columns are missing from `new_data`:
-#>   `sample`.
-#> i These columns have one of the following roles, which are required
-#>   at `bake()` time: `id variable`.
-#> i If these roles are not required at `bake()` time, use
-#>   `update_role_requirements(role = "your_role", bake = FALSE)`.
+#> x The following required columns are missing
+#>   from `new_data`: `sample`.
+#> i These columns have one of the following roles,
+#>   which are required at `bake()` time: `id variable`.
+#> i If these roles are not required at `bake()` time,
+#>   use `update_role_requirements(role = "your_role",
+#>   bake = FALSE)`.
 }\if{html}{\out{</div>}}
 
 As we mentioned before, the best way to avoid this issue is to not even use a role, just remove the \code{sample} column from \code{biomass} before calling \code{recipe()}. In general, predictors and non-standard roles that are supplied to \code{recipe()} should be present at both \code{prep()} and \code{bake()} time.

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -29,7 +29,7 @@ test_that("conditionMessage method for recipes errors works", {
   expect_snapshot(conditionMessage(attr(res, "condition")))
 })
 
-test_that("check_training_set errors are thrown", {
+test_that("validate_training_data errors are thrown", {
   expect_snapshot(
     error = TRUE,
     recipe(~., data = mtcars) %>% prep(fresh = TRUE)

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -41,7 +41,6 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_nominal_type"]
   step_check <- step_check[step_check != "check_factor_vars"]
   step_check <- step_check[step_check != "check_name"]
-  step_check <- step_check[step_check != "check_training_set"]
   step_check <- step_check[step_check != "check_is_lat_lon"]
   step_check <- step_check[step_check != "check_new_data"]
   step_check <- step_check[step_check != "check_role_requirements"]


### PR DESCRIPTION
Found during https://github.com/tidymodels/recipes/issues/1333. I think this is enough.

renamed to validate_training_data()