### PR TITLE
add and use check_zv() in spline steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * Make it so `recipe.formula()` can't take table objects as input, in accordance with documentation. (#1416)
 
 * Fixed bug where `step_lincomb()` would remove both variables if they were identical. (#1357)
+
+* `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, and `step_spline_nonnegative()` now gives informative errors when applied to zero variance predictors. (#1455)
  
 # recipes 1.2.1
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -465,7 +465,7 @@ check_type <- function(dat, quant = TRUE, types = NULL, call = caller_env()) {
       types <- "factor or character"
     }
   } else {
-    all_good <- purrr::map_lgl(get_types(dat)$type, ~any(.x %in% types))
+    all_good <- purrr::map_lgl(get_types(dat)$type, ~ any(.x %in% types))
   }
 
   if (!all(all_good)) {
@@ -1015,4 +1015,22 @@ get_from_info <- function(info, role) {
   res <- info$variable[info$role == role & !is.na(info$role)]
 
   res
+}
+
+check_zv <- function(data, call = rlang::caller_env()) {
+  vz_ind <- vapply(data, one_unique, logical(1))
+
+  if (any(vz_ind)) {
+    col_names <- colnames(data)
+    offenders <- col_names[vz_ind]
+    cli::cli_abort(
+      c(
+        "!" = "{cli::qty(offenders)} The following column{?s} {?has/have} zero \\
+        variance making computations unable to proceed: {offenders}.",
+        "i" = "Consider using {.help [?step_zv](recipes::step_zv)} to remove \\
+        those columns before this step."
+      ),
+      call = call
+    )
+  }
 }

--- a/R/spline_b.R
+++ b/R/spline_b.R
@@ -153,6 +153,8 @@ prep.step_spline_b <- function(x, training, info = NULL, ...) {
   check_number_whole(x$degree, arg = "degree", min = 0)
   check_number_whole(x$deg_free, arg = "deg_free", min = 0)
 
+  check_zv(training[, col_names])
+
   res <- list()
 
   for (col_name in col_names) {

--- a/R/spline_convex.R
+++ b/R/spline_convex.R
@@ -140,6 +140,8 @@ prep.step_spline_convex <- function(x, training, info = NULL, ...) {
   check_bool(x$complete_set, arg = "complete_set")
   check_number_whole(x$degree, arg = "degree", min = 0)
 
+  check_zv(training[, col_names])
+
   res <- list()
 
   for (col_name in col_names) {

--- a/R/spline_monotone.R
+++ b/R/spline_monotone.R
@@ -142,6 +142,8 @@ prep.step_spline_monotone <- function(x, training, info = NULL, ...) {
   check_number_whole(x$degree, arg = "degree", min = 0)
   check_number_whole(x$deg_free, arg = "deg_free", min = 0)
 
+  check_zv(training[, col_names])
+
   res <- list()
 
   for (col_name in col_names) {

--- a/R/spline_natural.R
+++ b/R/spline_natural.R
@@ -134,6 +134,8 @@ prep.step_spline_natural <- function(x, training, info = NULL, ...) {
   check_bool(x$complete_set, arg = "complete_set")
   check_number_whole(x$deg_free, arg = "deg_free", min = 2)
 
+  check_zv(training[, col_names])
+
   res <- list()
 
   for (col_name in col_names) {

--- a/R/spline_nonnegative.R
+++ b/R/spline_nonnegative.R
@@ -153,6 +153,8 @@ prep.step_spline_nonnegative <- function(x, training, info = NULL, ...) {
   check_number_whole(x$degree, arg = "degree", min = 0)
   check_number_whole(x$deg_free, arg = "deg_free", min = 0)
 
+  check_zv(training[, col_names])
+
   res <- list()
 
   for (col_name in col_names) {

--- a/tests/testthat/_snaps/spline_b.md
+++ b/tests/testthat/_snaps/spline_b.md
@@ -28,6 +28,17 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# errors with zero variance predictors (#1455)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_spline_b(all_numeric_predictors()) %>%
+        prep()
+    Condition
+      Error in `step_spline_b()`:
+      Caused by error in `prep()`:
+      ! The following columns have zero variance making computations unable to proceed: disp and vs.
+      i Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/spline_convex.md
+++ b/tests/testthat/_snaps/spline_convex.md
@@ -28,6 +28,17 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# errors with zero variance predictors (#1455)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_spline_convex(all_numeric_predictors()) %>%
+        prep()
+    Condition
+      Error in `step_spline_convex()`:
+      Caused by error in `prep()`:
+      ! The following columns have zero variance making computations unable to proceed: disp and vs.
+      i Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/spline_monotone.md
+++ b/tests/testthat/_snaps/spline_monotone.md
@@ -28,6 +28,17 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# errors with zero variance predictors (#1455)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_spline_monotone(all_numeric_predictors()) %>%
+        prep()
+    Condition
+      Error in `step_spline_monotone()`:
+      Caused by error in `prep()`:
+      ! The following columns have zero variance making computations unable to proceed: disp and vs.
+      i Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/spline_natural.md
+++ b/tests/testthat/_snaps/spline_natural.md
@@ -8,6 +8,17 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# errors with zero variance predictors (#1455)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_spline_natural(all_numeric_predictors()) %>%
+        prep()
+    Condition
+      Error in `step_spline_natural()`:
+      Caused by error in `prep()`:
+      ! The following columns have zero variance making computations unable to proceed: disp and vs.
+      i Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/spline_nonnegative.md
+++ b/tests/testthat/_snaps/spline_nonnegative.md
@@ -28,6 +28,17 @@
       ! Name collision occurred. The following variable names already exist:
       * `mpg_01`
 
+# errors with zero variance predictors (#1455)
+
+    Code
+      recipe(mpg ~ ., data = mtcars) %>% step_spline_nonnegative(
+        all_numeric_predictors()) %>% prep()
+    Condition
+      Error in `step_spline_nonnegative()`:
+      Caused by error in `prep()`:
+      ! The following columns have zero variance making computations unable to proceed: disp and vs.
+      i Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -50,6 +50,7 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_bake_role_requirements"]
   step_check <- step_check[step_check != "check_step_check_args"]
   step_check <- step_check[step_check != "check_sparse_arg"]
+  step_check <- step_check[step_check != "check_zv"]
 
   # R/import-standalone-types-check.R
   step_check <- step_check[step_check != "check_bool"]
@@ -86,8 +87,8 @@ test_that("check existing steps for `skip` arg", {
 test_that("skips for steps that remove columns (#239)", {
   simple_ex <-
     recipe(Species ~ ., data = iris) %>%
-      step_interact(terms = ~Sepal.Length:Sepal.Width) %>%
-      step_rm(Sepal.Length, skip = TRUE)
+    step_interact(terms = ~ Sepal.Length:Sepal.Width) %>%
+    step_rm(Sepal.Length, skip = TRUE)
 
   prep_simple <- prep(simple_ex, iris)
   simple_juiced <- juice(prep_simple)
@@ -121,11 +122,11 @@ test_that("skips for steps that remove columns (#239)", {
 
   complex_ex <-
     recipe(Species ~ ., data = iris) %>%
-      step_interact(terms = ~Sepal.Length:Sepal.Width) %>%
-      step_rm(Sepal.Length) %>%
-      step_pca(contains("Sepal")) %>%
-      step_rm(PC1, skip = TRUE) %>%
-      prep()
+    step_interact(terms = ~ Sepal.Length:Sepal.Width) %>%
+    step_rm(Sepal.Length) %>%
+    step_pca(contains("Sepal")) %>%
+    step_rm(PC1, skip = TRUE) %>%
+    prep()
 
   complex_juiced <- juice(complex_ex)
   complex_baked <- bake(complex_ex, new_data = iris)
@@ -141,15 +142,15 @@ test_that("skips for steps that remove columns (#239)", {
 
   iris_dups <-
     iris %>%
-      mutate(
-        dup_1 = Sepal.Width,
-        dup_2 = Sepal.Width
-      )
+    mutate(
+      dup_1 = Sepal.Width,
+      dup_2 = Sepal.Width
+    )
 
   corr_example <-
     recipe(Species ~ ., data = iris_dups) %>%
-      step_corr(all_predictors(), skip = TRUE) %>%
-      prep()
+    step_corr(all_predictors(), skip = TRUE) %>%
+    prep()
 
   corr_juiced <- juice(corr_example)
   corr_baked <- bake(corr_example, new_data = iris_dups)

--- a/tests/testthat/test-spline_b.R
+++ b/tests/testthat/test-spline_b.R
@@ -136,7 +136,7 @@ test_that("tunable", {
 
   rec <-
     recipe(~., data = iris) %>%
-      step_spline_b(all_predictors())
+    step_spline_b(all_predictors())
   rec_param <- tunable.step_spline_b(rec$steps[[1]])
   expect_equal(rec_param$name, c("deg_free", "degree"))
   expect_true(all(rec_param$source == "recipe"))
@@ -158,6 +158,18 @@ test_that("works when baked with 1 row", {
   )
 
   expect_identical(nrow(res), 1L)
+})
+
+test_that("errors with zero variance predictors (#1455)", {
+  mtcars$disp <- 1
+  mtcars$vs <- 1
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>%
+      step_spline_b(all_numeric_predictors()) %>%
+      prep()
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------

--- a/tests/testthat/test-spline_convex.R
+++ b/tests/testthat/test-spline_convex.R
@@ -146,7 +146,7 @@ test_that("tunable", {
 
   rec <-
     recipe(~., data = iris) %>%
-      step_spline_convex(all_predictors())
+    step_spline_convex(all_predictors())
   rec_param <- tunable.step_spline_convex(rec$steps[[1]])
   expect_equal(rec_param$name, c("deg_free", "degree"))
   expect_true(all(rec_param$source == "recipe"))
@@ -168,6 +168,18 @@ test_that("works when baked with 1 row", {
   )
 
   expect_identical(nrow(res), 1L)
+})
+
+test_that("errors with zero variance predictors (#1455)", {
+  mtcars$disp <- 1
+  mtcars$vs <- 1
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>%
+      step_spline_convex(all_numeric_predictors()) %>%
+      prep()
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------

--- a/tests/testthat/test-spline_monotone.R
+++ b/tests/testthat/test-spline_monotone.R
@@ -156,7 +156,7 @@ test_that("tunable", {
 
   rec <-
     recipe(~., data = iris) %>%
-      step_spline_monotone(all_predictors())
+    step_spline_monotone(all_predictors())
   rec_param <- tunable.step_spline_monotone(rec$steps[[1]])
   expect_equal(rec_param$name, c("deg_free", "degree"))
   expect_true(all(rec_param$source == "recipe"))
@@ -178,6 +178,18 @@ test_that("works when baked with 1 row", {
   )
 
   expect_identical(nrow(res), 1L)
+})
+
+test_that("errors with zero variance predictors (#1455)", {
+  mtcars$disp <- 1
+  mtcars$vs <- 1
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>%
+      step_spline_monotone(all_numeric_predictors()) %>%
+      prep()
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------

--- a/tests/testthat/test-spline_natural.R
+++ b/tests/testthat/test-spline_natural.R
@@ -106,7 +106,7 @@ test_that("tunable", {
 
   rec <-
     recipe(~., data = iris) %>%
-      step_spline_natural(all_predictors())
+    step_spline_natural(all_predictors())
   rec_param <- tunable.step_spline_natural(rec$steps[[1]])
   expect_equal(rec_param$name, c("deg_free"))
   expect_true(all(rec_param$source == "recipe"))
@@ -128,6 +128,18 @@ test_that("works when baked with 1 row", {
   )
 
   expect_identical(nrow(res), 1L)
+})
+
+test_that("errors with zero variance predictors (#1455)", {
+  mtcars$disp <- 1
+  mtcars$vs <- 1
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>%
+      step_spline_natural(all_numeric_predictors()) %>%
+      prep()
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------

--- a/tests/testthat/test-spline_nonnegative.R
+++ b/tests/testthat/test-spline_nonnegative.R
@@ -156,7 +156,7 @@ test_that("tunable", {
 
   rec <-
     recipe(~., data = iris) %>%
-      step_spline_nonnegative(all_predictors())
+    step_spline_nonnegative(all_predictors())
   rec_param <- tunable.step_spline_nonnegative(rec$steps[[1]])
   expect_equal(rec_param$name, c("deg_free", "degree"))
   expect_true(all(rec_param$source == "recipe"))
@@ -178,6 +178,18 @@ test_that("works when baked with 1 row", {
   )
 
   expect_identical(nrow(res), 1L)
+})
+
+test_that("errors with zero variance predictors (#1455)", {
+  mtcars$disp <- 1
+  mtcars$vs <- 1
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(mpg ~ ., data = mtcars) %>%
+      step_spline_nonnegative(all_numeric_predictors()) %>%
+      prep()
+  )
 })
 
 # Infrastructure ---------------------------------------------------------------


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/1455

``` r
library(recipes)

mtcars$disp <- 3

recipe(.~ disp, data = mtcars) %>%
  step_spline_convex(disp) %>%
  prep()
#> Error in `step_spline_convex()`:
#> Caused by error in `prep()`:
#> ! The following column has zero variance making computations unable to
#>   proceed: disp.
#> ℹ Consider using ?step_zv (`?recipes::step_zv()`) to remove those columns
#>   before this step.
```
