### PR TITLE
fixed bug where sparsity creation steps error if applied to variables created by other steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* fixed bug where sparsity creation steps error if applied to variables created by other steps. (#1448)
+
 # recipes 1.2.0
 
 ## Improvements

--- a/R/selections.R
+++ b/R/selections.R
@@ -150,6 +150,10 @@ NULL
 #'   Defaults to `TRUE`. This is rarely changed and only needed in [juice()],
 #'   [bake.recipe()], [update_role()], and [add_role()].
 #'
+#' @param strict Should selecting non-existing names throw an error?
+#'   Defaults to `TRUE`. This is rarely changed and only needed in
+#'   `.recipes_estimate_sparsity.recipe()``.
+#'
 #' @param call The execution environment of a currently running function, e.g.
 #'   `caller_env()`. The function will be mentioned in error messages as the
 #'   source of the error. See the call argument of [rlang::abort()] for more
@@ -182,6 +186,7 @@ recipes_eval_select <- function(
   ...,
   allow_rename = FALSE,
   check_case_weights = TRUE,
+  strict = TRUE,
   call = caller_env()
 ) {
   check_dots_empty()
@@ -228,6 +233,7 @@ recipes_eval_select <- function(
     expr = expr,
     data = data,
     allow_rename = allow_rename,
+    strict = strict,
     error_call = call
   )
 
@@ -316,7 +322,7 @@ recipes_eval_select <- function(
 has_role <- function(match = "predictor") {
   roles <- peek_roles()
   # roles is potentially a list columns so we unlist `.x` below.
-  lgl_matches <- purrr::map_lgl(roles, ~any(unlist(.x) %in% match))
+  lgl_matches <- purrr::map_lgl(roles, ~ any(unlist(.x) %in% match))
   which(lgl_matches)
 }
 
@@ -324,7 +330,7 @@ has_role <- function(match = "predictor") {
 #' @rdname has_role
 has_type <- function(match = "numeric") {
   types <- peek_types()
-  lgl_matches <- purrr::map_lgl(types, ~any(.x %in% match))
+  lgl_matches <- purrr::map_lgl(types, ~ any(.x %in% match))
   which(lgl_matches)
 }
 
@@ -338,7 +344,7 @@ peek_types <- function() {
 
 peek_info <- function(col) {
   .data <- current_info()$data
-  purrr::map(.data, ~unlist(.x[[col]]))
+  purrr::map(.data, ~ unlist(.x[[col]]))
 }
 
 #' @export

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -97,7 +97,12 @@ is_sparse_matrix <- function(x) {
 
   for (step in x$steps) {
     if (!is.null(step$sparse) && step$sparse != "no") {
-      col_names <- recipes_eval_select(step$terms, template, x$term_info)
+      col_names <- recipes_eval_select(
+        step$terms,
+        template,
+        x$term_info,
+        strict = FALSE
+      )
 
       adjustments <- .recipes_estimate_sparsity(step, template[col_names])
 

--- a/man/recipe.Rd
+++ b/man/recipe.Rd
@@ -266,7 +266,7 @@ pca_rec
 
 ## -- Operations
 
-## * Centering and scaling for: carbon and hydrogen, ... | Trained
+## * Centering and scaling for: carbon hydrogen, ... | Trained
 
 ## * PCA extraction with: carbon, hydrogen, oxygen, ... | Trained
 }\if{html}{\out{</div>}}

--- a/man/recipes_eval_select.Rd
+++ b/man/recipes_eval_select.Rd
@@ -11,6 +11,7 @@ recipes_eval_select(
   ...,
   allow_rename = FALSE,
   check_case_weights = TRUE,
+  strict = TRUE,
   call = caller_env()
 )
 }
@@ -36,6 +37,10 @@ It is unlikely that your step will need renaming capabilities.}
 \item{check_case_weights}{Should selecting case weights throw an error?
 Defaults to \code{TRUE}. This is rarely changed and only needed in \code{\link[=juice]{juice()}},
 \code{\link[=bake.recipe]{bake.recipe()}}, \code{\link[=update_role]{update_role()}}, and \code{\link[=add_role]{add_role()}}.}
+
+\item{strict}{Should selecting non-existing names throw an error?
+Defaults to \code{TRUE}. This is rarely changed and only needed in
+`.recipes_estimate_sparsity.recipe()``.}
 
 \item{call}{The execution environment of a currently running function, e.g.
 \code{caller_env()}. The function will be mentioned in error messages as the

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -325,10 +325,20 @@ test_that(".recipes_toggle_sparse_args works", {
 })
 
 test_that(".recipes_toggle_sparse_args works", {
-  rec <- recipe(~., mtcars) |>
+  rec <- recipe(~., mtcars) %>%
     step_dummy()
 
   expect_false(
     .recipes_preserve_sparsity(rec$steps[[1]])
+  )
+})
+
+test_that(".recipes_estimate_sparsity doesn't error on created vars (#1448)", {
+  rec <- recipe(~., iris) %>%
+    step_mutate(Species2 = Species) %>%
+    step_dummy(Species2)
+
+  expect_no_error(
+    .recipes_estimate_sparsity(rec)
   )
 })


### PR DESCRIPTION
To close #1448

``` r
library(tidymodels)

# Create sample data
data <- tibble(
  date = seq(as.Date("2020-01-01"), by = "day", length.out = 100),
  outcome = rnorm(100),
  predictor = rnorm(100)
)

# Define recipe
recipe_minimal <- recipes::recipe(outcome ~ date, data = data) %>%
  recipes::step_date("date", features = "month") %>%
  recipes::step_dummy("date_month") %>%
  recipes::step_rm("date")

# Define workflow
wflow_minimal <- workflows::workflow() %>%
  workflows::add_recipe(recipe_minimal) %>%
  workflows::add_model(
    parsnip::linear_reg(penalty = 0, mixture = 1) %>%
      parsnip::set_engine("glmnet")
  )

# Attempt to fit
fit(wflow_minimal, data)
#> ══ Workflow [trained] ══════════════════════════════════════════════════════════
#> Preprocessor: Recipe
#> Model: linear_reg()
#> 
#> ── Preprocessor ────────────────────────────────────────────────────────────────
#> 3 Recipe Steps
#> 
#> • step_date()
#> • step_dummy()
#> • step_rm()
#> 
#> ── Model ───────────────────────────────────────────────────────────────────────
#> 
#> Call:  glmnet::glmnet(x = maybe_matrix(x), y = y, family = "gaussian",      alpha = ~1) 
#> 
#>    Df %Dev   Lambda
#> 1   0 0.00 0.067690
#> 2   1 0.09 0.061670
#> 3   1 0.16 0.056190
#> 4   1 0.22 0.051200
#> 5   1 0.27 0.046650
#> 6   1 0.31 0.042510
#> 7   1 0.35 0.038730
#> 8   1 0.38 0.035290
#> 9   1 0.40 0.032160
#> 10  1 0.42 0.029300
#> 11  1 0.44 0.026700
#> 12  1 0.45 0.024330
#> 13  2 0.46 0.022160
#> 14  2 0.48 0.020200
#> 15  2 0.49 0.018400
#> 16  2 0.50 0.016770
#> 17  2 0.51 0.015280
#> 18  2 0.52 0.013920
#> 19  2 0.52 0.012680
#> 20  2 0.53 0.011560
#> 21  2 0.53 0.010530
#> 22  2 0.54 0.009594
#> 23  2 0.54 0.008742
#> 24  2 0.54 0.007965
#> 25  2 0.54 0.007258
#> 26  3 0.55 0.006613
#> 27  3 0.55 0.006026
#> 28  3 0.55 0.005490
#> 29  3 0.55 0.005003
#> 30  3 0.55 0.004558
#> 31  3 0.55 0.004153
#> 32  3 0.56 0.003784
#> 33  3 0.56 0.003448
#> 34  3 0.56 0.003142
#> 35  3 0.56 0.002863
#> 36  3 0.56 0.002608
#> 37  3 0.56 0.002377
#> 38  3 0.56 0.002165
#> 39  3 0.56 0.001973
#> 40  3 0.56 0.001798
#> 41  3 0.56 0.001638
#> 42  3 0.56 0.001493
#> 43  3 0.56 0.001360
#> 44  3 0.56 0.001239
#> 45  3 0.56 0.001129
#> 46  3 0.56 0.001029
#> 
#> ...
#> and 14 more lines.
```

<sup>Created on 2025-03-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>