### PR TITLE
special case predict.discretize() when x is all NA

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,9 @@
 * Fixed bug where `step_lincomb()` would remove both variables if they were identical. (#1357)
 
 * `step_spline_b()`, `step_spline_convex()`, `step_spline_monotone()`, `step_spline_natural()`, and `step_spline_nonnegative()` now gives informative errors when applied to zero variance predictors. (#1455)
- 
+
+* fixed bug where `bake.step_discretize()` would error if applied to predictor only containing `NA`s. (#1350)
+
 # recipes 1.2.1
 
 ## Bug Fixes

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -179,8 +179,12 @@ predict.discretize <- function(object, new_data, ...) {
     } else {
       object$labels
     }
-    out <-
-      cut(new_data, object$breaks, labels = labs, include.lowest = TRUE)
+    if (all(is.na(new_data))) {
+      out <- factor(new_data, levels = labs)
+    } else {
+      out <-
+        cut(new_data, object$breaks, labels = labs, include.lowest = TRUE)
+    }
 
     if (object$keep_na) {
       out_levels <- levels(out)


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1350

turned out it was more general, problems when vector only contained NAs, not just 1 NA.

``` r
library(recipes)

rec <- recipe(~ mpg, data = mtcars) |>
  step_discretize(mpg, min_unique = 4) |>
  prep()

rec |>
  bake(data.frame(mpg = c(NA, 3))) |>
  pull(mpg)
#> [1] <NA> bin1
#> Levels: bin1 bin2 bin3 bin4

rec |>
  bake(data.frame(mpg = c(3))) |>
    pull(mpg)
#> [1] bin1
#> Levels: bin1 bin2 bin3 bin4

rec |>
  bake(data.frame(mpg = c(NA, NA))) |>
  pull(mpg)
#> [1] <NA> <NA>
#> Levels: bin1 bin2 bin3 bin4
```
