### PR TITLE
fixes string interpolation failure for splines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: recipes
 Title: Preprocessing and Feature Engineering Steps for Modeling
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre")),
     person("Hadley", "Wickham", , "hadley@posit.co", role = "aut"),

--- a/R/spline_helpers.R
+++ b/R/spline_helpers.R
@@ -3,7 +3,7 @@ spline2_create <- function(x, nm = "pred", .fn = "bSpline", df = 3, complete_set
   vals <- c("bSpline", "cSpline", "iSpline", "mSpline", "naturalSpline", "bernsteinPoly")
   .fn <- rlang::arg_match(.fn, vals)
   fn_opts <- c(fn_opts, degree = degree)
-                             
+
   if (.fn != "bernsteinPoly" && isTRUE(degree > (df - complete_set))) {
     if (complete_set) {
       cli::cli_abort(
@@ -46,6 +46,14 @@ spline2_create <- function(x, nm = "pred", .fn = "bSpline", df = 3, complete_set
 
 spline_msg <- function(x) {
   x <- as.character(x)
+  # Error messages can contain brackets (e.g. "Error in if (df < 0) { : missing value")
+  # For glue string interpolation, the default open/close deliminators the
+  # brackets. cli_abort calls rlang's abort and that can't pass the arguments
+  # to change the delimiters but will ignore them if they are doubled. So we
+  # change "{" to "{{" (and also for close). Simultaneous substitution via
+  # `pattern = "(\\{)|(\\})"` produces poor results so we do them one at a time.
+  x <- gsub("(\\{)", "\\1\\1", x)
+  x <- gsub("(\\})", "\\1\\1", x)
   x <- strsplit(x, "\\n")[[1]]
   cli::cli_abort(x)
 }

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -64,3 +64,19 @@
       ! The previous data will be used by `prep()`.
       i The data passed using `training` will be ignored.
 
+# spline error messages
+
+    Code
+      recipes:::spline_msg("Error in if (df < 0) { : missing blah blah\n")
+    Condition
+      Error in `recipes:::spline_msg()`:
+      ! Error in if (df < 0) { : missing blah blah
+
+---
+
+    Code
+      recipes:::spline_msg("craaazzyy {{}}{}{}")
+    Condition
+      Error in `recipes:::spline_msg()`:
+      ! craaazzyy {{}}{}{}
+

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -109,3 +109,13 @@ test_that("vars without role in predictor/outcome avoid string processing", {
   expect_identical(new_lvls$chr_only_lime, list(values = NA, ordered = NA))
 })
 
+test_that("spline error messages", {
+  expect_snapshot(
+    recipes:::spline_msg("Error in if (df < 0) { : missing blah blah\n"),
+    error = TRUE
+  )
+  expect_snapshot(
+    recipes:::spline_msg("craaazzyy {{}}{}{}"),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Closes #1380

``` r
msg_test <- "Error in if (df < 0) { : missing value where TRUE/FALSE needed\n"
recipes:::spline_msg(msg_test)
#> Error in `recipes:::spline_msg()`:
#> ! Error in if (df < 0) { : missing value where TRUE/FALSE needed
```

<sup>Created on 2024-10-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

