### PR TITLE
handle very old grouped data frames

### DIFF
--- a/R/recipe.R
+++ b/R/recipe.R
@@ -809,6 +809,13 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   # set.
   info <- object$last_term_info
 
+  # Handle old grouped data.frames
+  if (!is.null(attr(info, "vars"))) {
+    group_vars <- attr(info, "vars")
+    info <- dplyr::ungroup(info)
+    info <- dplyr::group_by(info, dplyr::pick(group_vars))
+  }
+
   # Now reduce to only user selected columns
   out_names <- recipes_eval_select(
     terms,


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1401

``` r
library(dplyr)
library(tidymodels)

model_pipeline = readr::read_rds("~/Downloads/model_pipeline.rds")
model = model_pipeline$model
recipe = model_pipeline$recipe

# This works:
print(recipe)
#> 
#> ── Recipe ──────────────────────────────────────────────────────────────────────
#> 
#> ── Inputs
#> Number of variables by role
#> outcome:    1
#> predictor: 10
#> 
#> ── Training information
#> Training data contained 32 data points and no incomplete rows.
#> 
#> ── Operations
#> • Dummy variables from: am | Trained
#> • Mean imputation for: mpg, cyl, disp, hp, drat, wt, qsec, ... | Trained

# Issue 1: Printing the model fails with an error, unless we set elapsed:
model$elapsed[["elapsed"]] = 0
print(model)
#> parsnip model object
#> 
#> Fit time:  0ms 
#> Support Vector Machine object of class "ksvm" 
#> 
#> SV type: eps-svr  (regression) 
#>  parameter : epsilon = 0.1  cost C = 1 
#> 
#> Polynomial kernel function. 
#>  Hyperparameters : degree =  1  scale =  0.1  offset =  1 
#> 
#> Number of Support Vectors : 21 
#> 
#> Objective Function Value : -3.3445 
#> Training error : 0.055289

# Create Test Dataframe:
test_df = mtcars %>%
  mutate(label = (vs == 0)) %>%
  select(-vs) %>%
  mutate(am = paste0("am is ", am)) # Create a categorical field for one-hot encoding recipe

# Issue 2: Trying to run the recipe on the test with updated packages:

prepped_test_df = bake(recipe, new_data = test_df)
#> Warning: `keep_original_cols` was added to `step_dummy()` after this recipe was created.
#> ℹ Regenerate your recipe to avoid this warning.
```

<sup>Created on 2025-04-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>