### PR TITLE
declense verb in abort by 'offenders' quantity

### DIFF
--- a/R/selections.R
+++ b/R/selections.R
@@ -49,7 +49,7 @@
 #' functions aren't restricted to predictors. They will thus select outcomes,
 #' ID, and predictor columns alike. This is why these functions should be used
 #' with care, and why [tidyselect::everything()] likely isn't what you need.
-#' 
+#'
 #' For example:
 #'
 #' \preformatted{
@@ -204,8 +204,8 @@ recipes_eval_select <- function(quos, data, info, ..., allow_rename = FALSE,
     offenders <- offenders[offenders != ""]
 
     cli::cli_abort(
-      "The following argument{?s} {?was/were} specified but do not exist: \\
-      {.arg {offenders}}.", 
+      "The following argument{?s} {?was/were} specified but do{?es/} not exist: \\
+      {.arg {offenders}}.",
       call = call
   )
   }

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -210,7 +210,7 @@
     Condition
       Error in `step_pca()`:
       Caused by error in `prep()`:
-      ! The following argument was specified but do not exist: `number`.
+      ! The following argument was specified but does not exist: `number`.
 
 ---
 

--- a/tests/testthat/_snaps/rm.md
+++ b/tests/testthat/_snaps/rm.md
@@ -5,7 +5,7 @@
     Condition
       Error in `step_rm()`:
       Caused by error in `prep()`:
-      ! The following argument was specified but do not exist: `sepal_length`.
+      ! The following argument was specified but does not exist: `sepal_length`.
 
 # empty printing
 


### PR DESCRIPTION
This PR fixes issue #1399, as illustrated below (adapted from [this test](https://github.com/tidymodels/recipes/blob/59345e145351e636250412a5d3c4c52a6577d3ee/tests/testthat/test-basics.R#L405)).

``` r
remotes::install_github("corybrunson/recipes", ref = "declense", quiet = TRUE)
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
recipe(mpg ~ ., data = mtcars) %>% 
  step_pca(vs, am, gear, number = 2) %>% 
  prep()
#> Error in `step_pca()`:
#> Caused by error in `prep()`:
#> ! The following argument was specified but does not exist: `number`.
recipe(mpg ~ ., data = mtcars) %>% 
  step_pca(vs, am, gear, number = 2, category = "blue") %>% 
  prep()
#> Error in `step_pca()`:
#> Caused by error in `prep()`:
#> ! The following arguments were specified but do not exist: `number` and
#>   `category`.
```

<sup>Created on 2024-11-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>