### PR TITLE
make `step_intercept()` works with empty selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `step_num2factor()` has gotten improved documentation to avoid getting NAs as output. (#575)
 
+* `step_interact()` now works with empty selections instead of erroring. (#1417)
+
 * fixed bug where `step_nnmf_sparse()` required that the Matrix package was loaded. (#1141)
 
 * Fixed bug where `recipe()` would error on sf objects. (#1393)

--- a/R/interact.R
+++ b/R/interact.R
@@ -457,6 +457,9 @@ intersect_selectors <- c(
 plus_call <- function(x, y) call("+", x, y)
 
 vec_2_expr <- function(x) {
+  if (length(x) == 0) {
+    return(NULL)
+  }
   x <- rlang::syms(x)
   res <- purrr::reduce(x, plus_call)
   expr((!!res))

--- a/R/interact.R
+++ b/R/interact.R
@@ -353,9 +353,11 @@ make_small_terms <- function(forms, dat) {
 print.step_interact <-
   function(x, width = max(20, options()$width - 27), ...) {
     title <- "Interactions with "
-
     if (x$trained) {
-      terms <- as.character(x$terms)[-1]
+      terms <- map_chr(
+        x$objects,
+        function(x) utils::tail(attr(x, "term.labels"), 1)
+      )
     } else {
       terms <- as_label(x$terms[[1]])
       if (terms == "<empty>") {

--- a/tests/testthat/test-interact.R
+++ b/tests/testthat/test-interact.R
@@ -344,6 +344,27 @@ test_that("gives informative error if terms isn't a formula (#1299)", {
   )
 })
 
+test_that("one-sided empty selections works (#1299)", {
+  res <- recipe(~., data = mtcars) %>%
+    step_interact(~ any_of("vs"):any_of("not_am")) %>%
+    prep() %>%
+    bake(NULL)
+  exp <- as_tibble(mtcars)
+
+  expect_identical(res, exp)
+
+  res <- recipe(~., data = mtcars) %>%
+    step_interact(~ hp:mpg + any_of("vs"):any_of("not_am")) %>%
+    prep() %>%
+    bake(NULL)
+  exp <- recipe(~., data = mtcars) %>%
+    step_interact(~ hp:mpg) %>%
+    prep() %>%
+    bake(NULL)
+
+  expect_identical(res, exp)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1417

Empty selections mostly happen when you use tidyselect and one of the sides doesn't select anything.

``` r
library(recipes)

recipe(~., data = mtcars) %>%
  step_interact(~ any_of("vs"):any_of("not_am")) %>%
  prep()
#> 
#> ── Recipe ──────────────────────────────────────────────────────────────────────
#> 
#> ── Inputs
#> Number of variables by role
#> predictor: 11
#> 
#> ── Training information
#> Training data contained 32 data points and no incomplete rows.
#> 
#> ── Operations
#> • Interactions with: <none> | Trained
```

<sup>Created on 2025-04-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>