### PR TITLE
Use `expect_snapshot()` more

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -859,9 +859,8 @@ check_new_data <- function(req, object, new_data) {
   step_cls <- class(object)[1]
   step_id <- object$id
   cli::cli_abort(
-    "The following required {cli::qty(col_diff)} column{?s} {?is/are} \
-    missing from `new_data` in step '{step_id}': {col_diff}.",
-    class = "new_data_missing_column",
+    "The following required {cli::qty(col_diff)} column{?s} {?is/are} missing 
+    from `new_data`: {col_diff}.",
     call = rlang::call2(step_cls)
   )
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -860,7 +860,7 @@ check_new_data <- function(req, object, new_data) {
   step_id <- object$id
   cli::cli_abort(
     "The following required {cli::qty(col_diff)} column{?s} {?is/are} missing 
-    from `new_data`: {col_diff}.",
+    from {.arg new_data}: {col_diff}.",
     call = rlang::call2(step_cls)
   )
 }

--- a/R/mutate_at.R
+++ b/R/mutate_at.R
@@ -51,6 +51,10 @@ step_mutate_at <- function(recipe, ...,
                            inputs = NULL,
                            skip = FALSE,
                            id = rand_id("mutate_at")) {
+  if (rlang::is_missing(fn)) {
+    cli::cli_abort("Argument {.arg fn} must be specified.")
+  }
+
   add_step(
     recipe,
     step_mutate_at_new(

--- a/R/rename_at.R
+++ b/R/rename_at.R
@@ -42,6 +42,10 @@ step_rename_at <- function(recipe, ...,
                            inputs = NULL,
                            skip = FALSE,
                            id = rand_id("rename_at")) {
+  if (rlang::is_missing(fn)) {
+    cli::cli_abort("Argument {.arg fn} must be specified.")
+  }
+
   add_step(
     recipe,
     step_rename_at_new(

--- a/tests/testthat/_snaps/BoxCox.md
+++ b/tests/testthat/_snaps/BoxCox.md
@@ -33,6 +33,14 @@
       -- Operations 
       * Box-Cox transformation on: <none> | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 1:2])
+    Condition
+      Error in `step_BoxCox()`:
+      ! The following required column is missing from `new_data`: x4.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/R4.4/discretize.md
+++ b/tests/testthat/_snaps/R4.4/discretize.md
@@ -1,0 +1,12 @@
+# multiple column prefix
+
+    Code
+      recipe(~., data = example_data) %>% step_discretize(x1, x2, options = list(
+        labels = "hello")) %>% prep()
+    Condition
+      Warning:
+      Note that the options `prefix` and `labels` will be applied to all variables.
+      Error in `step_discretize()`:
+      Caused by error in `cut.default()`:
+      ! number of intervals and length of 'labels' differ
+

--- a/tests/testthat/_snaps/R4.4/selections.md
+++ b/tests/testthat/_snaps/R4.4/selections.md
@@ -1,0 +1,10 @@
+# simple name selections
+
+    Code
+      recipes_eval_select(quos = quos(I(beds:sqft)), data = Sacramento, info = info_sac)
+    Condition
+      Error:
+      i In argument: `I(beds:sqft)`.
+      Caused by error:
+      ! object 'beds' not found
+

--- a/tests/testthat/_snaps/YeoJohnson.md
+++ b/tests/testthat/_snaps/YeoJohnson.md
@@ -8,6 +8,14 @@
       x Missing values are not allowed for the YJ transformation.
       i See `na_rm` option.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 1:2])
+    Condition
+      Error in `step_YeoJohnson()`:
+      ! The following required column is missing from `new_data`: x4.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/bin2factor.md
+++ b/tests/testthat/_snaps/bin2factor.md
@@ -26,6 +26,14 @@
       x `levels` should be a 2-element character string.
       i It was an integer vector.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, mtcars)
+    Condition
+      Error in `step_bin2factor()`:
+      ! The following required column is missing from `new_data`: bin.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/bs.md
+++ b/tests/testthat/_snaps/bs.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_bs_1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(with_bs, new_data = biomass_tr[, c(-4)])
+    Condition
+      Error in `step_bs()`:
+      ! The following required column is missing from `new_data`: hydrogen.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/center.md
+++ b/tests/testthat/_snaps/center.md
@@ -80,6 +80,14 @@
       -- Operations 
       * Centering for: x | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(std_trained, new_data = biomass[, 1:2])
+    Condition
+      Error in `step_center()`:
+      ! The following required columns are missing from `new_data`: carbon, hydrogen, oxygen, nitrogen, and sulfur.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -73,6 +73,14 @@
       Error:
       ! `type` should have the class <factor> but has the class <character>.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = x[, -1])
+    Condition
+      Error in `check_class()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/classdist.md
+++ b/tests/testthat/_snaps/classdist.md
@@ -28,6 +28,14 @@
       -- Operations 
       * Distances to Species for: Sepal.Length, ... | Trained, weighted
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = iris[, c(-3)])
+    Condition
+      Error in `step_classdist()`:
+      ! The following required column is missing from `new_data`: Petal.Length.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/classdist.md
+++ b/tests/testthat/_snaps/classdist.md
@@ -11,6 +11,30 @@
 # case weights
 
     Code
+      recipes:::get_center(mtcars, wts = wts, mfun = median)
+    Condition
+      Error in `recipes:::get_center()`:
+      ! The centering function requested cannot be used with case weights.
+
+---
+
+    Code
+      recipes:::get_both(mtcars, wts = wts, mfun = median)
+    Condition
+      Error in `recipes:::get_both()`:
+      ! The centering function requested cannot be used with case weights.
+
+---
+
+    Code
+      recipes:::get_both(mtcars, wts = wts, cfun = mad)
+    Condition
+      Error in `recipes:::get_both()`:
+      ! The variance function requested cannot be used with case weights.
+
+---
+
+    Code
       rec_prep
     Message
       

--- a/tests/testthat/_snaps/classdist_shrunken.md
+++ b/tests/testthat/_snaps/classdist_shrunken.md
@@ -90,6 +90,14 @@
       Caused by error in `prep()`:
       ! `sd_offset` must be a number between 0 and 1, not the number -1.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = iris[, c(-3)])
+    Condition
+      Error in `step_classdist_shrunken()`:
+      ! The following required column is missing from `new_data`: Petal.Length.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/colcheck.md
+++ b/tests/testthat/_snaps/colcheck.md
@@ -19,14 +19,6 @@
 # non-standard roles during bake/predict
 
     Code
-      predict(role_fit, Chicago %>% select(-date))
-    Condition
-      Error in `validate_column_names()`:
-      ! The following required columns are missing: 'date'.
-
----
-
-    Code
       predict(role_wts_fit, head(Chicago) %>% select(-date))
     Condition
       Error in `validate_column_names()`:

--- a/tests/testthat/_snaps/colcheck.md
+++ b/tests/testthat/_snaps/colcheck.md
@@ -16,6 +16,38 @@
       x The following required columns are missing from `new_data`: `mpg`.
       i These columns have one of the following roles, which are required at `bake()` time: `predictor`.
 
+# non-standard roles during bake/predict
+
+    Code
+      predict(role_fit, Chicago %>% select(-date))
+    Condition
+      Error in `validate_column_names()`:
+      ! The following required columns are missing: 'date'.
+
+---
+
+    Code
+      predict(role_wts_fit, head(Chicago) %>% select(-date))
+    Condition
+      Error in `validate_column_names()`:
+      ! The following required columns are missing: 'date'.
+
+---
+
+    Code
+      predict(rm_fit, Chicago %>% select(-date))
+    Condition
+      Error in `validate_column_names()`:
+      ! The following required columns are missing: 'date'.
+
+---
+
+    Code
+      predict(rm_fit, Chicago %>% select(-date))
+    Condition
+      Error in `validate_column_names()`:
+      ! The following required columns are missing: 'date'.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -27,6 +27,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `Sepal.Width`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mt_tibble[, c(-1)])
+    Condition
+      Error in `step_count()`:
+      ! The following required column is missing from `new_data`: make_model.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/cut.md
+++ b/tests/testthat/_snaps/cut.md
@@ -34,6 +34,14 @@
       Warning:
       This will create a factor with one value only.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(prepped, df[, 2, drop = FALSE])
+    Condition
+      Error in `step_cut()`:
+      ! The following required column is missing from `new_data`: x.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `Dan_year`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(date_rec, new_data = examples[, 2, drop = FALSE])
+    Condition
+      Error in `step_date()`:
+      ! The following required column is missing from `new_data`: Dan.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/depth.md
+++ b/tests/testthat/_snaps/depth.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = iris[, 2:5])
+    Condition
+      Error in `step_depth()`:
+      ! The following required column is missing from `new_data`: Sepal.Length.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -119,6 +119,14 @@
       -- Operations 
       * Discretize numeric variables from: x1 | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = mtcars[, 2:ncol(mtcars)])
+    Condition
+      Error in `step_discretize()`:
+      ! The following required column is missing from `new_data`: mpg.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -145,6 +145,14 @@
       Caused by error:
       ! `x` contains too many levels (123456), which would result in a data.frame too large to fit in memory.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(dummy_trained, new_data = sacr_fac[, 3:4], all_predictors())
+    Condition
+      Error in `step_dummy()`:
+      ! The following required columns are missing from `new_data`: city and zip.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy_extract.md
+++ b/tests/testthat/_snaps/dummy_extract.md
@@ -55,6 +55,14 @@
       -- Operations 
       * Extract patterns from: medium | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(dummy_prepped, new_data = mini_tate[, 1:3])
+    Condition
+      Error in `step_dummy_extract()`:
+      ! The following required column is missing from `new_data`: medium.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/dummy_multi_choice.md
+++ b/tests/testthat/_snaps/dummy_multi_choice.md
@@ -18,6 +18,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `Species_setosa`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = languages[, -1])
+    Condition
+      Error in `step_dummy_multi_choice()`:
+      ! The following required column is missing from `new_data`: lang_1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/factor2string.md
+++ b/tests/testthat/_snaps/factor2string.md
@@ -8,6 +8,14 @@
       x All columns selected for the step should be factor or ordered.
       * 2 string variables found: `w` and `x`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(ex_1, new_data = ex_dat[, 1:3])
+    Condition
+      Error in `step_factor2string()`:
+      ! The following required column is missing from `new_data`: z.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/geodist.md
+++ b/tests/testthat/_snaps/geodist.md
@@ -164,6 +164,14 @@
       Error in `step_geodist()`:
       ! `is_lat_lon` must be `TRUE` or `FALSE`, not a logical vector.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = rand_data[, 2, drop = FALSE])
+    Condition
+      Error in `step_geodist()`:
+      ! The following required column is missing from `new_data`: x.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/harmonic.md
+++ b/tests/testthat/_snaps/harmonic.md
@@ -99,6 +99,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_sin_1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = harmonic_dat_mult[, 1:2])
+    Condition
+      Error in `step_harmonic()`:
+      ! The following required column is missing from `new_data`: time_var_2.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/holiday.md
+++ b/tests/testthat/_snaps/holiday.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `day_Easter`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(holiday_rec, exp_dates[, 2, drop = FALSE])
+    Condition
+      Error in `step_holiday()`:
+      ! The following required column is missing from `new_data`: day.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/hyperbolic.md
+++ b/tests/testthat/_snaps/hyperbolic.md
@@ -3,6 +3,14 @@
     `func` must be one of "sinh", "cosh", or "tanh", not "cos".
     i Did you mean "cosh"?
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE])
+    Condition
+      Error in `step_hyperbolic()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/ica.md
+++ b/tests/testthat/_snaps/ica.md
@@ -28,6 +28,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `IC1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(ica_extract_trained, new_data = biomass_tr[, c(-3)])
+    Condition
+      Error in `step_ica()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_bag.md
+++ b/tests/testthat/_snaps/impute_bag.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed_trained, new_data = biomass[, c(-3, -9)])
+    Condition
+      Error in `step_impute_bag()`:
+      ! The following required columns are missing from `new_data`: carbon and fac.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_knn.md
+++ b/tests/testthat/_snaps/impute_knn.md
@@ -6,6 +6,14 @@
       Warning in `gower_work()`:
       skipping variable with zero or non-finite range.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed_trained, new_data = biomass[, c(-4)])
+    Condition
+      Error in `step_impute_knn()`:
+      ! The following required column is missing from `new_data`: hydrogen.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_linear.md
+++ b/tests/testthat/_snaps/impute_linear.md
@@ -56,6 +56,14 @@
       -- Operations 
       * Linear regression imputation for: Lot_Frontage | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = ames_dat[, 2:3])
+    Condition
+      Error in `step_impute_linear()`:
+      ! The following required column is missing from `new_data`: Lot_Frontage.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_lower.md
+++ b/tests/testthat/_snaps/impute_lower.md
@@ -8,6 +8,14 @@
       x The following columns negative values: has_neg.
       i Lower bound imputation is intended for data bounded at zero.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed_trained, new_data = biomass[, 4:7])
+    Condition
+      Error in `step_impute_lower()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_mean.md
+++ b/tests/testthat/_snaps/impute_mean.md
@@ -48,6 +48,14 @@
       -- Operations 
       * Mean imputation for: Age, Assets, Income | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed, new_data = credit_te[, c(-5)])
+    Condition
+      Error in `step_impute_mean()`:
+      ! The following required column is missing from `new_data`: Age.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_median.md
+++ b/tests/testthat/_snaps/impute_median.md
@@ -48,6 +48,14 @@
       -- Operations 
       * Median imputation for: Age, Assets, Income | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed, new_data = credit_te[, c(-5)])
+    Condition
+      Error in `step_impute_median()`:
+      ! The following required column is missing from `new_data`: Age.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_mode.md
+++ b/tests/testthat/_snaps/impute_mode.md
@@ -54,6 +54,14 @@
       -- Operations 
       * Mode imputation for: x1 | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(imputed, new_data = credit_te[, c(-6)])
+    Condition
+      Error in `step_impute_mode()`:
+      ! The following required column is missing from `new_data`: Marital.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/impute_roll.md
+++ b/tests/testthat/_snaps/impute_roll.md
@@ -29,6 +29,14 @@
       x All columns selected for the step should be double.
       * 1 integer variable found: `x4`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(seven_pt, new_data = example_data[, c(-2)])
+    Condition
+      Error in `step_impute_roll()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/indicate_na.md
+++ b/tests/testthat/_snaps/indicate_na.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `na_ind_mpg`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec1, new_data = test[, 2:3])
+    Condition
+      Error in `step_indicate_na()`:
+      ! The following required column is missing from `new_data`: col1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/integer.md
+++ b/tests/testthat/_snaps/integer.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, te_dat[, 2:3], all_predictors())
+    Condition
+      Error in `step_integer()`:
+      ! The following required column is missing from `new_data`: x.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/interact.md
+++ b/tests/testthat/_snaps/interact.md
@@ -24,7 +24,7 @@
       bake(int_rec_trained, dat_tr[, 4:6])
     Condition
       Error in `step_interact()`:
-      ! The following required columns are missing from `new_data` in step '': z and x1.
+      ! The following required columns are missing from `new_data`: z and x1.
 
 # empty printing
 

--- a/tests/testthat/_snaps/inverse.md
+++ b/tests/testthat/_snaps/inverse.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 1:3])
+    Condition
+      Error in `step_inverse()`:
+      ! The following required column is missing from `new_data`: x4.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/invlogit.md
+++ b/tests/testthat/_snaps/invlogit.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE])
+    Condition
+      Error in `step_invlogit()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/isomap.md
+++ b/tests/testthat/_snaps/isomap.md
@@ -41,6 +41,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `Isomap1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(im_trained, new_data = dat2[, 1:2])
+    Condition
+      Error in `step_isomap()`:
+      ! The following required column is missing from `new_data`: x3.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/kpca.md
+++ b/tests/testthat/_snaps/kpca.md
@@ -33,6 +33,14 @@
       -- Operations 
       * Kernel PCA extraction with: X2, X3, X4, X5, X6 | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(kpca_trained, new_data = te_dat[, 1:3])
+    Condition
+      Error in `step_kpca()`:
+      ! The following required columns are missing from `new_data`: X4, X5, and X6.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/kpca_poly.md
+++ b/tests/testthat/_snaps/kpca_poly.md
@@ -27,6 +27,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `kPC1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(kpca_trained, new_data = te_dat[, 1:3])
+    Condition
+      Error in `step_kpca_poly()`:
+      ! The following required columns are missing from `new_data`: X4, X5, and X6.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/kpca_rbf.md
+++ b/tests/testthat/_snaps/kpca_rbf.md
@@ -27,6 +27,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `kPC1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(kpca_trained, new_data = te_dat[, 1:3])
+    Condition
+      Error in `step_kpca_rbf()`:
+      ! The following required columns are missing from `new_data`: X4, X5, and X6.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/lag.md
+++ b/tests/testthat/_snaps/lag.md
@@ -7,6 +7,14 @@
       Caused by error in `prep()`:
       ! `lag` argument must be integer-valued, not a function.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = df[, 1, drop = FALSE])
+    Condition
+      Error in `step_lag()`:
+      ! The following required column is missing from `new_data`: t.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/log.md
+++ b/tests/testthat/_snaps/log.md
@@ -19,6 +19,14 @@
       -- Operations 
       * Signed log transformation on: x | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 1:3])
+    Condition
+      Error in `step_log()`:
+      ! The following required column is missing from `new_data`: x4.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/logit.md
+++ b/tests/testthat/_snaps/logit.md
@@ -7,6 +7,14 @@
       Caused by error in `binomial()$linkfun()`:
       ! Value -0.77772 out of range (0, 1)
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, 2:3])
+    Condition
+      Error in `step_logit()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -4,7 +4,7 @@
       bake(log_obj, examples[, 2:4, drop = FALSE])
     Condition
       Error in `step_log()`:
-      ! The following required column is missing from `new_data` in step 'log_IhS7o': V1.
+      ! The following required column is missing from `new_data`: V1.
 
 ---
 
@@ -12,7 +12,7 @@
       bake(log_obj, examples[, 3:4, drop = FALSE])
     Condition
       Error in `step_log()`:
-      ! The following required columns are missing from `new_data` in step 'log_IhS7o': V1 and V2.
+      ! The following required columns are missing from `new_data`: V1 and V2.
 
 ---
 
@@ -20,7 +20,7 @@
       bake(log_obj, examples[, 4, drop = FALSE])
     Condition
       Error in `step_log()`:
-      ! The following required columns are missing from `new_data` in step 'log_IhS7o': V1, V2, and V3.
+      ! The following required columns are missing from `new_data`: V1, V2, and V3.
 
 # conditionMessage method for recipes errors works
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -29,7 +29,7 @@
     Output
       [1] "Error in `step_dummy()`:\nCaused by error in `prep()`:\nx All columns selected for the step should be factor or ordered.\n* 11 double variables found: `mpg`, `cyl`, `disp`, `hp`, ..."
 
-# check_training_set errors are thrown
+# validate_training_data errors are thrown
 
     Code
       recipe(~., data = mtcars) %>% prep(fresh = TRUE)

--- a/tests/testthat/_snaps/missing.md
+++ b/tests/testthat/_snaps/missing.md
@@ -60,6 +60,14 @@
       Error in `bake()`:
       ! The following columns contains missing values: a.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `check_missing()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/mutate_at.md
+++ b/tests/testthat/_snaps/mutate_at.md
@@ -1,3 +1,12 @@
+# no input
+
+    Code
+      iris_rec %>% step_mutate_at() %>% prep(training = iris) %>% bake(new_data = NULL,
+        composition = "data.frame")
+    Condition
+      Error in `step_mutate_at()`:
+      ! argument "fn" is missing, with no default
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/mutate_at.md
+++ b/tests/testthat/_snaps/mutate_at.md
@@ -5,7 +5,7 @@
         composition = "data.frame")
     Condition
       Error in `step_mutate_at()`:
-      ! argument "fn" is missing, with no default
+      ! Argument `fn` must be specified.
 
 # empty printing
 

--- a/tests/testthat/_snaps/naomit.md
+++ b/tests/testthat/_snaps/naomit.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = airquality[, -3])
+    Condition
+      Error in `step_naomit()`:
+      ! The following required column is missing from `new_data`: Wind.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/newvalues.md
+++ b/tests/testthat/_snaps/newvalues.md
@@ -119,6 +119,14 @@
       Error in `new_values_func()`:
       ! `a` contains the new value: "FALSE".
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `check_new_values()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/nnmf_sparse.md
+++ b/tests/testthat/_snaps/nnmf_sparse.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `NNMF1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_nnmf_sparse()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/normalize.md
+++ b/tests/testthat/_snaps/normalize.md
@@ -112,6 +112,14 @@
       -- Operations 
       * Centering and scaling for: x | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(std_trained, new_data = biomass[, 1:2])
+    Condition
+      Error in `step_normalize()`:
+      ! The following required columns are missing from `new_data`: carbon, hydrogen, oxygen, nitrogen, and sulfur.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/novel.md
+++ b/tests/testthat/_snaps/novel.md
@@ -17,6 +17,14 @@
       Caused by error in `prep()`:
       ! Columns already contain the new level: x.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(ex_1, new_data = tr_dat[, c(-3)])
+    Condition
+      Error in `step_novel()`:
+      ! The following required column is missing from `new_data`: x.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/ns.md
+++ b/tests/testthat/_snaps/ns.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_ns_1`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(with_ns, new_data = biomass_tr[, c(-3)])
+    Condition
+      Error in `step_ns()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/num2factor.md
+++ b/tests/testthat/_snaps/num2factor.md
@@ -16,6 +16,14 @@
       Error in `step_num2factor()`:
       ! Please provide a character vector of appropriate length for `levels`.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(ex_1, new_data = ex_dat[, 1:2])
+    Condition
+      Error in `step_num2factor()`:
+      ! The following required column is missing from `new_data`: z.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/ordinalscore.md
+++ b/tests/testthat/_snaps/ordinalscore.md
@@ -9,6 +9,14 @@
       * 1 double variable found: `numbers`
       * 1 factor variable found: `fact`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec1, new_data = ex_dat[, 1:3])
+    Condition
+      Error in `step_ordinalscore()`:
+      ! The following required columns are missing from `new_data`: ord2 and ord3.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/other.md
+++ b/tests/testthat/_snaps/other.md
@@ -53,6 +53,14 @@
       -- Operations 
       * Collapsing factor levels for: city | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(others, new_data = sacr_te[, 3:9])
+    Condition
+      Error in `step_other()`:
+      ! The following required columns are missing from `new_data`: city and zip.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/pca.md
+++ b/tests/testthat/_snaps/pca.md
@@ -96,6 +96,14 @@
       -- Operations 
       * PCA extraction with: carbon and hydrogen, ... | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(pca_extract_trained, new_data = biomass_te[, c(-3)])
+    Condition
+      Error in `step_pca()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/percentile.md
+++ b/tests/testthat/_snaps/percentile.md
@@ -45,6 +45,14 @@
       -- Operations 
       * Percentile transformation on: carbon and sulfur | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = biomass_tr[, c(-3, -7)])
+    Condition
+      Error in `step_percentile()`:
+      ! The following required columns are missing from `new_data`: carbon and sulfur.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/pls.md
+++ b/tests/testthat/_snaps/pls.md
@@ -35,6 +35,14 @@
       ! The `preserve` argument of `step_pls()` was deprecated in recipes 0.1.16 and is now defunct.
       i Please use the `keep_original_cols` argument instead.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = biom_tr[, c(-1)])
+    Condition
+      Error in `step_pls()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/poly.md
+++ b/tests/testthat/_snaps/poly.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_poly_1`
 
+# old option argument
+
+    Code
+      res <- recipe(~., data = iris) %>% step_poly(Sepal.Width, options = list(
+        degree = 3)) %>% prep() %>% bake(new_data = NULL)
+    Message
+      The `degree` argument is now a main argument instead of being within `options`.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/poly.md
+++ b/tests/testthat/_snaps/poly.md
@@ -16,6 +16,14 @@
     Message
       The `degree` argument is now a main argument instead of being within `options`.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(with_poly, new_data = biomass_tr[, c(-3)])
+    Condition
+      Error in `step_poly()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/poly_bernstein.md
+++ b/tests/testthat/_snaps/poly_bernstein.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_poly_bernstein()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/range.md
+++ b/tests/testthat/_snaps/range.md
@@ -61,6 +61,14 @@
       -- Operations 
       * Range scaling to [0,1] for: x | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(standardized_trained, new_data = biomass_te[, 1:3])
+    Condition
+      Error in `step_range()`:
+      ! The following required column is missing from `new_data`: hydrogen.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/range_check.md
+++ b/tests/testthat/_snaps/range_check.md
@@ -107,6 +107,14 @@
       Error in `range_check_func()`:
       i Largest value of `y` is 60, crossing the upper bound 55.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `check_range()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/ratio.md
+++ b/tests/testthat/_snaps/ratio.md
@@ -38,6 +38,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_o_disp`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec1, ex_dat[, 2:5])
+    Condition
+      Error in `step_ratio()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/regex.md
+++ b/tests/testthat/_snaps/regex.md
@@ -27,6 +27,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `Sepal.Width`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = mt_tibble[, c(-1)])
+    Condition
+      Error in `step_regex()`:
+      ! The following required column is missing from `new_data`: make_model.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/relevel.md
+++ b/tests/testthat/_snaps/relevel.md
@@ -17,6 +17,14 @@
       Caused by error in `prep()`:
       ! The following column doesn't include required reference level "missing_level": `city`.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_1, sacr_te[, c(1, 3:ncol(sacr_te))])
+    Condition
+      Error in `step_relevel()`:
+      ! The following required column is missing from `new_data`: zip.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/relu.md
+++ b/tests/testthat/_snaps/relu.md
@@ -32,6 +32,14 @@
       x All columns selected for the step should be double or integer.
       * 1 factor variable found: `val2`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, df[, 2, drop = FALSE])
+    Condition
+      Error in `step_relu()`:
+      ! The following required column is missing from `new_data`: val1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/rename_at.md
+++ b/tests/testthat/_snaps/rename_at.md
@@ -14,7 +14,7 @@
         composition = "data.frame")
     Condition
       Error in `step_rename_at()`:
-      ! argument "fn" is missing, with no default
+      ! Argument `fn` must be specified.
 
 # empty printing
 

--- a/tests/testthat/_snaps/rename_at.md
+++ b/tests/testthat/_snaps/rename_at.md
@@ -7,6 +7,15 @@
       Caused by error in `dplyr::rename_at()`:
       ! `.funs` must contain one renaming function, not 2.
 
+# no input
+
+    Code
+      iris_rec %>% step_rename_at() %>% prep(training = iris) %>% bake(new_data = NULL,
+        composition = "data.frame")
+    Condition
+      Error in `step_rename_at()`:
+      ! argument "fn" is missing, with no default
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/scale.md
+++ b/tests/testthat/_snaps/scale.md
@@ -102,6 +102,14 @@
       -- Operations 
       * Scaling for: cyl, disp, hp, drat, qsec, vs, ... | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(std_trained, new_data = biomass[, 1:2])
+    Condition
+      Error in `step_scale()`:
+      ! The following required columns are missing from `new_data`: carbon, hydrogen, oxygen, nitrogen, and sulfur.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = mtcars[, c(-2)])
+    Condition
+      Error in `step_select()`:
+      ! The following required column is missing from `new_data`: cyl.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/shuffle.md
+++ b/tests/testthat/_snaps/shuffle.md
@@ -6,6 +6,14 @@
       Warning:
       `new_data` contains a single row; unable to shuffle.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec1, dat[, 2:5])
+    Condition
+      Error in `step_shuffle()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spatialsign.md
+++ b/tests/testthat/_snaps/spatialsign.md
@@ -38,6 +38,14 @@
       -- Operations 
       * Spatial sign on: cyl, disp, hp, drat, qsec, ... | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(sp_sign_trained, new_data = biomass[, c(-3)])
+    Condition
+      Error in `step_spatialsign()`:
+      ! The following required column is missing from `new_data`: carbon.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spline_b.md
+++ b/tests/testthat/_snaps/spline_b.md
@@ -28,6 +28,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_spline_b()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spline_convex.md
+++ b/tests/testthat/_snaps/spline_convex.md
@@ -28,6 +28,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_spline_convex()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spline_monotone.md
+++ b/tests/testthat/_snaps/spline_monotone.md
@@ -28,6 +28,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_spline_monotone()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spline_natural.md
+++ b/tests/testthat/_snaps/spline_natural.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_spline_natural()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/spline_nonnegative.md
+++ b/tests/testthat/_snaps/spline_nonnegative.md
@@ -28,6 +28,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = mtcars[, -3])
+    Condition
+      Error in `step_spline_nonnegative()`:
+      ! The following required column is missing from `new_data`: disp.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/sqrt.md
+++ b/tests/testthat/_snaps/sqrt.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec, new_data = ex_dat[, 2, drop = FALSE])
+    Condition
+      Error in `step_sqrt()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/string2factor.md
+++ b/tests/testthat/_snaps/string2factor.md
@@ -16,6 +16,14 @@
       Error in `step_string2factor()`:
       ! `ordered` must be `TRUE` or `FALSE`, not the string "yes".
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = ex_dat[, -1])
+    Condition
+      Error in `step_string2factor()`:
+      ! The following required column is missing from `new_data`: w.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/time.md
+++ b/tests/testthat/_snaps/time.md
@@ -8,6 +8,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `time_hour`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = examples[, -1])
+    Condition
+      Error in `step_time()`:
+      ! The following required column is missing from `new_data`: times.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/unknown.md
+++ b/tests/testthat/_snaps/unknown.md
@@ -32,6 +32,14 @@
       Caused by error in `prep()`:
       ! Columns already contain the level "FAIR_OAKS": city.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_1, sacr_te[3:ncol(sacr_te)])
+    Condition
+      Error in `step_unknown()`:
+      ! The following required columns are missing from `new_data`: city and zip.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/unorder.md
+++ b/tests/testthat/_snaps/unorder.md
@@ -34,6 +34,14 @@
       -- Operations 
       * Unordered variables: X1 | Trained
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec1_trained, new_data = examples[, 1, drop = FALSE])
+    Condition
+      Error in `step_unorder()`:
+      ! The following required column is missing from `new_data`: X2.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/update-role-requirements.md
+++ b/tests/testthat/_snaps/update-role-requirements.md
@@ -49,6 +49,14 @@
       Warning:
       Column `x` returned NaN, because variance cannot be calculated and scaling cannot be used. Consider avoiding `Inf` or `-Inf` values and/or setting `na_rm = TRUE` before normalizing.
 
+---
+
+    Code
+      bake(rec, df)
+    Condition
+      Error in `step_scale()`:
+      ! The following required column is missing from `new_data`: x.
+
 # can update `bake` requirements after prepping
 
     Code

--- a/tests/testthat/_snaps/window.md
+++ b/tests/testthat/_snaps/window.md
@@ -17,6 +17,14 @@
 ---
 
     Code
+      rec %>% step_window(y1, size = NULL)
+    Condition
+      Error in `step_window()`:
+      ! `size` must be a number, not `NULL`.
+
+---
+
+    Code
       rec %>% step_window(y1, statistic = "average")
     Condition
       Error in `step_window()`:

--- a/tests/testthat/_snaps/window.md
+++ b/tests/testthat/_snaps/window.md
@@ -101,6 +101,14 @@
       ! Name collision occurred. The following variable names already exist:
       * `new_value`
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(rec_trained, new_data = sim_dat[, -1])
+    Condition
+      Error in `step_window()`:
+      ! The following required column is missing from `new_data`: x1.
+
 # empty printing
 
     Code

--- a/tests/testthat/test-BoxCox.R
+++ b/tests/testthat/test-BoxCox.R
@@ -100,8 +100,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
   )
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-YeoJohnson.R
+++ b/tests/testthat/test-YeoJohnson.R
@@ -81,7 +81,7 @@ test_that("missing data", {
   rec_true <- recipe(~., data = ex_dat) %>%
     step_YeoJohnson(x1, x2, x3, x4)
 
-  expect_error(prep(rec_true, training = ex_dat, verbose = FALSE), NA)
+  expect_no_error(prep(rec_true, training = ex_dat, verbose = FALSE))
 
   rec_false <- recipe(~., data = ex_dat) %>%
     step_YeoJohnson(x1, x2, x3, x4, na_rm = FALSE)

--- a/tests/testthat/test-YeoJohnson.R
+++ b/tests/testthat/test-YeoJohnson.R
@@ -101,8 +101,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-bin2factor.R
+++ b/tests/testthat/test-bin2factor.R
@@ -76,7 +76,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec <- prep(rec, mtcars_bin)
 
-  expect_error(bake(rec, mtcars), class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, mtcars))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -143,8 +143,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   with_bs <- prep(with_bs, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(with_bs, new_data = biomass_tr[,c(-4)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(with_bs, new_data = biomass_tr[,c(-4)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-bs.R
+++ b/tests/testthat/test-bs.R
@@ -219,9 +219,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -128,8 +128,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   std_trained <- prep(std, training = biomass)
 
-  expect_error(bake(std_trained, new_data = biomass[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(std_trained, new_data = biomass[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -14,15 +14,15 @@ class(x3) <- c(class(x3), "Julian")
 x_newdata_2 <- tibble(x1 = x1, x2 = x3)
 
 test_that("bake_check_class helper function gives expected output", {
-  expect_error(bake_check_class_core(x1, "numeric", "x1"), NA)
-  expect_error(bake_check_class_core(x2, c("POSIXct", "POSIXt"), "x1"), NA)
+  expect_no_error(bake_check_class_core(x1, "numeric", "x1"))
+  expect_no_error(bake_check_class_core(x2, c("POSIXct", "POSIXt"), "x1"))
   expect_snapshot(error = TRUE,
     bake_check_class_core(x1, "character", "x1")
   )
   expect_snapshot(error = TRUE,
     bake_check_class_core(x2, c("POSIXct", "Julian"), "x2")
   )
-  expect_error(bake_check_class_core(x2, "POSIXct", "x2", TRUE), NA)
+  expect_no_error(bake_check_class_core(x2, "POSIXct", "x2", TRUE))
   expect_snapshot(error = TRUE,
     bake_check_class_core(x2, "POSIXct", "x2")
   )
@@ -33,7 +33,7 @@ test_that("check_class works when class is learned", {
     check_class(all_predictors()) %>%
     prep()
 
-  expect_error(bake(rec1, x), NA)
+  expect_no_error(bake(rec1, x))
   expect_equal(bake(rec1, x), x)
   expect_snapshot(error = TRUE,
     bake(rec1, x_newdata)
@@ -48,7 +48,7 @@ test_that("check_class works when class is provided", {
     check_class(x1, class_nm = "numeric") %>%
     prep()
 
-  expect_error(bake(rec2, x), NA)
+  expect_no_error(bake(rec2, x))
   expect_equal(bake(rec2, x), x)
   expect_snapshot(error = TRUE,
     bake(rec2, x_newdata)
@@ -58,7 +58,7 @@ test_that("check_class works when class is provided", {
     check_class(x2, class_nm = c("POSIXct", "POSIXt")) %>%
     prep()
 
-  expect_error(bake(rec3, x), NA)
+  expect_no_error(bake(rec3, x))
   expect_equal(bake(rec3, x), x)
   expect_snapshot(error = TRUE,
     bake(rec3, x_newdata_2)
@@ -70,7 +70,7 @@ test_that("check_class works when class is provided", {
       allow_additional = TRUE
     ) %>%
     prep()
-  expect_error(bake(rec4, x_newdata_2), NA)
+  expect_no_error(bake(rec4, x_newdata_2))
 })
 
 # recipes has internal coercion to character >> factor
@@ -79,13 +79,13 @@ test_that("characters are handled correctly", {
     check_class(all_predictors()) %>%
     prep(Sacramento[1:10, ], strings_as_factors = FALSE)
 
-  expect_error(bake(rec5_NULL, Sacramento[11:20, ]), NA)
+  expect_no_error(bake(rec5_NULL, Sacramento[11:20, ]))
 
   rec5_man <- recipe(Sacramento[1:10, ], sqft ~ .) %>%
     check_class(city, zip) %>%
     prep(Sacramento[1:10, ], strings_as_factors = FALSE)
 
-  expect_error(bake(rec5_man, Sacramento[11:20, ]), NA)
+  expect_no_error(bake(rec5_man, Sacramento[11:20, ]))
 
   sacr_fac <-
     dplyr::mutate(

--- a/tests/testthat/test-class.R
+++ b/tests/testthat/test-class.R
@@ -122,8 +122,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec)
 
-  expect_error(bake(rec_trained, new_data = x[, -1]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = x[, -1]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-classdist.R
+++ b/tests/testthat/test-classdist.R
@@ -181,8 +181,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = iris, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = iris[,c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(trained, new_data = iris[,c(-3)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-classdist.R
+++ b/tests/testthat/test-classdist.R
@@ -113,9 +113,9 @@ test_that("case weights", {
 
   expect_equal(means_wts, means_wts_exp)
   expect_equal(means_no, means_exp)
-  expect_error(
-    recipes:::get_center(mtcars, wts = wts, mfun = median),
-    "The centering function requested cannot be used with case weights"
+  expect_snapshot(
+    error = TRUE,
+    recipes:::get_center(mtcars, wts = wts, mfun = median)
   )
 
   # ------------------------------------------------------------------------------
@@ -128,13 +128,13 @@ test_that("case weights", {
   expect_equal(cov_no$scale, cov_exp)
   expect_equal(cov_wts$center, means_wts_exp)
   expect_equal(cov_no$center, means_exp)
-  expect_error(
-    recipes:::get_both(mtcars, wts = wts, mfun = median),
-    "The centering function requested cannot be used with case weights"
+  expect_snapshot(
+    error = TRUE,
+    recipes:::get_both(mtcars, wts = wts, mfun = median)
   )
-  expect_error(
-    recipes:::get_both(mtcars, wts = wts, cfun = mad),
-    "The variance function requested cannot be used with case weights"
+  expect_snapshot(
+    error = TRUE,
+    recipes:::get_both(mtcars, wts = wts, cfun = mad)
   )
 
   # ------------------------------------------------------------------------------

--- a/tests/testthat/test-classdist.R
+++ b/tests/testthat/test-classdist.R
@@ -264,9 +264,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = iris),
-    NA
+  expect_no_error(
+    bake(rec, new_data = iris)
   )
 })
 

--- a/tests/testthat/test-classdist_shrunken.R
+++ b/tests/testthat/test-classdist_shrunken.R
@@ -169,8 +169,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = iris, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = iris[,c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(trained, new_data = iris[,c(-3)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-colcheck.R
+++ b/tests/testthat/test-colcheck.R
@@ -5,32 +5,37 @@ rp1 <- recipe(mtcars, cyl ~ .)
 rp2 <- recipe(mtcars, cyl ~ mpg + drat)
 
 test_that("check_col works in the prep stage", {
-  expect_error(rp1 %>% check_cols(all_predictors()) %>% prep(), NA)
-  expect_error(rp2 %>% check_cols(all_predictors()) %>% prep(), NA)
-  expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep(), NA)
-  expect_error(rp2 %>% check_cols(cyl, mpg) %>% prep(), NA)
+  expect_no_error(rp1 %>% check_cols(all_predictors()) %>% prep())
+  expect_no_error(rp2 %>% check_cols(all_predictors()) %>% prep())
+  expect_no_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep())
+  expect_no_error(rp2 %>% check_cols(cyl, mpg) %>% prep())
 })
 
 
 test_that("check_col works in the bake stage", {
 
-  expect_error(rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
-               NA)
+  expect_no_error(
+    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars)
+  )
   expect_equal(rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
                tibble(mtcars[ ,c(1, 3:11, 2)]))
-  expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep %>% bake(mtcars), NA)
+
+  expect_no_error(
+    rp2 %>% check_cols(cyl, mpg, drat) %>% prep %>% bake(mtcars)
+  )
   expect_equal(rp2 %>% check_cols(cyl, mpg, drat) %>% prep %>% bake(mtcars),
                tibble(mtcars[ ,c(1, 5, 2)]))
 
-  expect_error(
-    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
-    NA
+  expect_no_error(
+    rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars)
   )
   expect_equal(
     rp1 %>% check_cols(all_predictors()) %>% prep() %>% bake(mtcars),
     tibble(mtcars[, c(1, 3:11, 2)])
   )
-  expect_error(rp2 %>% check_cols(cyl, mpg, drat) %>% prep() %>% bake(mtcars), NA)
+  expect_no_error(
+    rp2 %>% check_cols(cyl, mpg, drat) %>% prep() %>% bake(mtcars)
+  )
   expect_equal(
     rp2 %>% check_cols(cyl, mpg, drat) %>% prep() %>% bake(mtcars),
     tibble(mtcars[, c(1, 5, 2)])
@@ -86,7 +91,7 @@ test_that("non-standard roles during bake/predict", {
 
   role_fit <- fit(role_wflow, data = Chicago)
 
-  expect_error(predict(role_fit, head(Chicago)), NA)
+  expect_no_error(predict(role_fit, head(Chicago)))
 
   # This should require 'date' to predict.
   # The error comes from hardhat, so we don't snapshot it because we don't own it.
@@ -108,8 +113,8 @@ test_that("non-standard roles during bake/predict", {
   role_wts_fit <- fit(role_wts_wflow, data = Chicago)
 
   # This should require 'date' but not 'wts' to predict
-  expect_error(predict(role_wts_fit, head(Chicago)), NA)
-  expect_error(predict(role_wts_fit, head(Chicago) %>% select(-wts)), NA)
+  expect_no_error(predict(role_wts_fit, head(Chicago)))
+  expect_no_error(predict(role_wts_fit, head(Chicago) %>% select(-wts)))
   expect_error(predict(role_wts_fit, head(Chicago) %>% select(-date)))
 
   # ----------------------------------------------------------------------------
@@ -143,7 +148,7 @@ test_that("non-standard roles during bake/predict", {
   rm_wts_fit <- fit(rm_wts_wflow, data = Chicago)
 
   # This should require 'date' but not 'wts' to predict
-  expect_error(predict(rm_fit, Chicago %>% select(-wts)), NA)
+  expect_no_error(predict(rm_fit, Chicago %>% select(-wts)))
   expect_error(predict(rm_fit, Chicago %>% select(-date)))
 })
 

--- a/tests/testthat/test-colcheck.R
+++ b/tests/testthat/test-colcheck.R
@@ -95,8 +95,7 @@ test_that("non-standard roles during bake/predict", {
 
   # This should require 'date' to predict.
   # The error comes from hardhat, so we don't snapshot it because we don't own it.
-  expect_snapshot(
-    error = TRUE,
+  expect_error(
     predict(role_fit, Chicago %>% select(-date))
   )
 

--- a/tests/testthat/test-colcheck.R
+++ b/tests/testthat/test-colcheck.R
@@ -95,7 +95,10 @@ test_that("non-standard roles during bake/predict", {
 
   # This should require 'date' to predict.
   # The error comes from hardhat, so we don't snapshot it because we don't own it.
-  expect_error(predict(role_fit, Chicago %>% select(-date)))
+  expect_snapshot(
+    error = TRUE,
+    predict(role_fit, Chicago %>% select(-date))
+  )
 
   # ----------------------------------------------------------------------------
   # non-standard role used in a step and case weights
@@ -115,7 +118,10 @@ test_that("non-standard roles during bake/predict", {
   # This should require 'date' but not 'wts' to predict
   expect_no_error(predict(role_wts_fit, head(Chicago)))
   expect_no_error(predict(role_wts_fit, head(Chicago) %>% select(-wts)))
-  expect_error(predict(role_wts_fit, head(Chicago) %>% select(-date)))
+  expect_snapshot(
+    error = TRUE,
+    predict(role_wts_fit, head(Chicago) %>% select(-date))
+  )
 
   # ----------------------------------------------------------------------------
   # Removing variable after use
@@ -131,7 +137,10 @@ test_that("non-standard roles during bake/predict", {
   rm_fit <- fit(rm_wflow, data = Chicago)
 
   # This should require 'date' to predict
-  expect_error(predict(rm_fit, Chicago %>% select(-date)))
+  expect_snapshot(
+    error = TRUE,
+    predict(rm_fit, Chicago %>% select(-date))
+  )
 
   # ----------------------------------------------------------------------------
   # Removing variable after use, with case weights
@@ -149,7 +158,10 @@ test_that("non-standard roles during bake/predict", {
 
   # This should require 'date' but not 'wts' to predict
   expect_no_error(predict(rm_fit, Chicago %>% select(-wts)))
-  expect_error(predict(rm_fit, Chicago %>% select(-date)))
+  expect_snapshot(
+    error = TRUE,
+    predict(rm_fit, Chicago %>% select(-date))
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -161,9 +161,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = covers),
-    NA
+  expect_no_error(
+    bake(rec, new_data = covers)
   )
 })
 

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -82,8 +82,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mt_tibble)
 
-  expect_error(bake(rec_trained, new_data = mt_tibble[,c(-1)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mt_tibble[,c(-1)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-cut.R
+++ b/tests/testthat/test-cut.R
@@ -182,8 +182,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep()
 
-  expect_error(bake(prepped, df[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(prepped, df[, 2, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-cut.R
+++ b/tests/testthat/test-cut.R
@@ -34,8 +34,8 @@ test_that("full_breaks_check will give warnings", {
   expect_snapshot(
     full_breaks_check(c(10, 20))
   )
-  expect_error(full_breaks_check(c(10, 20, 30)), NA)
-  expect_warning(full_breaks_check(c(10, 20, 30)), NA)
+  expect_no_error(full_breaks_check(c(10, 20, 30)))
+  expect_no_warning(full_breaks_check(c(10, 20, 30)))
 })
 
 test_that("cut_var gives correct output", {

--- a/tests/testthat/test-cut.R
+++ b/tests/testthat/test-cut.R
@@ -1,6 +1,6 @@
 test_that("step_cut throws error on non-numerics", {
   x <- tibble(num_var = 1:3, cat_var = c("1", "2", "3"))
-  expect_error(recipe(x) %>% step_cut(num_var, breaks = 2) %>% prep(), NA)
+  expect_no_error(recipe(x) %>% step_cut(num_var, breaks = 2) %>% prep())
   expect_snapshot(error = TRUE,
     recipe(x) %>% step_cut(cat_var, breaks = 2) %>% prep()
   )

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -192,8 +192,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
   date_rec <- prep(date_rec, training = examples)
   date_res <- bake(date_rec, new_data = examples)
 
-  expect_error(bake(date_rec, new_data = examples[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(date_rec, new_data = examples[, 2, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -104,6 +104,9 @@ test_that("check_name() is used", {
 })
 
 test_that("locale argument have recipe work in different locale", {
+  skip_if(getRversion() < "4.3.0")
+  # Locales on GHA are weird on old versions of R
+
   old_locale <- Sys.getlocale("LC_TIME")
   withr::defer(Sys.setlocale("LC_TIME", old_locale))
   Sys.setlocale("LC_TIME", 'fr_FR.UTF-8')
@@ -122,6 +125,9 @@ test_that("locale argument have recipe work in different locale", {
 })
 
 test_that("locale argument works when specified", {
+  skip_if(getRversion() < "4.3.0")
+  # Locales on GHA are weird on old versions of R
+
   old_locale <- Sys.getlocale("LC_TIME")
   withr::defer(Sys.setlocale("LC_TIME", old_locale))
   date_rec <- recipe(~ Dan + Stefan, examples) %>%

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -125,7 +125,7 @@ test_that("locale argument have recipe work in different locale", {
 })
 
 test_that("locale argument works when specified", {
-  skip_if(getRversion() <= "4.3.0")
+  skip_if(getRversion() < "4.3.0")
   # Locales on GHA are weird on old versions of R
 
   old_locale <- Sys.getlocale("LC_TIME")

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -175,9 +175,8 @@ test_that("can bake and recipes with no locale", {
 
   date_rec$steps[[1]]$locale <- NULL
 
-  expect_error(
-    date_res <- bake(date_rec, new_data = examples, all_predictors()),
-    NA
+  expect_no_error(
+    date_res <- bake(date_rec, new_data = examples, all_predictors())
   )
 })
 
@@ -273,9 +272,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = examples),
-    NA
+  expect_no_error(
+    bake(rec, new_data = examples)
   )
 })
 

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -174,9 +174,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = iris),
-    NA
+  expect_no_error(
+    bake(rec, new_data = iris)
   )
 })
 

--- a/tests/testthat/test-depth.R
+++ b/tests/testthat/test-depth.R
@@ -93,8 +93,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = iris, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = iris[, 2:5]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(trained, new_data = iris[, 2:5]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-discretize.R
+++ b/tests/testthat/test-discretize.R
@@ -180,8 +180,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   rec <- prep(rec, mtcars)
 
-  expect_error(bake(rec, new_data = mtcars[, 2:ncol(mtcars)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = mtcars[, 2:ncol(mtcars)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -354,8 +354,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   dummy_trained <- prep(dummy, training = sacr_fac, verbose = FALSE, strings_as_factors = FALSE)
 
-  expect_error(bake(dummy_trained, new_data = sacr_fac[, 3:4], all_predictors()),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(dummy_trained, new_data = sacr_fac[, 3:4], all_predictors())
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -433,9 +433,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = iris),
-    NA
+  expect_no_error(
+    bake(rec, new_data = iris)
   )
 })
 

--- a/tests/testthat/test-dummy_extract.R
+++ b/tests/testthat/test-dummy_extract.R
@@ -306,8 +306,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   dummy_prepped <- prep(dummy)
 
-  expect_error(bake(dummy_prepped, new_data = mini_tate[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(dummy_prepped, new_data = mini_tate[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-dummy_extract.R
+++ b/tests/testthat/test-dummy_extract.R
@@ -384,9 +384,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = color_examples),
-    NA
+  expect_no_error(
+    bake(rec, new_data = color_examples)
   )
 })
 

--- a/tests/testthat/test-dummy_multi_choice.R
+++ b/tests/testthat/test-dummy_multi_choice.R
@@ -143,8 +143,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = languages)
 
-  expect_error(bake(rec_trained, new_data = languages[, -1]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = languages[, -1]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-dummy_multi_choice.R
+++ b/tests/testthat/test-dummy_multi_choice.R
@@ -219,9 +219,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = languages),
-    NA
+  expect_no_error(
+    bake(rec, new_data = languages)
   )
 })
 

--- a/tests/testthat/test-factor2string.R
+++ b/tests/testthat/test-factor2string.R
@@ -41,8 +41,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(ex_dat, strings_as_factors = FALSE)
 
-  expect_error(bake(ex_1, new_data = ex_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(ex_1, new_data = ex_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -83,9 +83,8 @@ test_that("quasiquotation", {
 
   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
 
-  expect_error(
-    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
-    regexp = NA
+  expect_no_error(
+    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
   )
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)

--- a/tests/testthat/test-geodist.R
+++ b/tests/testthat/test-geodist.R
@@ -231,8 +231,11 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role(x, y, new_role = "potato") %>%
     update_role_requirements(role = "potato", bake = FALSE)
   rec_trained <- prep(rec, rand_data)
-  expect_error(bake(rec_trained, new_data = rand_data[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  
+  expect_snapshot(
+    error = TRUE, 
+    bake(rec_trained, new_data = rand_data[, 2, drop = FALSE])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-geodist.R
+++ b/tests/testthat/test-geodist.R
@@ -330,9 +330,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = rand_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = rand_data)
   )
 })
 

--- a/tests/testthat/test-harmonic.R
+++ b/tests/testthat/test-harmonic.R
@@ -520,9 +520,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-harmonic.R
+++ b/tests/testthat/test-harmonic.R
@@ -435,8 +435,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep()
 
-  expect_error(bake(rec, new_data = harmonic_dat_mult[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = harmonic_dat_mult[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-holiday.R
+++ b/tests/testthat/test-holiday.R
@@ -192,8 +192,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   holiday_rec <- prep(holiday_rec, training = test_data)
 
-  expect_error(bake(holiday_rec, exp_dates[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(holiday_rec, exp_dates[, 2, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-holiday.R
+++ b/tests/testthat/test-holiday.R
@@ -270,9 +270,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = test_data),
-    NA
+  expect_no_error(
+    bake(rec, new_data = test_data)
   )
 })
 

--- a/tests/testthat/test-hyperbolic.R
+++ b/tests/testthat/test-hyperbolic.R
@@ -69,8 +69,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -154,8 +154,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   ica_extract_trained <- prep(ica_extract, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(ica_extract_trained, new_data = biomass_tr[, c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(ica_extract_trained, new_data = biomass_tr[, c(-3)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-ica.R
+++ b/tests/testthat/test-ica.R
@@ -258,9 +258,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-impute_bag.R
+++ b/tests/testthat/test-impute_bag.R
@@ -125,8 +125,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   imputed_trained <- prep(imputed, training = biomass, verbose = FALSE)
 
-  expect_error(bake(imputed_trained, new_data = biomass[, c(-3, -9)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(imputed_trained, new_data = biomass[, c(-3, -9)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_knn.R
+++ b/tests/testthat/test-impute_knn.R
@@ -183,8 +183,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   imputed_trained <- prep(imputed, training = biomass, verbose = FALSE)
 
-  expect_error(bake(imputed_trained, new_data = biomass[, c(-4)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(imputed_trained, new_data = biomass[, c(-4)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_linear.R
+++ b/tests/testthat/test-impute_linear.R
@@ -143,8 +143,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(ames_dat)
 
-  expect_error(bake(rec, new_data = ames_dat[, 2:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(rec, new_data = ames_dat[, 2:3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_lower.R
+++ b/tests/testthat/test-impute_lower.R
@@ -71,8 +71,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   imputed_trained <- prep(imputed, training = biomass, verbose = FALSE)
 
-  expect_error(bake(imputed_trained, new_data = biomass[, 4:7]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(imputed_trained, new_data = biomass[, 4:7])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_mean.R
+++ b/tests/testthat/test-impute_mean.R
@@ -208,8 +208,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   imputed <- prep(impute_rec, training = credit_tr, verbose = FALSE)
 
-  expect_error(bake(imputed, new_data = credit_te[, c(-5)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(imputed, new_data = credit_te[, c(-5)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_median.R
+++ b/tests/testthat/test-impute_median.R
@@ -130,8 +130,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   imputed <- prep(impute_rec, training = credit_tr, verbose = FALSE)
 
-  expect_error(bake(imputed, new_data = credit_te[, c(-5)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(imputed, new_data = credit_te[, c(-5)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_mode.R
+++ b/tests/testthat/test-impute_mode.R
@@ -148,8 +148,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)
   imputed <- prep(impute_rec, training = credit_tr, verbose = FALSE)
 
-  expect_error(bake(imputed, new_data = credit_te[, c(-6)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(imputed, new_data = credit_te[, c(-6)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-impute_roll.R
+++ b/tests/testthat/test-impute_roll.R
@@ -117,8 +117,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(training = example_data)
 
-  expect_error(bake(seven_pt, new_data = example_data[, c(-2)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(seven_pt, new_data = example_data[, c(-2)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-indicate_na.R
+++ b/tests/testthat/test-indicate_na.R
@@ -183,9 +183,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-indicate_na.R
+++ b/tests/testthat/test-indicate_na.R
@@ -107,8 +107,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)%>%
     prep(train, verbose = FALSE, retain = TRUE)
 
-  expect_error(bake(rec1, new_data = test[, 2:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec1, new_data = test[, 2:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-integer.R
+++ b/tests/testthat/test-integer.R
@@ -87,8 +87,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   tr_int <- bake(rec_trained, new_data = NULL, all_predictors())
 
-  expect_error(bake(rec_trained, te_dat[, 2:3], all_predictors()),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(rec_trained, te_dat[, 2:3], all_predictors())
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -330,10 +330,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
       prep(int_rec, training = dat_tr, verbose = FALSE)
   )
 
-  expect_error(bake(int_rec_trained, dat_tr[, 4:6]),
-               class = "new_data_missing_column")
-
-  expect_snapshot(bake(int_rec_trained, dat_tr[, 4:6]), error = TRUE)
+  expect_snapshot(
+    error = TRUE, 
+    bake(int_rec_trained, dat_tr[, 4:6])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -409,9 +409,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = dat_tr),
-    NA
+  expect_no_error(
+    bake(rec, new_data = dat_tr)
   )
 })
 

--- a/tests/testthat/test-inverse.R
+++ b/tests/testthat/test-inverse.R
@@ -45,8 +45,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-invlogit.R
+++ b/tests/testthat/test-invlogit.R
@@ -36,8 +36,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(rec_trained, new_data = ex_dat[, 2, drop = FALSE])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-isomap.R
+++ b/tests/testthat/test-isomap.R
@@ -251,9 +251,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     transform = scrub_timestamp
   )
 
-  expect_error(
-    bake(rec, new_data = dat1),
-    NA
+  expect_no_error(
+    bake(rec, new_data = dat1)
   )
 })
 

--- a/tests/testthat/test-isomap.R
+++ b/tests/testthat/test-isomap.R
@@ -158,8 +158,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   im_trained <- prep(im_rec, training = dat1, verbose = FALSE)
 
-  expect_error(bake(im_trained, new_data = dat2[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(im_trained, new_data = dat2[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -100,8 +100,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
 
-  expect_error(bake(kpca_trained, new_data = te_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(kpca_trained, new_data = te_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-kpca.R
+++ b/tests/testthat/test-kpca.R
@@ -178,9 +178,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -108,8 +108,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
 
-  expect_error(bake(kpca_trained, new_data = te_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(kpca_trained, new_data = te_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-kpca_poly.R
+++ b/tests/testthat/test-kpca_poly.R
@@ -192,9 +192,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = tr_dat),
-    NA
+  expect_no_error(
+    bake(rec, new_data = tr_dat)
   )
 })
 

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -108,8 +108,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   kpca_trained <- prep(kpca_rec, training = tr_dat, verbose = FALSE)
 
-  expect_error(bake(kpca_trained, new_data = te_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(kpca_trained, new_data = te_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-kpca_rbf.R
+++ b/tests/testthat/test-kpca_rbf.R
@@ -186,9 +186,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-lag.R
+++ b/tests/testthat/test-lag.R
@@ -87,8 +87,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)%>%
     prep(df)
 
-  expect_error(bake(rec, new_data = df[, 1, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = df[, 1, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-lag.R
+++ b/tests/testthat/test-lag.R
@@ -163,9 +163,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -68,8 +68,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-logit.R
+++ b/tests/testthat/test-logit.R
@@ -57,8 +57,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, 2:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, 2:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -57,8 +57,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-missing.R
+++ b/tests/testthat/test-missing.R
@@ -20,7 +20,7 @@ test_that("check_missing passes silently when no NA", {
   no_na_rp <- recipe(mtcars) %>%
     check_missing(all_numeric()) %>%
     prep()
-  expect_error(bake(no_na_rp, mtcars), NA)
+  expect_no_error(bake(no_na_rp, mtcars))
   expect_equal(bake(no_na_rp, mtcars), tibble(mtcars))
 })
 

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -64,9 +64,8 @@ test_that("quasiquotation", {
   expect_snapshot(error = TRUE,
     prep(rec_1, training = iris %>% slice(1:75))
   )
-  expect_error(
-    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
-    regexp = NA
+  expect_no_error(
+    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
   )
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)

--- a/tests/testthat/test-mutate_at.R
+++ b/tests/testthat/test-mutate_at.R
@@ -71,7 +71,8 @@ test_that("mulitple functions", {
 
 test_that("no input", {
   # Wait for call pass through
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     iris_rec %>%
       step_mutate_at() %>%
       prep(training = iris) %>%

--- a/tests/testthat/test-mutate_at.R
+++ b/tests/testthat/test-mutate_at.R
@@ -70,7 +70,6 @@ test_that("mulitple functions", {
 })
 
 test_that("no input", {
-  # Wait for call pass through
   expect_snapshot(
     error = TRUE,
     iris_rec %>%

--- a/tests/testthat/test-naomit.R
+++ b/tests/testthat/test-naomit.R
@@ -43,8 +43,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = airquality)
 
-  expect_error(bake(rec_trained, new_data = airquality[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = airquality[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-newvalues.R
+++ b/tests/testthat/test-newvalues.R
@@ -165,8 +165,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-newvalues.R
+++ b/tests/testthat/test-newvalues.R
@@ -6,7 +6,7 @@ x_na <- c(rep(letters[1:3], 2), NA)
 allowed_values <- letters[1:3]
 
 test_that("new_values_func passes when no new values", {
-  expect_error(new_values_func(x, allowed_values), NA)
+  expect_no_error(new_values_func(x, allowed_values))
 })
 
 test_that("new_values_func breaks when x contains new values", {
@@ -22,7 +22,7 @@ test_that("new_values_func correctly prints multiple new values", {
 })
 
 test_that("new_values_func by default ignores NA", {
-  expect_error(new_values_func(x_na, allowed_values), NA)
+  expect_no_error(new_values_func(x_na, allowed_values))
 })
 
 test_that("new_values_func breaks when NA is new value and ignore_NA is FALSE", {
@@ -57,10 +57,9 @@ test_that("new_values_func correctly prints only non na-values when also NA as n
 })
 
 test_that("check_new_values does nothing when no new values", {
-  expect_error(
+  expect_no_error(
     x <- recipe(credit_data) %>% check_new_values(Home) %>%
-      prep() %>% bake(credit_data),
-    NA
+      prep() %>% bake(credit_data)
   )
   expect_equal(x, as_tibble(credit_data))
 })
@@ -83,10 +82,9 @@ test_that("check_new_values breaks with new values", {
 test_that("check_new_values ignores NA by default", {
   x1 <- data.frame(a = letters[1:3])
   x2 <- data.frame(a = letters[1:4] %>% c(NA))
-  expect_error(
+  expect_no_error(
     recipe(x1) %>% check_new_values(a) %>%
-      prep() %>% bake(x2[-4, , drop = FALSE]),
-    NA
+      prep() %>% bake(x2[-4, , drop = FALSE])
   )
 
   expect_snapshot(error = TRUE,
@@ -111,10 +109,9 @@ test_that("check_new_values not ignoring NA argument", {
 })
 
 check_new_values_data_type_unit_tests <- function(x1, x2, saf = TRUE) {
-  expect_error(
+  expect_no_error(
     res <- recipe(x1) %>% check_new_values(a) %>%
-      prep(strings_as_factors = saf) %>% bake(x1),
-    NA
+      prep(strings_as_factors = saf) %>% bake(x1)
   )
 
   expect_equal(res, x1)

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -131,9 +131,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-nnmf_sparse.R
+++ b/tests/testthat/test-nnmf_sparse.R
@@ -40,8 +40,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -162,8 +162,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   std_trained <- prep(std, training = biomass)
 
-  expect_error(bake(std_trained, new_data = biomass[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(std_trained, new_data = biomass[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-novel.R
+++ b/tests/testthat/test-novel.R
@@ -106,8 +106,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE)%>%
     prep(tr_dat, strings_as_factors = FALSE)
 
-  expect_error(bake(ex_1, new_data = tr_dat[, c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(ex_1, new_data = tr_dat[, c(-3)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -221,9 +221,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-ns.R
+++ b/tests/testthat/test-ns.R
@@ -145,8 +145,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   with_ns <- prep(with_ns, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(with_ns, new_data = biomass_tr[, c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(with_ns, new_data = biomass_tr[, c(-3)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-num2factor.R
+++ b/tests/testthat/test-num2factor.R
@@ -56,8 +56,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(ex_dat)
 
-  expect_error(bake(ex_1, new_data = ex_dat[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(ex_1, new_data = ex_dat[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-ordinalscore.R
+++ b/tests/testthat/test-ordinalscore.R
@@ -83,8 +83,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
                strings_as_factors = FALSE, verbose = FALSE
   )
 
-  expect_error(bake(rec1, new_data = ex_dat[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec1, new_data = ex_dat[, 1:3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-other.R
+++ b/tests/testthat/test-other.R
@@ -381,8 +381,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   others <- prep(others, training = sacr_tr)
 
-  expect_error(bake(others, new_data = sacr_te[, 3:9]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(others, new_data = sacr_te[, 3:9]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-other.R
+++ b/tests/testthat/test-other.R
@@ -320,9 +320,8 @@ test_that("issue #415 -  strings to factor conversion", {
   iris_no_outcome <- iris
   iris_no_outcome["Species"] <- NULL
 
-  expect_error(
-    res <- bake(prepped, iris_no_outcome),
-    regex = NA
+  expect_no_error(
+    res <- bake(prepped, iris_no_outcome)
   )
   expect_equal(names(res), names(iris[, 1:4]))
 })

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -346,9 +346,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -262,8 +262,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   pca_extract_trained <- prep(pca_extract, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(pca_extract_trained, new_data = biomass_te[, c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(pca_extract_trained, new_data = biomass_te[, c(-3)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-percentile.R
+++ b/tests/testthat/test-percentile.R
@@ -234,8 +234,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec)
 
-  expect_error(bake(rec_trained, new_data = biomass_tr[, c(-3, -7)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(rec_trained, new_data = biomass_tr[, c(-3, -7)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -282,8 +282,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec <- prep(rec)
 
-  expect_error(bake(rec, new_data = biom_tr[, c(-1)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = biom_tr[, c(-1)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-pls.R
+++ b/tests/testthat/test-pls.R
@@ -365,9 +365,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-poly.R
+++ b/tests/testthat/test-poly.R
@@ -123,8 +123,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   with_poly <- prep(with_poly, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(with_poly, new_data = biomass_tr[, c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(with_poly, new_data = biomass_tr[, c(-3)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-poly.R
+++ b/tests/testthat/test-poly.R
@@ -90,13 +90,12 @@ test_that("tunable", {
 })
 
 test_that("old option argument", {
-  expect_message(
+  expect_snapshot(
     res <-
       recipe(~., data = iris) %>%
       step_poly(Sepal.Width, options = list(degree = 3)) %>%
       prep() %>%
-      bake(new_data = NULL),
-    "The `degree` argument is now a main argument"
+      bake(new_data = NULL)
   )
   exp_names <- c(
     "Sepal.Length", "Petal.Length", "Petal.Width", "Species",

--- a/tests/testthat/test-poly.R
+++ b/tests/testthat/test-poly.R
@@ -199,9 +199,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-poly_bernstein.R
+++ b/tests/testthat/test-poly_bernstein.R
@@ -118,8 +118,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-range.R
+++ b/tests/testthat/test-range.R
@@ -202,8 +202,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   standardized_trained <- prep(standardized, training = biomass_tr, verbose = FALSE)
 
-  expect_error(bake(standardized_trained, new_data = biomass_te[, 1:3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(standardized_trained, new_data = biomass_te[, 1:3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-range_check.R
+++ b/tests/testthat/test-range_check.R
@@ -3,18 +3,18 @@ library(testthat)
 x <- -10:110
 
 test_that("core function - correct input", {
-  expect_error(range_check_func(x, -10, 110), NA)
+  expect_no_error(range_check_func(x, -10, 110))
   expect_snapshot(error = TRUE, range_check_func(as.character(x), -10, 110))
   expect_snapshot(error = TRUE, range_check_func(x, -10, 110, "a"))
-  expect_error(range_check_func(x, -10, 110, .05), NA)
-  expect_error(range_check_func(x, -10, 110, c(.05, .08)), NA)
+  expect_no_error(range_check_func(x, -10, 110, .05))
+  expect_no_error(range_check_func(x, -10, 110, c(.05, .08)))
   expect_snapshot(error = TRUE,
     range_check_func(x, -10, 110, c(.05, .08, .05))
   )
 })
 
 test_that("core function - workings", {
-  expect_error(range_check_func(x, -5, 110), NA)
+  expect_no_error(range_check_func(x, -5, 110))
   expect_snapshot(error = TRUE,
     range_check_func(x, 0, 100)
   )

--- a/tests/testthat/test-range_check.R
+++ b/tests/testthat/test-range_check.R
@@ -70,8 +70,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-range_check.R
+++ b/tests/testthat/test-range_check.R
@@ -41,8 +41,8 @@ test_that("in recipe", {
   rec1 <- recipe(train) %>%
     check_range(x, y, slack_prop = 0.2) %>%
     prep()
-  expect_error(bake(rec1, test), NA)
-  expect_warning(bake(rec1, test), NA)
+  expect_no_warning(bake(rec1, test))
+  expect_no_error(bake(rec1, test))
 
   rec2 <- recipe(train) %>%
     check_range(x, y) %>%

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -155,8 +155,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec1 <- prep(rec1, ex_dat, verbose = FALSE)
 
-  expect_error(bake(rec1, ex_dat[, 2:5]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec1, ex_dat[, 2:5]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -231,9 +231,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = mtcars),
-    NA
+  expect_no_error(
+    bake(rec, new_data = mtcars)
   )
 })
 

--- a/tests/testthat/test-regex.R
+++ b/tests/testthat/test-regex.R
@@ -72,8 +72,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(mt_tibble)
 
-  expect_error(bake(rec, new_data = mt_tibble[, c(-1)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = mt_tibble[, c(-1)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-regex.R
+++ b/tests/testthat/test-regex.R
@@ -150,9 +150,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = covers),
-    NA
+  expect_no_error(
+    bake(rec, new_data = covers)
   )
 })
 

--- a/tests/testthat/test-relevel.R
+++ b/tests/testthat/test-relevel.R
@@ -55,8 +55,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep()
 
-  expect_error(bake(rec_1, sacr_te[, c(1, 3:ncol(sacr_te))]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_1, sacr_te[, c(1, 3:ncol(sacr_te))]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-relu.R
+++ b/tests/testthat/test-relu.R
@@ -99,8 +99,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements("potato", bake = FALSE) %>%
     prep(df, verbose = FALSE)
 
-  expect_error(bake(rec, df[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, df[, 2, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-rename_at.R
+++ b/tests/testthat/test-rename_at.R
@@ -40,7 +40,8 @@ test_that("mulitple functions", {
 
 test_that("no input", {
   # Wait for call pass through
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     iris_rec %>%
       step_rename_at() %>%
       prep(training = iris) %>%

--- a/tests/testthat/test-rename_at.R
+++ b/tests/testthat/test-rename_at.R
@@ -39,7 +39,6 @@ test_that("mulitple functions", {
 })
 
 test_that("no input", {
-  # Wait for call pass through
   expect_snapshot(
     error = TRUE,
     iris_rec %>%

--- a/tests/testthat/test-rm.R
+++ b/tests/testthat/test-rm.R
@@ -160,9 +160,8 @@ test_that("remove with quasi-quotation", {
 
   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
 
-  # expect_error(
-  #   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
-  #   regexp = NA
+  # expect_no_error(
+  #   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
   # )
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)

--- a/tests/testthat/test-scale.R
+++ b/tests/testthat/test-scale.R
@@ -166,8 +166,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   std_trained <- prep(std, training = biomass)
 
-  expect_error(bake(std_trained, new_data = biomass[, 1:2]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(std_trained, new_data = biomass[, 1:2]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -141,8 +141,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(training = mtcars)
 
-  expect_error(bake(rec, new_data = mtcars[, c(-2)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = mtcars[, c(-2)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -194,39 +194,35 @@ test_that("namespaced selectors", {
 
 test_that("new dplyr selectors", {
   vnames <- c("hydrogen", "carbon")
-  expect_error(
+  expect_no_error(
     rec_1 <-
       recipe(HHV ~ ., data = biomass) %>%
       step_normalize(all_of(c("hydrogen", "carbon"))) %>%
-      prep(),
-    regex = NA
+      prep()
   )
   expect_equal(names(rec_1$steps[[1]]$means), c("hydrogen", "carbon"))
 
-  expect_error(
+  expect_no_error(
     rec_2 <-
       recipe(HHV ~ ., data = biomass) %>%
       step_normalize(all_of(!!vnames)) %>%
-      prep(),
-    regex = NA
+      prep()
   )
   expect_equal(names(rec_2$steps[[1]]$means), c("hydrogen", "carbon"))
 
-  expect_error(
+  expect_no_error(
     rec_3 <-
       recipe(HHV ~ ., data = biomass) %>%
       step_normalize(any_of(c("hydrogen", "carbon"))) %>%
-      prep(),
-    regex = NA
+      prep()
   )
   expect_equal(names(rec_3$steps[[1]]$means), c("hydrogen", "carbon"))
 
-  expect_error(
+  expect_no_error(
     rec_4 <-
       recipe(HHV ~ ., data = biomass) %>%
       step_normalize(any_of(c("hydrogen", "carbon", "bourbon"))) %>%
-      prep(),
-    regex = NA
+      prep()
   )
   expect_equal(names(rec_4$steps[[1]]$means), c("hydrogen", "carbon"))
 })

--- a/tests/testthat/test-shuffle.R
+++ b/tests/testthat/test-shuffle.R
@@ -79,8 +79,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec1 <- prep(rec1, training = dat, verbose = FALSE)
 
-  expect_error(bake(rec1, dat[, 2:5]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec1, dat[, 2:5]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -75,11 +75,10 @@ test_that("quasiquotation", {
   rec_1_train <- bake(prepped_1, new_data = NULL)
   expect_equal(dplyr_train, rec_1_train)
 
-  expect_error(
+  expect_no_error(
     rec_2 <-
       iris_rec %>%
-      step_slice(!!values),
-    regexp = NA
+      step_slice(!!values)
   )
 
   prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
@@ -88,9 +87,8 @@ test_that("quasiquotation", {
   expect_snapshot(error = TRUE,
     prep(rec_1, training = iris %>% slice(1:75))
   )
-  expect_error(
-    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75)),
-    regexp = NA
+  expect_no_error(
+    prepped_2 <- prep(rec_2, training = iris %>% slice(1:75))
   )
   rec_2_train <- bake(prepped_2, new_data = NULL)
   expect_equal(dplyr_train, rec_2_train)

--- a/tests/testthat/test-spatialsign.R
+++ b/tests/testthat/test-spatialsign.R
@@ -100,8 +100,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   sp_sign_trained <- prep(sp_sign, training = biomass, verbose = FALSE)
 
-  expect_error(bake(sp_sign_trained, new_data = biomass[,c(-3)]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(sp_sign_trained, new_data = biomass[,c(-3)])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -161,8 +161,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -161,8 +161,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -161,8 +161,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -131,8 +131,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -161,8 +161,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = mtcars)
 
-  expect_error(bake(rec_trained, new_data = mtcars[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = mtcars[, -3]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-sqrt.R
+++ b/tests/testthat/test-sqrt.R
@@ -27,8 +27,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep(ex_dat)
 
-  expect_error(bake(rec, new_data = ex_dat[, 2, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec, new_data = ex_dat[, 2, drop = FALSE]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-string2factor.R
+++ b/tests/testthat/test-string2factor.R
@@ -73,8 +73,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = ex_dat)
 
-  expect_error(bake(rec_trained, new_data = ex_dat[, -1]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = ex_dat[, -1]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -123,8 +123,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = examples)
 
-  expect_error(bake(rec_trained, new_data = examples[, -1]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = examples[, -1]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -209,9 +209,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = examples),
-    NA
+  expect_no_error(
+    bake(rec, new_data = examples)
   )
 })
 

--- a/tests/testthat/test-unknown.R
+++ b/tests/testthat/test-unknown.R
@@ -90,8 +90,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
     update_role_requirements(role = "potato", bake = FALSE) %>%
     prep()
 
-  expect_error(bake(rec_1, sacr_te[3:ncol(sacr_te)]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_1, sacr_te[3:ncol(sacr_te)]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-unorder.R
+++ b/tests/testthat/test-unorder.R
@@ -40,8 +40,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec1_trained <- prep(rec1, training = examples, verbose = FALSE)
 
-  expect_error(bake(rec1_trained, new_data = examples[, 1, drop = FALSE]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE, 
+    bake(rec1_trained, new_data = examples[, 1, drop = FALSE])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-update-role-requirements.R
+++ b/tests/testthat/test-update-role-requirements.R
@@ -80,7 +80,10 @@ test_that("will still error if a step actually used a role that set `bake = FALS
   df$x <- NULL
 
   # Error is specific to details of `step_scale()`
-  expect_error(bake(rec, df))
+  expect_snapshot(
+    error = TRUE,
+    bake(rec, df)
+  )
 })
 
 test_that("can `bake()` without roles that set `bake = FALSE`", {

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -154,8 +154,7 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   rec_trained <- prep(rec, training = sim_dat)
 
-  expect_error(bake(rec_trained, new_data = sim_dat[, -1]),
-               class = "new_data_missing_column")
+  expect_snapshot(error = TRUE, bake(rec_trained, new_data = sim_dat[, -1]))
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -19,7 +19,6 @@ test_that("error checks", {
   expect_snapshot(error = TRUE,
     rec %>% step_window(y1, size = NA)
   )
-  # Wait for call pass through
   expect_snapshot(
     error = TRUE,
     rec %>% step_window(y1, size = NULL)

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -237,9 +237,8 @@ test_that("keep_original_cols - can prep recipes with it missing", {
     rec <- prep(rec)
   )
 
-  expect_error(
-    bake(rec, new_data = sim_dat),
-    NA
+  expect_no_error(
+    bake(rec, new_data = sim_dat)
   )
 })
 

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -20,7 +20,8 @@ test_that("error checks", {
     rec %>% step_window(y1, size = NA)
   )
   # Wait for call pass through
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     rec %>% step_window(y1, size = NULL)
   )
   expect_snapshot(error = TRUE,


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/1363

This PR:

- switched from `expect_warning()` and `expect_message()` to `expect_snapshot()`
- removed classed `expect_error()` and switched to `expect_snapshot(error = TRUE)`
- Switched from `expect_error(..., NA)` to `expect_no_error()`. Can't do `expect_no_condition()` due to dplyr_regroup signal
- Switched rest of `expect_error()` to `expect_snapshot(error = TRUE)`

No bad snapshots were found in the switch 🙌 

