### PR TITLE
adds better error message when step_impute_bag() fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * The `strings_as_factors` argument of `prep.recipe()` has been soft-deprecated in favor of `recipe(strings_as_factors)`. If both are provided, the value in `recipe()` takes precedence. This allows control of recipe behavior within a workflow, which wasn't previously possible. (@smingerson, #331, #287)
 
+* More informative error for some failures of `step_impute_bag()` (#209)
+
 * Fixed bugs in `step_bs()`, `step_depth()`, `step_harmonic()`, `step_invlogit()`, `step_isomap()`, `step_logit()`, `check_range()`, `step_poly_bernstein()`, `step_spline_b()`, `step_spline_convex()`, `step_monotone()`, `step_natural()`, `step_nonnegative()` would error in `bake()` with zero-row data. (#1219)
 
 * Fixed bug where `step_lincomb()` would remove both variables if they were identical. (#1357)

--- a/tests/testthat/_snaps/impute_bag.md
+++ b/tests/testthat/_snaps/impute_bag.md
@@ -18,6 +18,16 @@
       Warning:
       The `impute_with` variables for `disp` only contains missing values for row: 10. Cannot impute for those rows.
 
+# Better error message for nzv fit error (#209)
+
+    Code
+      recipe(~., d) %>% step_impute_bag(let) %>% prep()
+    Condition
+      Error in `step_impute_bag()`:
+      Caused by error in `prep()`:
+      x The bagged tree model was not able to fit to `let`. It appears to be because it had near zero variance.
+      i Please deselect it for this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/test-impute_bag.R
+++ b/tests/testthat/test-impute_bag.R
@@ -148,6 +148,17 @@ test_that("Warns when impute_with contains all NAs in a row", {
   )
 })
 
+test_that("Better error message for nzv fit error (#209)", {
+  d <- data.frame(let = c(rep("a", 99), rep("b", 1)), num = seq_len(100))
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., d) %>%
+      step_impute_bag(let) %>%
+      prep()
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
new error:

``` r
library(recipes)

d <- data.frame(let = c(rep("a", 99), NA), num = 1:100)

rec_obj <- recipe(~., d) %>%
  step_impute_bag(let)

prep(rec_obj)
#> Error in `step_impute_bag()`:
#> Caused by error in `prep()`:
#> ✖ The bagged tree model was not able to fit to `let`. It appears to be
#>   because it had near zero variance.
#> ℹ Please deselect it for this step.
```

<sup>Created on 2025-04-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>