### PR TITLE
fix missing sparse arg error

### DIFF
--- a/R/dummy.R
+++ b/R/dummy.R
@@ -182,7 +182,6 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names], types = c("factor", "ordered"))
   check_bool(x$one_hot, arg = "one_hot")
   check_function(x$naming, arg = "naming", allow_empty = FALSE)
-  rlang::arg_match0(x$sparse, c("auto", "yes", "no"), arg_nm = "sparse")
 
   if (length(col_names) > 0) {
     ## I hate doing this but currently we are going to have

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -182,6 +182,7 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
   check_type(training[, col_names], types = c("factor", "ordered"))
   check_bool(x$one_hot, arg = "one_hot")
   check_function(x$naming, arg = "naming", allow_empty = FALSE)
+  check_sparse_arg(x$sparse)
 
   if (length(col_names) > 0) {
     ## I hate doing this but currently we are going to have
@@ -301,7 +302,7 @@ bake.step_dummy <- function(object, new_data, ...) {
       ordered = is_ordered
     )
 
-    if (object$sparse == "yes") {
+    if (sparse_is_yes(object$sparse)) {
       current_contrast <- getOption("contrasts")[is_ordered + 1]
       if (!current_contrast %in% c("contr.treatment", "contr_one_hot")) {
         cli::cli_abort(

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -111,3 +111,13 @@ is_sparse_matrix <- function(x) {
 
   zeroes / (n_rows * n_cols)
 }
+
+check_sparse_arg <- function(x) {
+  if (!is.null(x)) {
+    rlang::arg_match0(x, c("auto", "yes", "no"), arg_nm = "sparse")
+  }
+}
+
+sparse_is_yes <- function(x) {
+  !is.null(x) && x == "yes"
+}

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -382,6 +382,23 @@ test_that("sparse = 'yes' errors on unsupported contrasts", {
   )
 })
 
+test_that("sparse argument is backwards compatible", {
+  dat <- tibble(x = c(letters))
+  rec <- recipe(~ ., data = dat) %>%
+    step_dummy(x) %>%
+    prep()
+
+  exp <- bake(rec, dat)
+
+  # Simulate old recipe
+  rec$steps[[1]]$sparse <- NULL
+
+  expect_identical(
+    bake(rec, dat),
+    exp
+  )
+})
+
 test_that(".recipes_toggle_sparse_args works", {
   rec <- recipe(~., iris) %>%
     step_dummy(all_nominal_predictors())

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -46,6 +46,7 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_role_requirements"]
   step_check <- step_check[step_check != "check_bake_role_requirements"]
   step_check <- step_check[step_check != "check_step_check_args"]
+  step_check <- step_check[step_check != "check_sparse_arg"]
 
   # R/import-standalone-types-check.R
   step_check <- step_check[step_check != "check_bool"]


### PR DESCRIPTION
Since the `sparse` argument of `step_dummy()` is new, we need to make sure the step doesn't break if used from an old recipe

This PR fixes this by adding a couple of helper functions, that will be used across all the recipes steps that will get sparse arguments