### PR TITLE
add `sparse` argument to `step_dummy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * All steps and checks now require arguments `trained`, `skip`, `role`, and `id` at all times.
 
+* `step_dummy()` gained `sparse` argument. When set to `TRUE`, `step_dummy()` will produce sparse vectors.
+
 # recipes 1.1.0
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * All steps and checks now require arguments `trained`, `skip`, `role`, and `id` at all times.
 
-* `step_dummy()` gained `sparse` argument. When set to `TRUE`, `step_dummy()` will produce sparse vectors.
+* `step_dummy()` gained `sparse` argument. When set to `TRUE`, `step_dummy()` will produce sparse vectors. (#1392)
 
 # recipes 1.1.0
 

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -63,7 +63,8 @@
 #' this step.
 #'
 #' Also, there are a number of contrast methods that return fractional values.
-#' The columns returned by this step are doubles (not integers).
+#' The columns returned by this step are doubles (not integers) when 
+#' `sparse = FALSE`. The columns returned when `sparse = TRUE` are integers.
 #'
 #' The [package vignette for dummy variables](https://recipes.tidymodels.org/articles/Dummies.html)
 #' and interactions has more information.

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -304,8 +304,8 @@ bake.step_dummy <- function(object, new_data, ...) {
       current_contrast <- getOption("contrasts")[is_ordered + 1]
       if (current_contrast != "contr.treatment") {
         cli::cli_abort(
-          "when {.code sparse = TRUE}, only {.val contr.treatment} contrasts are
-          supported. Not {.val {current_contrast}}."
+          "When {.code sparse = TRUE}, only {.val contr.treatment} contrasts are
+          supported, not {.val {current_contrast}}."
         )
       } 
 

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -112,7 +112,8 @@ be changed by passing in a different function to the \code{naming} argument for
 this step.
 
 Also, there are a number of contrast methods that return fractional values.
-The columns returned by this step are doubles (not integers).
+The columns returned by this step are doubles (not integers) when
+\code{sparse = FALSE}. The columns returned when \code{sparse = TRUE} are integers.
 
 The \href{https://recipes.tidymodels.org/articles/Dummies.html}{package vignette for dummy variables}
 and interactions has more information.

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -13,6 +13,7 @@ step_dummy(
   preserve = deprecated(),
   naming = dummy_names,
   levels = NULL,
+  sparse = FALSE,
   keep_original_cols = FALSE,
   skip = FALSE,
   id = rand_id("dummy")
@@ -45,6 +46,10 @@ columns. See Details below.}
 \item{levels}{A list that contains the information needed to create dummy
 variables for each variable contained in \code{terms}. This is \code{NULL} until the
 step is trained by \code{\link[=prep]{prep()}}.}
+
+\item{sparse}{A logical. Should the columns produced be sparse vectors.
+Sparsity is only supported for \code{"contr.treatment"} contrasts. Defaults to
+\code{FALSE}.}
 
 \item{keep_original_cols}{A logical to keep the original variables in the
 output. Defaults to \code{FALSE}.}

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -162,7 +162,7 @@
     Condition
       Error in `step_dummy()`:
       Caused by error in `bake()`:
-      ! when `sparse = TRUE`, only "contr.treatment" contrasts are supported. Not "contr.helmert".
+      ! When `sparse = TRUE`, only "contr.treatment" contrasts are supported, not "contr.helmert".
 
 # bake method errors when needed non-standard role columns are missing
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -154,6 +154,16 @@
       Caused by error in `bake()`:
       ! Only one factor level in `x`: "only-level".
 
+# sparse = TRUE errors on unsupported contrasts
+
+    Code
+      recipe(~., data = tibble(x = letters)) %>% step_dummy(x, sparse = TRUE) %>%
+        prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `bake()`:
+      ! when `sparse = TRUE`, only "contr.treatment" contrasts are supported. Not "contr.helmert".
+
 # bake method errors when needed non-standard role columns are missing
 
     Code


### PR DESCRIPTION
This PR adds the creation of sparse dummy variables in `step_dummy()` via the use of the `sparse` argument.