### PR TITLE
test that `prep()` and `bake()` can accept sparse tibbles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Example for `step_novel()` now better illustrates how it works. (@Edgar-Zamora, #1248)
 
-* `recipe()` now works with sparse tibbles. (#1364)
+* `recipe()`, `prep()`, and `bake()` now works with sparse tibbles. (#1364, #1366)
 
 # recipes 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Example for `step_novel()` now better illustrates how it works. (@Edgar-Zamora, #1248)
 
-* `recipe()`, `prep()`, and `bake()` now works with sparse tibbles. (#1364, #1366)
+* `recipe()`, `prep()`, and `bake()` now work with sparse tibbles. (#1364, #1366)
 
 # recipes 1.1.0
 

--- a/man/roles.Rd
+++ b/man/roles.Rd
@@ -93,13 +93,11 @@ If you really aren't using \code{sample} in your recipe, we recommend that you i
 
 bake(rec, biomass_test)
 #> Error in `bake()`:
-#> x The following required columns are missing
-#>   from `new_data`: `sample`.
-#> i These columns have one of the following roles,
-#>   which are required at `bake()` time: `id variable`.
-#> i If these roles are not required at `bake()` time,
-#>   use `update_role_requirements(role = "your_role",
-#>   bake = FALSE)`.
+#> x The following required columns are missing from `new_data`: `sample`.
+#> i These columns have one of the following roles, which are required at `bake()` time: `id
+#>   variable`.
+#> i If these roles are not required at `bake()` time, use `update_role_requirements(role =
+#>   "your_role", bake = FALSE)`.
 }\if{html}{\out{</div>}}
 
 As we mentioned before, the best way to avoid this issue is to not even use a role, just remove the \code{sample} column from \code{biomass} before calling \code{recipe()}. In general, predictors and non-standard roles that are supplied to \code{recipe()} should be present at both \code{prep()} and \code{bake()} time.

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -29,3 +29,27 @@ test_that("recipe() accepts sparse tibbles", {
   )
 })
 
+test_that("prep() accepts sparse tibbles", {
+  skip_if_not_installed("modeldata")
+
+  hotel_data <- sparse_hotel_rates()
+  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+
+  rec_spec <- recipe(avg_price_per_room ~ ., data = hotel_data)
+  
+  expect_no_error(
+    rec <- prep(rec_spec)
+  )
+
+  expect_true(
+    is_sparse_tibble(rec$template)
+  )
+  
+  expect_no_error(
+    rec <- prep(rec_spec, training = hotel_data)
+  )
+
+  expect_true(
+    is_sparse_tibble(rec$template)
+  )
+})

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -53,3 +53,29 @@ test_that("prep() accepts sparse tibbles", {
     is_sparse_tibble(rec$template)
   )
 })
+
+test_that("bake() accepts sparse tibbles", {
+  skip_if_not_installed("modeldata")
+
+  hotel_data <- sparse_hotel_rates()
+  hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
+
+  rec_spec <- recipe(avg_price_per_room ~ ., data = hotel_data) %>%
+    prep()
+  
+  expect_no_condition(
+    res <- bake(rec_spec, new_data = NULL)
+  )
+
+  expect_true(
+    is_sparse_tibble(res)
+  )
+  
+  expect_no_error(
+    res <- bake(rec_spec, new_data = hotel_data)
+  )
+
+  expect_true(
+    is_sparse_tibble(res)
+  )
+})


### PR DESCRIPTION
ref: https://github.com/tidymodels/recipes/issues/1343

it already works, so this PR just adds tests to confirm