### PR TITLE
Stricter sparsevctrs tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     Matrix,
     purrr (>= 1.0.0),
     rlang (>= 1.1.0),
-    sparsevctrs (>= 0.1.0.9000),
+    sparsevctrs (>= 0.1.0.9001),
     stats,
     tibble,
     tidyr (>= 1.0.0),

--- a/R/misc.R
+++ b/R/misc.R
@@ -218,6 +218,8 @@ n_complete_rows <- function(x) {
     x[[pos_list_col]] <- purrr::map_lgl(x[[pos_list_col]], flatten_na)
   }
 
+  x <- x[, vapply(x, anyNA, logical(1))]
+
   sum(vec_detect_complete(x))
 }
 

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -1,5 +1,6 @@
 test_that("recipe() accepts sparse tibbles", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
@@ -31,6 +32,7 @@ test_that("recipe() accepts sparse tibbles", {
 
 test_that("prep() accepts sparse tibbles", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
@@ -56,6 +58,7 @@ test_that("prep() accepts sparse tibbles", {
 
 test_that("bake() accepts sparse tibbles", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
   hotel_data <- sparsevctrs::coerce_to_sparse_tibble(hotel_data)
@@ -82,6 +85,7 @@ test_that("bake() accepts sparse tibbles", {
 
 test_that("recipe() accepts sparse matrices", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
 
@@ -112,6 +116,7 @@ test_that("recipe() accepts sparse matrices", {
 
 test_that("prep() accepts sparse matrices", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
 
@@ -136,6 +141,7 @@ test_that("prep() accepts sparse matrices", {
 
 test_that("bake() accepts sparse matrices", {
   skip_if_not_installed("modeldata")
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
 
   hotel_data <- sparse_hotel_rates()
 


### PR DESCRIPTION
All sparsvctrs tests now have option set such that unintentional materialization results in an error. 