### PR TITLE
Pass `call` argument around

### DIFF
--- a/R/cut.R
+++ b/R/cut.R
@@ -116,7 +116,7 @@ prep.step_cut <- function(x, training, info = NULL, ...) {
   if (!is.numeric(x$breaks)) {
     cli::cli_abort(
       "{.arg breaks} must be a numeric vector, \\
-      not {.obj_type_friendly {breaks}}."
+      not {.obj_type_friendly {x$breaks}}."
     )
   }
 

--- a/R/pca.R
+++ b/R/pca.R
@@ -351,7 +351,11 @@ tidy.step_pca <- function(x, type = "coef", ...) {
       component = na_chr
     )
   } else {
-    type <- match.arg(type, c("coef", "variance"))
+    type <- rlang::arg_match(
+      type, 
+      c("coef", "variance"), 
+      error_call = rlang::caller_env()
+    )
     if (type == "coef") {
       res <- pca_coefs(x)
     } else {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -208,6 +208,13 @@ recipe.formula <- function(formula, data, ...) {
     cli::cli_abort("{.arg data} is missing with no default.")
   }
 
+  if (!is.data.frame(data) && !is.matrix(data) && !is_sparse_matrix(data)) {
+    cli::cli_abort(
+      "{.arg data} must be a data frame, matrix, or sparse matrix, 
+      not {.obj_type_friendly {data}}."
+    )
+  }
+
   # check for minus:
   f_funcs <- fun_calls(formula, data)
   if (any(f_funcs == "-")) {

--- a/R/update.R
+++ b/R/update.R
@@ -59,7 +59,7 @@ update.step <- function(object, ...) {
   reconstruct_step(object)
 }
 
-update_fields <- function(object, changes) {
+update_fields <- function(object, changes, call = rlang::caller_env()) {
   validate_has_unique_names(changes)
 
   new_nms <- names(changes)
@@ -71,7 +71,8 @@ update_fields <- function(object, changes) {
     if (!(nm %in% old_nms)) {
       cli::cli_abort(
         "The step you are trying to update, {.fn {step_type}}, \\
-        does not have the {.field {nm}} field."
+        does not have the {.field {nm}} field.",
+        call = call
       )
     }
 

--- a/R/update.R
+++ b/R/update.R
@@ -127,12 +127,13 @@ validate_has_unique_names <- function(x) {
   invisible(x)
 }
 
-validate_not_trained <- function(x) {
+validate_not_trained <- function(x, call = rlang::caller_env()) {
   if (is_trained(x)) {
     step_type <- class(x)[1]
 
     cli::cli_abort(
-      "To update {.fn {step_type}}, it must not be trained."
+      "To update {.fn {step_type}}, it must not be trained.",
+      call = call
     )
   }
 

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -227,14 +227,14 @@
     Code
       recipe(~a, data = data)
     Condition
-      Error in `as.data.frame.default()`:
-      ! cannot coerce class '"function"' to a data.frame
+      Error in `recipe()`:
+      ! `data` must be a data frame, matrix, or sparse matrix, not a function.
 
 ---
 
     Code
       recipe(~., data = data)
     Condition
-      Error in `as.data.frame.default()`:
-      ! cannot coerce class '"function"' to a data.frame
+      Error in `recipe()`:
+      ! `data` must be a data frame, matrix, or sparse matrix, not a function.
 

--- a/tests/testthat/_snaps/cut.md
+++ b/tests/testthat/_snaps/cut.md
@@ -40,10 +40,8 @@
       recipe(~., data = mtcars) %>% step_cut(disp, hp, breaks = TRUE) %>% prep()
     Condition
       Error in `step_cut()`:
-      Caused by error:
-      ! Could not evaluate cli `{}` expression: `breaks`.
-      Caused by error:
-      ! object 'breaks' not found
+      Caused by error in `prep()`:
+      ! `breaks` must be a numeric vector, not `TRUE`.
 
 ---
 
@@ -52,10 +50,8 @@
         prep()
     Condition
       Error in `step_cut()`:
-      Caused by error:
-      ! Could not evaluate cli `{}` expression: `breaks`.
-      Caused by error:
-      ! object 'breaks' not found
+      Caused by error in `prep()`:
+      ! `breaks` must be a numeric vector, not a character vector.
 
 # bake method errors when needed non-standard role columns are missing
 

--- a/tests/testthat/_snaps/pca.md
+++ b/tests/testthat/_snaps/pca.md
@@ -3,8 +3,9 @@
     Code
       tidy(pca_extract_trained, number = 3, type = "variances")
     Condition
-      Error in `match.arg()`:
-      ! 'arg' should be one of "coef", "variance"
+      Error in `tidy()`:
+      ! `type` must be one of "coef" or "variance", not "variances".
+      i Did you mean "variance"?
 
 # No PCA comps
 

--- a/tests/testthat/_snaps/update.md
+++ b/tests/testthat/_snaps/update.md
@@ -3,7 +3,7 @@
     Code
       update(stp, y = 5)
     Condition
-      Error in `update_fields()`:
+      Error in `update()`:
       ! The step you are trying to update, `step_stp()`, does not have the y field.
 
 # cannot update trained steps

--- a/tests/testthat/_snaps/update.md
+++ b/tests/testthat/_snaps/update.md
@@ -11,6 +11,6 @@
     Code
       update(stp, x = 5)
     Condition
-      Error in `validate_not_trained()`:
+      Error in `update()`:
       ! To update `step_stp()`, it must not be trained.
 

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -79,7 +79,8 @@ test_that("correct PCA values", {
     var_obj$value[var_obj$terms == "cumulative percent variance"],
     cumsum(variances) / sum(variances) * 100
   )
-  expect_snapshot(error = TRUE,
+  expect_snapshot(
+    error = TRUE,
     tidy(pca_extract_trained, number = 3, type = "variances")
   )
 })

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -10,7 +10,8 @@ test_that("can update a step", {
 test_that("cannot create new fields for a step", {
   stp <- recipes::step("stp", x = 4, trained = FALSE)
 
-  expect_snapshot(error = TRUE,
+  expect_snapshot(
+    error = TRUE,
     update(stp, y = 5)
   )
 })


### PR DESCRIPTION
This was mostly easy because we do the fancy `recipes_error_context()` work. But I still found a handful of small things to fix.

The last couple of things can be done once https://github.com/tidymodels/hardhat/issues/273 has been merged. to be tracked in https://github.com/tidymodels/recipes/issues/1390

