### PR TITLE
turn table to tibble in recipe.formula

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -209,6 +209,10 @@ recipe.formula <- function(formula, data, ...) {
     cli::cli_abort("{.arg data} is missing with no default.")
   }
 
+  if (is.table(data)) {
+    data <- as_tibble(data)
+  }
+
   if (!is.data.frame(data) && !is.matrix(data) && !is_sparse_matrix(data)) {
     cli::cli_abort(
       "{.arg data} must be a data frame, matrix, or sparse matrix, 

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -210,6 +210,10 @@ recipe.formula <- function(formula, data, ...) {
   }
 
   if (is.table(data)) {
+    cli::cli_warn(
+      "Passing a table to {.fn recipe} is undocumented unsupported behavior.
+      This will no longer be possible in the next release of {.pkg recipes}."
+    )
     data <- as_tibble(data)
   }
 


### PR DESCRIPTION
This issue was found during revdepcheck: https://github.com/spsanderson/healthyR.ai/pull/349

we didn't use to check what type the data was that was passed to `recipe.formula()` which resulted in anything that passed `tibble::as_tibble()` worked. This is not ideal. This PR lets us release soon without having to fix it. Then we can later remove it so the functions does what the documentation says