### PR TITLE
change minimum `min_unique()` for `step_discretize()` to 1

### DIFF
--- a/R/discretize.R
+++ b/R/discretize.R
@@ -346,7 +346,7 @@ prep.step_discretize <- function(x, training, info = NULL, ...) {
   col_names <- recipes_eval_select(x$terms, training, info)
   check_type(training[, col_names], types = c("double", "integer"))
   check_number_whole(x$num_breaks, min = 1, arg = "num_breaks")
-  check_number_whole(x$min_unique, min = 2, arg = "min_unique")
+  check_number_whole(x$min_unique, min = 1, arg = "min_unique")
 
   if (length(col_names) > 1 & any(names(x$options) %in% c("prefix", "labels"))) {
     cli::cli_warn(

--- a/tests/testthat/_snaps/discretize.md
+++ b/tests/testthat/_snaps/discretize.md
@@ -137,7 +137,7 @@
     Condition
       Error in `step_discretize()`:
       Caused by error in `prep()`:
-      ! `min_unique` must be a whole number larger than or equal to 2, not the number -1.
+      ! `min_unique` must be a whole number larger than or equal to 1, not the number -1.
 
 # war when less breaks are generated
 


### PR DESCRIPTION
having that low of a minimum unique isn't going to useful properly, but we do run into revdepcheck issues without this change so I think it is fine