### PR TITLE
make sure n_complete_rows() work with surv objects

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -220,7 +220,17 @@ n_complete_rows <- function(x) {
 
   x <- x[, vapply(x, anyNA, logical(1))]
 
-  sum(vec_detect_complete(x))
+  surv_col_ind <- purrr::map_lgl(x, inherits, "Surv")
+  if (any(surv_col_ind)) {
+    surv_cols <- stats::complete.cases(x[, surv_col_ind, drop = FALSE])
+    non_surv_cols <- vec_detect_complete(x[, !surv_col_ind, drop = FALSE])
+
+    res <- sum(surv_cols & non_surv_cols)
+  } else {
+    res <- sum(vec_detect_complete(x))
+  }
+
+  res
 }
 
 flatten_na <- function(x) {


### PR DESCRIPTION
the switch from `complete.cases()` to `vec_detect_complete()` broke the automated testing in extratests, because `vec_detect_complete()` didn't like `Surv()` objects