### PR TITLE
make sure that bake.step_impute_knn() sees same ptype

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `step_cut()` not longer errors on NA values in `bake()`. (#1304)
 
+* Fixed bug in `step_impute_knn()` would error on character vectors when `strings_as_factors = TRUE`. (#926)
+
 * Make it so `recipe.formula()` can't take table objects as input, in accordance with documentation. (#1416)
 
 * The `strings_as_factors` argument of `prep.recipe()` has been soft-deprecated in favor of `recipe(strings_as_factors)`. If both are provided, the value in `recipe()` takes precedence. This allows control of recipe behavior within a workflow, which wasn't previously possible. (@smingerson, #331, #287)

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -266,6 +266,11 @@ bake.step_impute_knn <- function(object, new_data, ...) {
         next
       }
     }
+    # make sure imp_data as same types as ref_data
+    imp_data <- vctrs::tib_cast(
+      imp_data,
+      select(object$ref_data, names(imp_data))
+    )
 
     imp_var_complete <- !is.na(object$ref_data[[col_name]])
     nn_ind <- nn_index(

--- a/tests/testthat/test-impute_knn.R
+++ b/tests/testthat/test-impute_knn.R
@@ -230,6 +230,32 @@ test_that("error on wrong options argument", {
   )
 })
 
+test_that("step_impute_knn() can prep with character vectors (#926)", {
+  set.seed(42)
+
+  dat <- tibble(
+    criterion = rnorm(50),
+    num_pred_a = rnorm(50) + .8 * criterion,
+    char_pred = ifelse(
+      criterion < .2,
+      sample(c("a", "b"), 1, prob = c(.75, .25)),
+      sample(c("a", "b"), 1, prob = c(.5, .5))
+    )
+  )
+
+  dat[sample(1:nrow(dat), 2), 2] <- NA
+  dat[sample(1:nrow(dat), 2), 3] <- NA
+
+  rec <- recipe(criterion ~ ., data = dat, strings_as_factors = TRUE) %>%
+    step_impute_knn(all_predictors())
+
+  rec_prepped <- prep(rec, dat)
+
+  expect_no_error(
+    bake(rec_prepped, dat)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
to close https://github.com/tidymodels/recipes/issues/926

``` r
library(tibble)
library(recipes)

# set up data
set.seed(42)

dat <- tibble(
  criterion = rnorm(50),
  num_pred_a = rnorm(50) + .8 * criterion,
  char_pred = ifelse(
    criterion < .2,
    sample(c("a", "b"), 1, prob = c(.75, .25)),
    sample(c("a", "b"), 1, prob = c(.5, .5))
  )
)

dat[sample(1:nrow(dat), 2), 2] <- NA
dat[sample(1:nrow(dat), 2), 3] <- NA

rec <- recipe(criterion ~ ., data = dat) %>%
  step_impute_knn(all_predictors())

rec_prepped <- prep(rec, dat)

bake(rec_prepped, dat)
#> # A tibble: 50 × 3
#>    num_pred_a char_pred criterion
#>         <dbl> <fct>         <dbl>
#>  1     1.42   a            1.37  
#>  2    -1.24   b           -0.565 
#>  3     1.87   a            0.363 
#>  4     1.15   a            0.633 
#>  5     0.413  a            0.404 
#>  6     0.192  b           -0.106 
#>  7     1.89   a            1.51  
#>  8     0.0141 b           -0.0947
#>  9    -1.38   a            2.02  
#> 10     0.235  b           -0.0627
#> # ℹ 40 more rows
```