### PR TITLE
Clean up documentation for main functions

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -2,30 +2,7 @@
 #'
 #' A recipe is a description of the steps to be applied to a data set in
 #'   order to prepare it for data analysis.
-#'
-#' @aliases recipe recipe.default recipe.formula
-#' @export
-recipe <- function(x, ...) {
-  UseMethod("recipe")
-}
-
-#' @rdname recipe
-#' @export
-recipe.default <- function(x, ...) {
-
-  # Doing this here since it should work for all types of Matrix classes
-  if (is_sparse_matrix(x)) {
-    x <- sparsevctrs::coerce_to_sparse_tibble(x, call = caller_env(0))
-    return(recipe(x, ...))
-  }
-
-  cli::cli_abort(c(
-    x = "{.arg x} should be a data frame, matrix, formula, or tibble.",
-    i = "{.arg x} is {.obj_type_friendly {x}}."
-  ))
-}
-
-#' @rdname recipe
+#' 
 #' @param vars A character string of column names corresponding to variables
 #'   that will be used in any context (see below)
 #' @param roles A character string (the same length of `vars`) that
@@ -59,7 +36,6 @@ recipe.default <- function(x, ...) {
 #'
 #' @includeRmd man/rmd/recipes.Rmd details
 #'
-#' @export
 #' @examplesIf rlang::is_installed("modeldata")
 #'
 #' # formula example with single outcome:
@@ -104,6 +80,30 @@ recipe.default <- function(x, ...) {
 #'   update_role(sample, new_role = "id variable") %>%
 #'   update_role(dataset, new_role = "splitting indicator")
 #' rec
+#' 
+#' @export
+recipe <- function(x, ...) {
+  UseMethod("recipe")
+}
+
+#' @rdname recipe
+#' @export
+recipe.default <- function(x, ...) {
+
+  # Doing this here since it should work for all types of Matrix classes
+  if (is_sparse_matrix(x)) {
+    x <- sparsevctrs::coerce_to_sparse_tibble(x, call = caller_env(0))
+    return(recipe(x, ...))
+  }
+
+  cli::cli_abort(c(
+    x = "{.arg x} should be a data frame, matrix, formula, or tibble.",
+    i = "{.arg x} is {.obj_type_friendly {x}}."
+  ))
+}
+
+#' @rdname recipe
+#' @export
 recipe.data.frame <-
   function(x,
            formula = NULL,
@@ -307,20 +307,14 @@ inline_check <- function(x, data, call) {
 }
 
 
-#' @aliases prep prep.recipe
-#' @param x an object
-#' @param ... further arguments passed to or from other methods (not currently
-#'   used).
-#' @export
-prep <- function(x, ...) {
-  UseMethod("prep")
-}
-
 #' Estimate a preprocessing recipe
 #'
 #' For a recipe with at least one preprocessing operation, estimate the required
 #'   parameters from a training set that can be later applied to other data
 #'   sets.
+#' @param x an object
+#' @param ... further arguments passed to or from other methods (not currently
+#'   used).
 #' @param training A data frame, tibble, or sparse matrix from the `Matrix`
 #'   package, that will be used to estimate parameters for preprocessing. See
 #'   [sparse_data] for more information about use of sparse data.
@@ -387,6 +381,12 @@ prep <- function(x, ...) {
 #' prep(ames_rec, verbose = TRUE)
 #'
 #' prep(ames_rec, log_changes = TRUE)
+#' @export
+prep <- function(x, ...) {
+  UseMethod("prep")
+}
+
+
 #' @rdname prep
 #' @export
 prep.recipe <-
@@ -593,13 +593,6 @@ prep.recipe <-
     x
   }
 
-#' @rdname bake
-#' @aliases bake bake.recipe
-#' @export
-bake <- function(object, ...) {
-  UseMethod("bake")
-}
-
 #' Apply a trained preprocessing recipe
 #'
 #' For a recipe with at least one preprocessing operation that has been trained by
@@ -637,7 +630,6 @@ bake <- function(object, ...) {
 #'   data when [bake()] is invoked with a data set in `new_data`.
 #'   `bake(object, new_data = NULL)` will always have all of the steps applied.
 #' @seealso [recipe()], [prep()]
-#' @rdname bake
 #' @examplesIf rlang::is_installed("modeldata")
 #' data(ames, package = "modeldata")
 #'
@@ -661,6 +653,13 @@ bake <- function(object, ...) {
 #' # only return selected variables:
 #' bake(ames_rec, new_data = head(ames), all_numeric_predictors())
 #' bake(ames_rec, new_data = head(ames), starts_with(c("Longitude", "Latitude")))
+#' @export
+bake <- function(object, ...) {
+  UseMethod("bake")
+}
+  
+  
+#' @rdname bake
 #' @export
 bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   if (rlang::is_missing(new_data)) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -1,43 +1,46 @@
 #' Create a recipe for preprocessing data
 #'
-#' A recipe is a description of the steps to be applied to a data set in
-#'   order to prepare it for data analysis.
-#' 
-#' @param vars A character string of column names corresponding to variables
-#'   that will be used in any context (see below)
-#' @param roles A character string (the same length of `vars`) that
-#'   describes a single role that the variable will take. This value could be
-#'   anything but common roles are `"outcome"`, `"predictor"`,
-#'   `"case_weight"`, or `"ID"`
+#' A recipe is a description of the steps to be applied to a data set in order
+#' to prepare it for data analysis.
+#'
+#' @param x,data A data frame, tibble, or sparse matrix from the `Matrix`
+#'   package of the *template* data set. See [sparse_data] for more information
+#'   about use of sparse data. (see below).
 #' @param ... Further arguments passed to or from other methods (not currently
 #'   used).
 #' @param formula A model formula. No in-line functions should be used here
-#'  (e.g. `log(x)`, `x:y`, etc.) and minus signs are not allowed. These types of
-#'  transformations should be enacted using `step` functions in this package.
-#'  Dots are allowed as are simple multivariate outcome terms (i.e. no need for
-#'  `cbind`; see Examples). A model formula may not be the best choice for
-#'  high-dimensional data with many columns, because of problems with memory.
-#' @param x,data A data frame, tibble, or sparse matrix from the `Matrix`
-#'   package of the *template* data set. See [sparse_data] for more information
-#'   about use of sparse data.
-#'   (see below).
-#' @return An object of class `recipe` with sub-objects:
-#'   \item{var_info}{A tibble containing information about the original data
-#'   set columns}
-#'   \item{term_info}{A tibble that contains the current set of terms in the
-#'   data set. This initially defaults to the same data contained in
-#'   `var_info`.}
-#'   \item{steps}{A list of `step`  or `check` objects that define the sequence of
-#'   preprocessing operations that will be applied to data. The default value is
-#'   `NULL`}
-#'   \item{template}{A tibble of the data. This is initialized to be the same
-#'   as the data given in the `data` argument but can be different after
-#'   the recipe is trained.}
+#'   (e.g. `log(x)`, `x:y`, etc.) and minus signs are not allowed. These types
+#'   of transformations should be enacted using `step` functions in this
+#'   package. Dots are allowed as are simple multivariate outcome terms (i.e. no
+#'   need for `cbind`; see Examples). A model formula may not be the best choice
+#'   for high-dimensional data with many columns, because of problems with
+#'   memory.
+#' @param vars A character string of column names corresponding to variables
+#'   that will be used in any context (see below)
+#' @param roles A character string (the same length of `vars`) that describes a
+#'   single role that the variable will take. This value could be anything but
+#'   common roles are `"outcome"`, `"predictor"`, `"case_weight"`, or `"ID"`
 #'
 #' @includeRmd man/rmd/recipes.Rmd details
 #'
-#' @examplesIf rlang::is_installed("modeldata")
+#' @return
 #'
+#' An object of class `recipe` with sub-objects:
+#' \item{var_info}{A tibble containing information about the original data set
+#' columns}
+#' \item{term_info}{A tibble that contains the current set of terms in the
+#' data set. This initially defaults to the same data contained in
+#' `var_info`.}
+#' \item{steps}{A list of `step` or `check` objects that define the sequence
+#' of preprocessing operations that will be applied to data. The default value
+#' is `NULL`}
+#' \item{template}{A tibble of the data. This is initialized to be the same as
+#' the data given in the `data` argument but can be different after the recipe
+#' is trained.}
+#'
+#' @seealso [prep()] and [bake()]
+#'
+#' @examplesIf rlang::is_installed("modeldata")
 #' # formula example with single outcome:
 #' data(biomass, package = "modeldata")
 #'
@@ -80,7 +83,6 @@
 #'   update_role(sample, new_role = "id variable") %>%
 #'   update_role(dataset, new_role = "splitting indicator")
 #' rec
-#' 
 #' @export
 recipe <- function(x, ...) {
   UseMethod("recipe")
@@ -310,8 +312,8 @@ inline_check <- function(x, data, call) {
 #' Estimate a preprocessing recipe
 #'
 #' For a recipe with at least one preprocessing operation, estimate the required
-#'   parameters from a training set that can be later applied to other data
-#'   sets.
+#' parameters from a training set that can be later applied to other data sets.
+#'
 #' @param x an object
 #' @param ... further arguments passed to or from other methods (not currently
 #'   used).
@@ -321,45 +323,49 @@ inline_check <- function(x, data, call) {
 #' @param fresh A logical indicating whether already trained operation should be
 #'   re-trained. If `TRUE`, you should pass in a data set to the argument
 #'   `training`.
-#' @param verbose A logical that controls whether progress is reported as operations
-#'   are executed.
+#' @param verbose A logical that controls whether progress is reported as
+#'   operations are executed.
+#' @param retain A logical: should the *preprocessed* training set be saved into
+#'   the `template` slot of the recipe after training? This is a good idea if
+#'   you want to add more steps later but want to avoid re-training the existing
+#'   steps. Also, it is advisable to use `retain = TRUE` if any steps use the
+#'   option `skip = FALSE`. **Note** that this can make the final recipe size
+#'   large. When `verbose = TRUE`, a message is written with the approximate
+#'   object size in memory but may be an underestimate since it does not take
+#'   environments into account.
 #' @param log_changes A logical for printing a summary for each step regarding
-#'  which (if any) columns were added or removed during training.
-#' @param retain A logical: should the *preprocessed* training set be saved
-#'   into the `template` slot of the recipe after training? This is a good
-#'     idea if you want to add more steps later but want to avoid re-training
-#'     the existing steps. Also, it is advisable to use `retain = TRUE`
-#'     if any steps use the option `skip = FALSE`. **Note** that this can make
-#'     the final recipe size large. When `verbose = TRUE`, a message is written
-#'     with the approximate object size in memory but may be an underestimate
-#'     since it does not take environments into account.
+#'   which (if any) columns were added or removed during training.
 #' @param strings_as_factors A logical: should character columns that have role
 #'   "predictor" or "outcome" be converted to factors? This affects the
 #'   preprocessed training set (when `retain = TRUE`) as well as the results of
-#'  `bake.recipe`.
-#' @return A recipe whose step objects have been updated with the required
-#'   quantities (e.g. parameter estimates, model objects, etc). Also, the
-#'   `term_info` object is likely to be modified as the operations are
-#'   executed.
+#'   `bake.recipe`.
+#'
 #' @details
 #'
 #' Given a data set, this function estimates the required quantities and
-#' statistics needed by any operations. [prep()] returns an updated recipe
-#' with the estimates. If you are using a recipe as a preprocessor for modeling,
-#' we **highly recommend** that you use a `workflow()` instead of manually
+#' statistics needed by any operations. [prep()] returns an updated recipe with
+#' the estimates. If you are using a recipe as a preprocessor for modeling, we
+#' **highly recommend** that you use a `workflow()` instead of manually
 #' estimating a recipe (see the example in [recipe()]).
 #'
-#' Note that missing data is handled in the steps; there is no global
-#'   `na.rm` option at the recipe level or in [prep()].
+#' Note that missing data is handled in the steps; there is no global `na.rm`
+#' option at the recipe level or in [prep()].
 #'
-#' Also, if a recipe has been trained using [prep()] and then steps
-#'   are added, [prep()] will only update the new operations. If
-#'   `fresh = TRUE`, all of the operations will be (re)estimated.
+#' Also, if a recipe has been trained using [prep()] and then steps are added,
+#' [prep()] will only update the new operations. If `fresh = TRUE`, all of the
+#' operations will be (re)estimated.
 #'
-#' As the steps are executed, the `training` set is updated. For example,
-#'   if the first step is to center the data and the second is to scale the
-#'   data, the step for scaling is given the centered data.
+#' As the steps are executed, the `training` set is updated. For example, if the
+#' first step is to center the data and the second is to scale the data, the
+#' step for scaling is given the centered data.
 #'
+#' @return
+#'
+#' A recipe whose step objects have been updated with the required quantities
+#' (e.g. parameter estimates, model objects, etc). Also, the `term_info` object
+#' is likely to be modified as the operations are executed.
+#'
+#' @seealso [recipe()] and [bake()]
 #'
 #' @examplesIf rlang::is_installed("modeldata")
 #' data(ames, package = "modeldata")
@@ -385,7 +391,6 @@ inline_check <- function(x, data, call) {
 prep <- function(x, ...) {
   UseMethod("prep")
 }
-
 
 #' @rdname prep
 #' @export
@@ -595,41 +600,47 @@ prep.recipe <-
 
 #' Apply a trained preprocessing recipe
 #'
-#' For a recipe with at least one preprocessing operation that has been trained by
-#'   [prep()], apply the computations to new data.
-#' @param object A trained object such as a [recipe()] with at least
-#'   one preprocessing operation.
+#' For a recipe with at least one preprocessing operation that has been trained
+#' by [prep()], apply the computations to new data.
+#'
+#' @param object A trained object such as a [recipe()] with at least one
+#'   preprocessing operation.
+#' @param ... One or more selector functions to choose which variables will be
+#'   returned by the function. See [selections()] for more details. If no
+#'   selectors are given, the default is to use [dplyr::everything()].
 #' @param new_data A data frame, tibble, or sparse matrix from the `Matrix`
 #'   package for whom the preprocessing will be applied. If `NULL` is given to
 #'   `new_data`, the pre-processed _training data_ will be returned (assuming
 #'   that `prep(retain = TRUE)` was used). See [sparse_data] for more
 #'   information about use of sparse data.
-#' @param ... One or more selector functions to choose which variables will be
-#'   returned by the function. See [selections()] for more details.
-#'   If no selectors are given, the default is to use
-#'   [dplyr::everything()].
-#' @param composition Either "tibble", "matrix", "data.frame", or
-#'  "dgCMatrix" for the format of the processed data set. Note that
-#'  all computations during the baking process are done in a
-#'  non-sparse format. Also, note that this argument should be
-#'  called **after** any selectors and the selectors should only
-#'  resolve to numeric columns (otherwise an error is thrown).
-#' @return A tibble, matrix, or sparse matrix that may have different
-#'  columns than the original columns in `new_data`.
-#' @details [bake()] takes a trained recipe and applies its operations to a
-#'  data set to create a design matrix. If you are using a recipe as a
-#'  preprocessor for modeling, we **highly recommend** that you use a `workflow()`
-#'  instead of manually applying a recipe (see the example in [recipe()]).
+#' @param composition Either "tibble", "matrix", "data.frame", or "dgCMatrix"
+#'   for the format of the processed data set. Note that all computations during
+#'   the baking process are done in a non-sparse format. Also, note that this
+#'   argument should be called **after** any selectors and the selectors should
+#'   only resolve to numeric columns (otherwise an error is thrown).
 #'
-#' If the data set is not too large, time can be saved by using the
-#'  `retain = TRUE` option of [prep()]. This stores the processed version of the
-#'  training set. With this option set, `bake(object, new_data = NULL)`
-#'  will return it for free.
+#' @details
 #'
-#' Also, any steps with `skip = TRUE` will not be applied to the
-#'   data when [bake()] is invoked with a data set in `new_data`.
-#'   `bake(object, new_data = NULL)` will always have all of the steps applied.
-#' @seealso [recipe()], [prep()]
+#' [bake()] takes a trained recipe and applies its operations to a data set to
+#' create a design matrix. If you are using a recipe as a preprocessor for
+#' modeling, we **highly recommend** that you use a `workflow()` instead of
+#' manually applying a recipe (see the example in [recipe()]).
+#'
+#' If the data set is not too large, time can be saved by using the `retain =
+#' TRUE` option of [prep()]. This stores the processed version of the training
+#' set. With this option set, `bake(object, new_data = NULL)` will return it for
+#' free.
+#'
+#' Also, any steps with `skip = TRUE` will not be applied to the data when
+#' [bake()] is invoked with a data set in `new_data`. `bake(object, new_data =
+#' NULL)` will always have all of the steps applied.
+#'
+#' @return
+#' A tibble, matrix, or sparse matrix that may have different columns than the
+#' original columns in `new_data`.
+#'
+#' @seealso [recipe()] and [prep()]
+#'
 #' @examplesIf rlang::is_installed("modeldata")
 #' data(ames, package = "modeldata")
 #'
@@ -657,8 +668,8 @@ prep.recipe <-
 bake <- function(object, ...) {
   UseMethod("bake")
 }
-  
-  
+
+
 #' @rdname bake
 #' @export
 bake.recipe <- function(object, new_data, ..., composition = "tibble") {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -12,14 +12,14 @@
 #'   (e.g. `log(x)`, `x:y`, etc.) and minus signs are not allowed. These types
 #'   of transformations should be enacted using `step` functions in this
 #'   package. Dots are allowed as are simple multivariate outcome terms (i.e. no
-#'   need for `cbind`; see Examples). A model formula may not be the best choice
-#'   for high-dimensional data with many columns, because of problems with
-#'   memory.
+#'   need for [cbind()]; see Examples). A model formula may not be the best
+#'   choice for high-dimensional data with many columns, because of problems
+#'   with memory.
 #' @param vars A character string of column names corresponding to variables
 #'   that will be used in any context (see below)
 #' @param roles A character string (the same length of `vars`) that describes a
 #'   single role that the variable will take. This value could be anything but
-#'   common roles are `"outcome"`, `"predictor"`, `"case_weight"`, or `"ID"`
+#'   common roles are `"outcome"`, `"predictor"`, `"case_weight"`, or `"ID"`.
 #'
 #' @includeRmd man/rmd/recipes.Rmd details
 #'
@@ -27,13 +27,13 @@
 #'
 #' An object of class `recipe` with sub-objects:
 #' \item{var_info}{A tibble containing information about the original data set
-#' columns}
+#' columns.}
 #' \item{term_info}{A tibble that contains the current set of terms in the
 #' data set. This initially defaults to the same data contained in
 #' `var_info`.}
 #' \item{steps}{A list of `step` or `check` objects that define the sequence
 #' of preprocessing operations that will be applied to data. The default value
-#' is `NULL`}
+#' is `NULL`.}
 #' \item{template}{A tibble of the data. This is initialized to be the same as
 #' the data given in the `data` argument but can be different after the recipe
 #' is trained.}
@@ -314,7 +314,7 @@ inline_check <- function(x, data, call) {
 #' For a recipe with at least one preprocessing operation, estimate the required
 #' parameters from a training set that can be later applied to other data sets.
 #'
-#' @param x an object
+#' @param x an [recipe()] object.
 #' @param ... further arguments passed to or from other methods (not currently
 #'   used).
 #' @param training A data frame, tibble, or sparse matrix from the `Matrix`
@@ -336,9 +336,9 @@ inline_check <- function(x, data, call) {
 #' @param log_changes A logical for printing a summary for each step regarding
 #'   which (if any) columns were added or removed during training.
 #' @param strings_as_factors A logical: should character columns that have role
-#'   "predictor" or "outcome" be converted to factors? This affects the
+#'   `"predictor"` or `"outcome"` be converted to factors? This affects the
 #'   preprocessed training set (when `retain = TRUE`) as well as the results of
-#'   `bake.recipe`.
+#'   [bake()].
 #'
 #' @details
 #'
@@ -613,11 +613,12 @@ prep.recipe <-
 #'   `new_data`, the pre-processed _training data_ will be returned (assuming
 #'   that `prep(retain = TRUE)` was used). See [sparse_data] for more
 #'   information about use of sparse data.
-#' @param composition Either "tibble", "matrix", "data.frame", or "dgCMatrix"
-#'   for the format of the processed data set. Note that all computations during
-#'   the baking process are done in a non-sparse format. Also, note that this
-#'   argument should be called **after** any selectors and the selectors should
-#'   only resolve to numeric columns (otherwise an error is thrown).
+#' @param composition Either `"tibble"`, `"matrix"`, `"data.frame"`, or
+#'   `"dgCMatrix"``for the format of the processed data set. Note that all
+#'   computations during the baking process are done in a non-sparse format.
+#'   Also, note that this argument should be called **after** any selectors and
+#'   the selectors should only resolve to numeric columns (otherwise an error is
+#'   thrown).
 #'
 #' @details
 #'
@@ -636,6 +637,7 @@ prep.recipe <-
 #' NULL)` will always have all of the steps applied.
 #'
 #' @return
+#'
 #' A tibble, matrix, or sparse matrix that may have different columns than the
 #' original columns in `new_data`.
 #'

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -10,13 +10,12 @@ bake(object, ...)
 \method{bake}{recipe}(object, new_data, ..., composition = "tibble")
 }
 \arguments{
-\item{object}{A trained object such as a \code{\link[=recipe]{recipe()}} with at least
-one preprocessing operation.}
+\item{object}{A trained object such as a \code{\link[=recipe]{recipe()}} with at least one
+preprocessing operation.}
 
 \item{...}{One or more selector functions to choose which variables will be
-returned by the function. See \code{\link[=selections]{selections()}} for more details.
-If no selectors are given, the default is to use
-\code{\link[dplyr:reexports]{dplyr::everything()}}.}
+returned by the function. See \code{\link[=selections]{selections()}} for more details. If no
+selectors are given, the default is to use \code{\link[dplyr:reexports]{dplyr::everything()}}.}
 
 \item{new_data}{A data frame, tibble, or sparse matrix from the \code{Matrix}
 package for whom the preprocessing will be applied. If \code{NULL} is given to
@@ -24,35 +23,32 @@ package for whom the preprocessing will be applied. If \code{NULL} is given to
 that \code{prep(retain = TRUE)} was used). See \link{sparse_data} for more
 information about use of sparse data.}
 
-\item{composition}{Either "tibble", "matrix", "data.frame", or
-"dgCMatrix" for the format of the processed data set. Note that
-all computations during the baking process are done in a
-non-sparse format. Also, note that this argument should be
-called \strong{after} any selectors and the selectors should only
-resolve to numeric columns (otherwise an error is thrown).}
+\item{composition}{Either "tibble", "matrix", "data.frame", or "dgCMatrix"
+for the format of the processed data set. Note that all computations during
+the baking process are done in a non-sparse format. Also, note that this
+argument should be called \strong{after} any selectors and the selectors should
+only resolve to numeric columns (otherwise an error is thrown).}
 }
 \value{
-A tibble, matrix, or sparse matrix that may have different
-columns than the original columns in \code{new_data}.
+A tibble, matrix, or sparse matrix that may have different columns than the
+original columns in \code{new_data}.
 }
 \description{
-For a recipe with at least one preprocessing operation that has been trained by
-\code{\link[=prep]{prep()}}, apply the computations to new data.
+For a recipe with at least one preprocessing operation that has been trained
+by \code{\link[=prep]{prep()}}, apply the computations to new data.
 }
 \details{
-\code{\link[=bake]{bake()}} takes a trained recipe and applies its operations to a
-data set to create a design matrix. If you are using a recipe as a
-preprocessor for modeling, we \strong{highly recommend} that you use a \code{workflow()}
-instead of manually applying a recipe (see the example in \code{\link[=recipe]{recipe()}}).
+\code{\link[=bake]{bake()}} takes a trained recipe and applies its operations to a data set to
+create a design matrix. If you are using a recipe as a preprocessor for
+modeling, we \strong{highly recommend} that you use a \code{workflow()} instead of
+manually applying a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
-If the data set is not too large, time can be saved by using the
-\code{retain = TRUE} option of \code{\link[=prep]{prep()}}. This stores the processed version of the
-training set. With this option set, \code{bake(object, new_data = NULL)}
-will return it for free.
+If the data set is not too large, time can be saved by using the \code{retain = TRUE} option of \code{\link[=prep]{prep()}}. This stores the processed version of the training
+set. With this option set, \code{bake(object, new_data = NULL)} will return it for
+free.
 
-Also, any steps with \code{skip = TRUE} will not be applied to the
-data when \code{\link[=bake]{bake()}} is invoked with a data set in \code{new_data}.
-\code{bake(object, new_data = NULL)} will always have all of the steps applied.
+Also, any steps with \code{skip = TRUE} will not be applied to the data when
+\code{\link[=bake]{bake()}} is invoked with a data set in \code{new_data}. \code{bake(object, new_data = NULL)} will always have all of the steps applied.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -81,5 +77,5 @@ bake(ames_rec, new_data = head(ames), starts_with(c("Longitude", "Latitude")))
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[=recipe]{recipe()}}, \code{\link[=prep]{prep()}}
+\code{\link[=recipe]{recipe()}} and \code{\link[=prep]{prep()}}
 }

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -23,11 +23,12 @@ package for whom the preprocessing will be applied. If \code{NULL} is given to
 that \code{prep(retain = TRUE)} was used). See \link{sparse_data} for more
 information about use of sparse data.}
 
-\item{composition}{Either "tibble", "matrix", "data.frame", or "dgCMatrix"
-for the format of the processed data set. Note that all computations during
-the baking process are done in a non-sparse format. Also, note that this
-argument should be called \strong{after} any selectors and the selectors should
-only resolve to numeric columns (otherwise an error is thrown).}
+\item{composition}{Either \code{"tibble"}, \code{"matrix"}, \code{"data.frame"}, or
+`"dgCMatrix"``for the format of the processed data set. Note that all
+computations during the baking process are done in a non-sparse format.
+Also, note that this argument should be called \strong{after} any selectors and
+the selectors should only resolve to numeric columns (otherwise an error is
+thrown).}
 }
 \value{
 A tibble, matrix, or sparse matrix that may have different columns than the

--- a/man/juice.Rd
+++ b/man/juice.Rd
@@ -14,11 +14,12 @@ juice(object, ..., composition = "tibble")
 returned by the function. See \code{\link[=selections]{selections()}} for more details. If no
 selectors are given, the default is to use \code{\link[dplyr:reexports]{dplyr::everything()}}.}
 
-\item{composition}{Either "tibble", "matrix", "data.frame", or "dgCMatrix"
-for the format of the processed data set. Note that all computations during
-the baking process are done in a non-sparse format. Also, note that this
-argument should be called \strong{after} any selectors and the selectors should
-only resolve to numeric columns (otherwise an error is thrown).}
+\item{composition}{Either \code{"tibble"}, \code{"matrix"}, \code{"data.frame"}, or
+`"dgCMatrix"``for the format of the processed data set. Note that all
+computations during the baking process are done in a non-sparse format.
+Also, note that this argument should be called \strong{after} any selectors and
+the selectors should only resolve to numeric columns (otherwise an error is
+thrown).}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}

--- a/man/juice.Rd
+++ b/man/juice.Rd
@@ -11,16 +11,14 @@ juice(object, ..., composition = "tibble")
 \code{retain = TRUE}.}
 
 \item{...}{One or more selector functions to choose which variables will be
-returned by the function. See \code{\link[=selections]{selections()}} for more details.
-If no selectors are given, the default is to use
-\code{\link[dplyr:reexports]{dplyr::everything()}}.}
+returned by the function. See \code{\link[=selections]{selections()}} for more details. If no
+selectors are given, the default is to use \code{\link[dplyr:reexports]{dplyr::everything()}}.}
 
-\item{composition}{Either "tibble", "matrix", "data.frame", or
-"dgCMatrix" for the format of the processed data set. Note that
-all computations during the baking process are done in a
-non-sparse format. Also, note that this argument should be
-called \strong{after} any selectors and the selectors should only
-resolve to numeric columns (otherwise an error is thrown).}
+\item{composition}{Either "tibble", "matrix", "data.frame", or "dgCMatrix"
+for the format of the processed data set. Note that all computations during
+the baking process are done in a non-sparse format. Also, note that this
+argument should be called \strong{after} any selectors and the selectors should
+only resolve to numeric columns (otherwise an error is thrown).}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -47,9 +47,10 @@ since it does not take environments into account.}
 \item{log_changes}{A logical for printing a summary for each step regarding
 which (if any) columns were added or removed during training.}
 
-\item{strings_as_factors}{A logical: should character columns be converted to
-factors? This affects the preprocessed training set (when
-\code{retain = TRUE}) as well as the results of \code{bake.recipe}.}
+\item{strings_as_factors}{A logical: should character columns that have role
+"predictor" or "outcome" be converted to factors? This affects the
+preprocessed training set (when \code{retain = TRUE}) as well as the results of
+\code{bake.recipe}.}
 }
 \value{
 A recipe whose step objects have been updated with the required

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -19,7 +19,7 @@ prep(x, ...)
 )
 }
 \arguments{
-\item{x}{an object}
+\item{x}{an \code{\link[=recipe]{recipe()}} object.}
 
 \item{...}{further arguments passed to or from other methods (not currently
 used).}
@@ -48,9 +48,9 @@ environments into account.}
 which (if any) columns were added or removed during training.}
 
 \item{strings_as_factors}{A logical: should character columns that have role
-"predictor" or "outcome" be converted to factors? This affects the
+\code{"predictor"} or \code{"outcome"} be converted to factors? This affects the
 preprocessed training set (when \code{retain = TRUE}) as well as the results of
-\code{bake.recipe}.}
+\code{\link[=bake]{bake()}}.}
 }
 \value{
 A recipe whose step objects have been updated with the required quantities

--- a/man/prep.Rd
+++ b/man/prep.Rd
@@ -32,17 +32,17 @@ package, that will be used to estimate parameters for preprocessing. See
 re-trained. If \code{TRUE}, you should pass in a data set to the argument
 \code{training}.}
 
-\item{verbose}{A logical that controls whether progress is reported as operations
-are executed.}
+\item{verbose}{A logical that controls whether progress is reported as
+operations are executed.}
 
-\item{retain}{A logical: should the \emph{preprocessed} training set be saved
-into the \code{template} slot of the recipe after training? This is a good
-idea if you want to add more steps later but want to avoid re-training
-the existing steps. Also, it is advisable to use \code{retain = TRUE}
-if any steps use the option \code{skip = FALSE}. \strong{Note} that this can make
-the final recipe size large. When \code{verbose = TRUE}, a message is written
-with the approximate object size in memory but may be an underestimate
-since it does not take environments into account.}
+\item{retain}{A logical: should the \emph{preprocessed} training set be saved into
+the \code{template} slot of the recipe after training? This is a good idea if
+you want to add more steps later but want to avoid re-training the existing
+steps. Also, it is advisable to use \code{retain = TRUE} if any steps use the
+option \code{skip = FALSE}. \strong{Note} that this can make the final recipe size
+large. When \code{verbose = TRUE}, a message is written with the approximate
+object size in memory but may be an underestimate since it does not take
+environments into account.}
 
 \item{log_changes}{A logical for printing a summary for each step regarding
 which (if any) columns were added or removed during training.}
@@ -53,33 +53,31 @@ preprocessed training set (when \code{retain = TRUE}) as well as the results of
 \code{bake.recipe}.}
 }
 \value{
-A recipe whose step objects have been updated with the required
-quantities (e.g. parameter estimates, model objects, etc). Also, the
-\code{term_info} object is likely to be modified as the operations are
-executed.
+A recipe whose step objects have been updated with the required quantities
+(e.g. parameter estimates, model objects, etc). Also, the \code{term_info} object
+is likely to be modified as the operations are executed.
 }
 \description{
 For a recipe with at least one preprocessing operation, estimate the required
-parameters from a training set that can be later applied to other data
-sets.
+parameters from a training set that can be later applied to other data sets.
 }
 \details{
 Given a data set, this function estimates the required quantities and
-statistics needed by any operations. \code{\link[=prep]{prep()}} returns an updated recipe
-with the estimates. If you are using a recipe as a preprocessor for modeling,
-we \strong{highly recommend} that you use a \code{workflow()} instead of manually
+statistics needed by any operations. \code{\link[=prep]{prep()}} returns an updated recipe with
+the estimates. If you are using a recipe as a preprocessor for modeling, we
+\strong{highly recommend} that you use a \code{workflow()} instead of manually
 estimating a recipe (see the example in \code{\link[=recipe]{recipe()}}).
 
-Note that missing data is handled in the steps; there is no global
-\code{na.rm} option at the recipe level or in \code{\link[=prep]{prep()}}.
+Note that missing data is handled in the steps; there is no global \code{na.rm}
+option at the recipe level or in \code{\link[=prep]{prep()}}.
 
-Also, if a recipe has been trained using \code{\link[=prep]{prep()}} and then steps
-are added, \code{\link[=prep]{prep()}} will only update the new operations. If
-\code{fresh = TRUE}, all of the operations will be (re)estimated.
+Also, if a recipe has been trained using \code{\link[=prep]{prep()}} and then steps are added,
+\code{\link[=prep]{prep()}} will only update the new operations. If \code{fresh = TRUE}, all of the
+operations will be (re)estimated.
 
-As the steps are executed, the \code{training} set is updated. For example,
-if the first step is to center the data and the second is to scale the
-data, the step for scaling is given the centered data.
+As the steps are executed, the \code{training} set is updated. For example, if the
+first step is to center the data and the second is to scale the data, the
+step for scaling is given the centered data.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -103,4 +101,7 @@ prep(ames_rec, verbose = TRUE)
 
 prep(ames_rec, log_changes = TRUE)
 \dontshow{\}) # examplesIf}
+}
+\seealso{
+\code{\link[=recipe]{recipe()}} and \code{\link[=bake]{bake()}}
 }

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -3,8 +3,8 @@
 \name{recipe}
 \alias{recipe}
 \alias{recipe.default}
-\alias{recipe.formula}
 \alias{recipe.data.frame}
+\alias{recipe.formula}
 \alias{recipe.matrix}
 \title{Create a recipe for preprocessing data}
 \usage{

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -21,44 +21,43 @@ recipe(x, ...)
 \arguments{
 \item{x, data}{A data frame, tibble, or sparse matrix from the \code{Matrix}
 package of the \emph{template} data set. See \link{sparse_data} for more information
-about use of sparse data.
-(see below).}
+about use of sparse data. (see below).}
 
 \item{...}{Further arguments passed to or from other methods (not currently
 used).}
 
 \item{formula}{A model formula. No in-line functions should be used here
-(e.g. \code{log(x)}, \code{x:y}, etc.) and minus signs are not allowed. These types of
-transformations should be enacted using \code{step} functions in this package.
-Dots are allowed as are simple multivariate outcome terms (i.e. no need for
-\code{cbind}; see Examples). A model formula may not be the best choice for
-high-dimensional data with many columns, because of problems with memory.}
+(e.g. \code{log(x)}, \code{x:y}, etc.) and minus signs are not allowed. These types
+of transformations should be enacted using \code{step} functions in this
+package. Dots are allowed as are simple multivariate outcome terms (i.e. no
+need for \code{cbind}; see Examples). A model formula may not be the best choice
+for high-dimensional data with many columns, because of problems with
+memory.}
 
 \item{vars}{A character string of column names corresponding to variables
 that will be used in any context (see below)}
 
-\item{roles}{A character string (the same length of \code{vars}) that
-describes a single role that the variable will take. This value could be
-anything but common roles are \code{"outcome"}, \code{"predictor"},
-\code{"case_weight"}, or \code{"ID"}}
+\item{roles}{A character string (the same length of \code{vars}) that describes a
+single role that the variable will take. This value could be anything but
+common roles are \code{"outcome"}, \code{"predictor"}, \code{"case_weight"}, or \code{"ID"}}
 }
 \value{
 An object of class \code{recipe} with sub-objects:
-\item{var_info}{A tibble containing information about the original data
-set columns}
+\item{var_info}{A tibble containing information about the original data set
+columns}
 \item{term_info}{A tibble that contains the current set of terms in the
 data set. This initially defaults to the same data contained in
 \code{var_info}.}
-\item{steps}{A list of \code{step}  or \code{check} objects that define the sequence of
-preprocessing operations that will be applied to data. The default value is
-\code{NULL}}
-\item{template}{A tibble of the data. This is initialized to be the same
-as the data given in the \code{data} argument but can be different after
-the recipe is trained.}
+\item{steps}{A list of \code{step} or \code{check} objects that define the sequence
+of preprocessing operations that will be applied to data. The default value
+is \code{NULL}}
+\item{template}{A tibble of the data. This is initialized to be the same as
+the data given in the \code{data} argument but can be different after the recipe
+is trained.}
 }
 \description{
-A recipe is a description of the steps to be applied to a data set in
-order to prepare it for data analysis.
+A recipe is a description of the steps to be applied to a data set in order
+to prepare it for data analysis.
 }
 \details{
 \subsection{Defining recipes}{
@@ -318,7 +317,6 @@ applications.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-
 # formula example with single outcome:
 data(biomass, package = "modeldata")
 
@@ -362,4 +360,7 @@ rec <- recipe(biomass_tr) \%>\%
   update_role(dataset, new_role = "splitting indicator")
 rec
 \dontshow{\}) # examplesIf}
+}
+\seealso{
+\code{\link[=prep]{prep()}} and \code{\link[=bake]{bake()}}
 }

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -30,27 +30,27 @@ used).}
 (e.g. \code{log(x)}, \code{x:y}, etc.) and minus signs are not allowed. These types
 of transformations should be enacted using \code{step} functions in this
 package. Dots are allowed as are simple multivariate outcome terms (i.e. no
-need for \code{cbind}; see Examples). A model formula may not be the best choice
-for high-dimensional data with many columns, because of problems with
-memory.}
+need for \code{\link[=cbind]{cbind()}}; see Examples). A model formula may not be the best
+choice for high-dimensional data with many columns, because of problems
+with memory.}
 
 \item{vars}{A character string of column names corresponding to variables
 that will be used in any context (see below)}
 
 \item{roles}{A character string (the same length of \code{vars}) that describes a
 single role that the variable will take. This value could be anything but
-common roles are \code{"outcome"}, \code{"predictor"}, \code{"case_weight"}, or \code{"ID"}}
+common roles are \code{"outcome"}, \code{"predictor"}, \code{"case_weight"}, or \code{"ID"}.}
 }
 \value{
 An object of class \code{recipe} with sub-objects:
 \item{var_info}{A tibble containing information about the original data set
-columns}
+columns.}
 \item{term_info}{A tibble that contains the current set of terms in the
 data set. This initially defaults to the same data contained in
 \code{var_info}.}
 \item{steps}{A list of \code{step} or \code{check} objects that define the sequence
 of preprocessing operations that will be applied to data. The default value
-is \code{NULL}}
+is \code{NULL}.}
 \item{template}{A tibble of the data. This is initialized to be the same as
 the data given in the \code{data} argument but can be different after the recipe
 is trained.}

--- a/man/roles.Rd
+++ b/man/roles.Rd
@@ -93,11 +93,14 @@ If you really aren't using \code{sample} in your recipe, we recommend that you i
 
 try(bake(rec, biomass_test))
 #> Error in bake(rec, biomass_test) : 
-#>   x The following required columns are missing from `new_data`: `sample`.
-#> i These columns have one of the following roles, which are required at `bake()`
-#>   time: `id variable`.
-#> i If these roles are not required at `bake()` time, use
-#>   `update_role_requirements(role = "your_role", bake = FALSE)`.
+#>   x The following required columns are missing
+#>   from `new_data`: `sample`.
+#> i These columns have one of the following roles,
+#>   which are required at `bake()` time: `id
+#>   variable`.
+#> i If these roles are not required at `bake()` time,
+#>   use `update_role_requirements(role = "your_role",
+#>   bake = FALSE)`.
 }\if{html}{\out{</div>}}
 
 As we mentioned before, the best way to avoid this issue is to not even use a role, just remove the \code{sample} column from \code{biomass} before calling \code{recipe()}. In general, predictors and non-standard roles that are supplied to \code{recipe()} should be present at both \code{prep()} and \code{bake()} time.

--- a/man/roles.Rd
+++ b/man/roles.Rd
@@ -93,14 +93,11 @@ If you really aren't using \code{sample} in your recipe, we recommend that you i
 
 try(bake(rec, biomass_test))
 #> Error in bake(rec, biomass_test) : 
-#>   x The following required columns are missing
-#>   from `new_data`: `sample`.
-#> i These columns have one of the following roles,
-#>   which are required at `bake()` time: `id
-#>   variable`.
-#> i If these roles are not required at `bake()` time,
-#>   use `update_role_requirements(role = "your_role",
-#>   bake = FALSE)`.
+#>   x The following required columns are missing from `new_data`: `sample`.
+#> i These columns have one of the following roles, which are required at `bake()`
+#>   time: `id variable`.
+#> i If these roles are not required at `bake()` time, use
+#>   `update_role_requirements(role = "your_role", bake = FALSE)`.
 }\if{html}{\out{</div>}}
 
 As we mentioned before, the best way to avoid this issue is to not even use a role, just remove the \code{sample} column from \code{biomass} before calling \code{recipe()}. In general, predictors and non-standard roles that are supplied to \code{recipe()} should be present at both \code{prep()} and \code{bake()} time.


### PR DESCRIPTION
This PR cleans up the documentation for `recipe()`, `prep()`, and `bake()` just a little bit

- makes sure they all `@seaalso` eachother
- have documentation in one place rather than across multiple files
- have roxygen tags in "correct" order