### PR TITLE
add `contrasts` argument to `step_dummy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 * Officially deprecate `printer()` in favor of `print_step()`. (#1243)
 
+* `step_dummy()` has gained `contrasts` argument. This change soft deprecates the use of `getOption("contrasts")` with `step_dummy()`. (##1349)
+
 * `step_mutate_at()` has been superceded in favor of `step_mutate()` when used with `across()`. (#662)
 
 # recipes 1.2.1

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -232,6 +232,22 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
 
   check_contrasts_arg(x$contrasts)
 
+  if (
+    !identical(
+      getOption("contrasts"),
+      c(unordered = "contr.treatment", ordered = "contr.poly")
+    )
+  ) {
+    x$contrasts <- getOption("contrasts")
+    x$contrasts <- lapply(x$contrasts, get)
+
+    lifecycle::deprecate_warn(
+      "1.3.0",
+      I("options(contrasts) with step_dummy()"),
+      I("step_dummy(contrasts)")
+    )
+  }
+
   if (length(col_names) > 0) {
     ## I hate doing this but currently we are going to have
     ## to save the terms object from the original (= training)

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -225,9 +225,12 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
       ordered = stats::contr.poly
     )
   }
+
   if (is.function(x$contrasts)) {
     x$contrasts <- list(unordered = x$contrasts, ordered = x$contrasts)
   }
+
+  check_contrasts_arg(x$contrasts)
 
   if (length(col_names) > 0) {
     ## I hate doing this but currently we are going to have
@@ -277,6 +280,48 @@ prep.step_dummy <- function(x, training, info = NULL, ...) {
     keep_original_cols = get_keep_original_cols(x),
     skip = x$skip,
     id = x$id
+  )
+}
+
+check_contrasts_arg <- function(x, call = rlang::caller_env()) {
+  if (is.list(x)) {
+    if (!identical(sort(names(x)), c("ordered", "unordered"))) {
+      offender <- names(x)
+      if (length(offender) == 0) {
+        cli::cli_abort(
+          "The list passed to {.arg contrasts} must have the names 
+          {.val ordered} and {.val unordered}.",
+          call = call
+        )
+      }
+      cli::cli_abort(
+        "The names of list passed to {.arg contrasts} must be {.val ordered} and
+        {.val unordered}, not {.val {offender}}.",
+        call = call
+      )
+    }
+    if (!is.function(x$ordered)) {
+      cli::cli_abort(
+        "The {.field ordered} element of {.arg contracts} but be a function, 
+        not {.obj_type_friendly {x$ordered}}.",
+        call = call
+      )
+    }
+    if (!is.function(x$unordered)) {
+      cli::cli_abort(
+        "The {.field unordered} element of {.arg contracts} but be a function, 
+        not {.obj_type_friendly {x$unordered}}.",
+        call = call
+      )
+    }
+
+    return(NULL)
+  }
+
+  cli::cli_abort(
+    "{.arg contrasts} must be a function or list,
+    not {.obj_type_friendly {x}}.",
+    call = call
   )
 }
 

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -36,7 +36,10 @@
 #' two additional columns of 0/1 data for two of those three values (and remove
 #' the original column). For ordered factors, polynomial contrasts are used to
 #' encode the numeric values. These defaults are controlled by the `contrasts`
-#' argument.
+#' argument. Note that since the contrasts are specified via character strings
+#' you will need to have those packages loaded. If you are using this with the
+#' tune package, you might need to add that these packages to the `pkg` option
+#' in `control_grid()`.
 #'
 #' By default, the excluded dummy variable (i.e. the reference cell) will
 #' correspond to the first level of the unordered factor being converted.

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -35,10 +35,11 @@
 #'
 #' `step_dummy()` will create a set of binary dummy variables from a factor
 #' variable. For example, if an unordered factor column in the data set has
-#' levels of "red", "green", "blue", the dummy variable bake will create two
-#' additional columns of 0/1 data for two of those three values (and remove the
-#' original column). For ordered factors, polynomial contrasts are used to
-#' encode the numeric values.
+#' levels of `"red"`, `"green"`, `"blue"`, the dummy variable bake will create
+#' two additional columns of 0/1 data for two of those three values (and remove
+#' the original column). For ordered factors, polynomial contrasts are used to
+#' encode the numeric values. These defaults are controlled by the `contrasts`
+#' argument.
 #'
 #' By default, the excluded dummy variable (i.e. the reference cell) will
 #' correspond to the first level of the unordered factor being converted.
@@ -48,9 +49,6 @@
 #' @template dummy-naming
 #'
 #' @details
-#'
-#' To change the type of contrast being used, change the global contrast option
-#' via `options`.
 #'
 #' When the factor being converted has a missing value, all of the corresponding
 #' dummy variables are also missing. See [step_unknown()] for a solution.
@@ -63,12 +61,10 @@
 #' will return the data as-is (e.g. with no dummy variables).
 #'
 #' Note that, by default, the new dummy variable column names obey the naming
-#' rules for columns. If there are levels such as "0", [dummy_names()] will put
-#' a leading "X" in front of the level (since it uses [make.names()]). This can
-#' be changed by passing in a different function to the `naming` argument for
-#' this step.
-#'
-#'
+#' rules for columns. If there are levels such as `"0"`, [dummy_names()] will
+#' put a leading `"X"` in front of the level (since it uses [make.names()]).
+#' This can be changed by passing in a different function to the `naming`
+#' argument for this step.
 #'
 #' Also, there are a number of contrast methods that return fractional values.
 #' The columns returned by this step are doubles (not integers) when
@@ -104,28 +100,39 @@
 #' # Default dummy coding: 36 dummy variables
 #' dummies <- rec %>%
 #'   step_dummy(city) %>%
-#'   prep(training = Sacramento)
+#'   prep()
 #'
 #' dummy_data <- bake(dummies, new_data = NULL)
 #'
 #' dummy_data %>%
 #'   select(starts_with("city")) %>%
-#'   names() # level "anything" is the reference level
+#'   glimpse() # level "anything" is the reference level
 #'
 #' # Obtain the full set of 37 dummy variables using `one_hot` option
 #' dummies_one_hot <- rec %>%
 #'   step_dummy(city, one_hot = TRUE) %>%
-#'   prep(training = Sacramento)
+#'   prep()
 #'
 #' dummy_data_one_hot <- bake(dummies_one_hot, new_data = NULL)
 #'
 #' dummy_data_one_hot %>%
 #'   select(starts_with("city")) %>%
-#'   names() # no reference level
+#'   glimpse() # no reference level
 #'
+#' # Obtain the full set of 37 dummy variables using helmert contrasts
+#' dummies_helmert <- rec %>%
+#'   step_dummy(city, contrasts = contr.helmert) %>%
+#'   prep()
+#'
+#' dummy_data_helmert <- bake(dummies_helmert, new_data = NULL)
+#'
+#' dummy_data_helmert %>%
+#'   select(starts_with("city")) %>%
+#'   glimpse() # no reference level
 #'
 #' tidy(dummies, number = 1)
 #' tidy(dummies_one_hot, number = 1)
+#' tidy(dummies_helmert, number = 1)
 step_dummy <-
   function(
     recipe,

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -468,19 +468,15 @@ bake.step_dummy <- function(object, new_data, ...) {
         }
       )
 
+      used_lvl <- attr(indicators, "assign") == 1
+      used_lvl <- rownames(attr(indicators, "contrasts")[[1]])[used_lvl]
+
       if (!object$one_hot) {
         indicators <- indicators[,
           colnames(indicators) != "(Intercept)",
           drop = FALSE
         ]
       }
-
-      ## use backticks for nonstandard factor levels here
-      used_lvl <- gsub(
-        paste0("^\\`?", col_name, "\\`?"),
-        "",
-        colnames(indicators)
-      )
     }
 
     new_names <- object$naming(col_name, used_lvl, is_ordered)

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -84,7 +84,10 @@ levels of \code{"red"}, \code{"green"}, \code{"blue"}, the dummy variable bake w
 two additional columns of 0/1 data for two of those three values (and remove
 the original column). For ordered factors, polynomial contrasts are used to
 encode the numeric values. These defaults are controlled by the \code{contrasts}
-argument.
+argument. Note that since the contrasts are specified via character strings
+you will need to have those packages loaded. If you are using this with the
+tune package, you might need to add that these packages to the \code{pkg} option
+in \code{control_grid()}.
 
 By default, the excluded dummy variable (i.e. the reference cell) will
 correspond to the first level of the unordered factor being converted.

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -10,7 +10,7 @@ step_dummy(
   role = "predictor",
   trained = FALSE,
   one_hot = FALSE,
-  contrasts = list(unordered = stats::contr.treatment, ordered = stats::contr.poly),
+  contrasts = list(unordered = "contr.treatment", ordered = "contr.poly"),
   preserve = deprecated(),
   naming = dummy_names,
   levels = NULL,
@@ -38,12 +38,9 @@ preprocessing have been estimated.}
 \item{one_hot}{A logical. For C levels, should C dummy variables be created
 rather than C-1?}
 
-\item{contrasts}{A named list of contrast functions or a single contrast
-function. Defaults to
-\code{list(unordered = contr.treatment, ordered = contr.poly)}. If it is a list,
-it must include both \code{unordered} and \code{ordered} elements. If a constrast
-function is passed by itself, it will be used for both unordered and
-ordered predictors.}
+\item{contrasts}{A named vector or list of contrast functions names. Defaults
+to \code{list(unordered = "contr.treatment", ordered = "contr.poly")}. If only a
+single string is passed it will be used for both \code{unordered} and \code{ordered}.}
 
 \item{preserve}{This argument has been deprecated. Please use
 \code{keep_original_cols} instead.}
@@ -189,7 +186,7 @@ dummy_data_one_hot \%>\%
 
 # Obtain the full set of 37 dummy variables using helmert contrasts
 dummies_helmert <- rec \%>\%
-  step_dummy(city, contrasts = contr.helmert) \%>\%
+  step_dummy(city, contrasts = "contr.helmert") \%>\%
   prep()
 
 dummy_data_helmert <- bake(dummies_helmert, new_data = NULL)

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -83,10 +83,11 @@ corresponding to the levels of the original data.
 \details{
 \code{step_dummy()} will create a set of binary dummy variables from a factor
 variable. For example, if an unordered factor column in the data set has
-levels of "red", "green", "blue", the dummy variable bake will create two
-additional columns of 0/1 data for two of those three values (and remove the
-original column). For ordered factors, polynomial contrasts are used to
-encode the numeric values.
+levels of \code{"red"}, \code{"green"}, \code{"blue"}, the dummy variable bake will create
+two additional columns of 0/1 data for two of those three values (and remove
+the original column). For ordered factors, polynomial contrasts are used to
+encode the numeric values. These defaults are controlled by the \code{contrasts}
+argument.
 
 By default, the excluded dummy variable (i.e. the reference cell) will
 correspond to the first level of the unordered factor being converted.
@@ -100,9 +101,6 @@ new variable called \code{x_b}. The naming format can be changed using
 the \code{naming} argument; the function \code{\link[=dummy_names]{dummy_names()}} is the
 default.
 
-To change the type of contrast being used, change the global contrast option
-via \code{options}.
-
 When the factor being converted has a missing value, all of the corresponding
 dummy variables are also missing. See \code{\link[=step_unknown]{step_unknown()}} for a solution.
 
@@ -114,10 +112,10 @@ If no columns are selected (perhaps due to an earlier \code{step_zv()}), \code{\
 will return the data as-is (e.g. with no dummy variables).
 
 Note that, by default, the new dummy variable column names obey the naming
-rules for columns. If there are levels such as "0", \code{\link[=dummy_names]{dummy_names()}} will put
-a leading "X" in front of the level (since it uses \code{\link[=make.names]{make.names()}}). This can
-be changed by passing in a different function to the \code{naming} argument for
-this step.
+rules for columns. If there are levels such as \code{"0"}, \code{\link[=dummy_names]{dummy_names()}} will
+put a leading \code{"X"} in front of the level (since it uses \code{\link[=make.names]{make.names()}}).
+This can be changed by passing in a different function to the \code{naming}
+argument for this step.
 
 Also, there are a number of contrast methods that return fractional values.
 The columns returned by this step are doubles (not integers) when
@@ -170,28 +168,39 @@ rec <- recipe(~ city + sqft + price, data = Sacramento)
 # Default dummy coding: 36 dummy variables
 dummies <- rec \%>\%
   step_dummy(city) \%>\%
-  prep(training = Sacramento)
+  prep()
 
 dummy_data <- bake(dummies, new_data = NULL)
 
 dummy_data \%>\%
   select(starts_with("city")) \%>\%
-  names() # level "anything" is the reference level
+  glimpse() # level "anything" is the reference level
 
 # Obtain the full set of 37 dummy variables using `one_hot` option
 dummies_one_hot <- rec \%>\%
   step_dummy(city, one_hot = TRUE) \%>\%
-  prep(training = Sacramento)
+  prep()
 
 dummy_data_one_hot <- bake(dummies_one_hot, new_data = NULL)
 
 dummy_data_one_hot \%>\%
   select(starts_with("city")) \%>\%
-  names() # no reference level
+  glimpse() # no reference level
 
+# Obtain the full set of 37 dummy variables using helmert contrasts
+dummies_helmert <- rec \%>\%
+  step_dummy(city, contrasts = contr.helmert) \%>\%
+  prep()
+
+dummy_data_helmert <- bake(dummies_helmert, new_data = NULL)
+
+dummy_data_helmert \%>\%
+  select(starts_with("city")) \%>\%
+  glimpse() # no reference level
 
 tidy(dummies, number = 1)
 tidy(dummies_one_hot, number = 1)
+tidy(dummies_helmert, number = 1)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/step_dummy.Rd
+++ b/man/step_dummy.Rd
@@ -10,6 +10,7 @@ step_dummy(
   role = "predictor",
   trained = FALSE,
   one_hot = FALSE,
+  contrasts = list(unordered = stats::contr.treatment, ordered = stats::contr.poly),
   preserve = deprecated(),
   naming = dummy_names,
   levels = NULL,
@@ -36,6 +37,13 @@ preprocessing have been estimated.}
 
 \item{one_hot}{A logical. For C levels, should C dummy variables be created
 rather than C-1?}
+
+\item{contrasts}{A named list of contrast functions or a single contrast
+function. Defaults to
+\code{list(unordered = contr.treatment, ordered = contr.poly)}. If it is a list,
+it must include both \code{unordered} and \code{ordered} elements. If a constrast
+function is passed by itself, it will be used for both unordered and
+ordered predictors.}
 
 \item{preserve}{This argument has been deprecated. Please use
 \code{keep_original_cols} instead.}

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -67,6 +67,15 @@
       Caused by error in `prep()`:
       ! The unordered element of `contracts` but be a function, not a number.
 
+# getOption('contrasts') gives deprecation warning in step_dummy
+
+    Code
+      tmp <- recipe(~., data = iris) %>% step_dummy(Species) %>% prep()
+    Condition
+      Warning:
+      options(contrasts) with step_dummy() was deprecated in recipes 1.3.0.
+      i Please use step_dummy(contrasts) instead.
+
 # tests for NA values in factor
 
     Code

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -26,7 +26,7 @@
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! `contrasts` must be a function or list, not `TRUE`.
+      ! The ordered element of `contracts` must be a string, not `TRUE`.
 
 ---
 
@@ -40,32 +40,32 @@
 ---
 
     Code
-      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = contr.treatment)) %>%
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = "contr.treatment")) %>%
         prep()
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! The names of list passed to `contrasts` must be "ordered" and "unordered", not "ordered".
+      ! The ordered element of `contracts` must be a string, not a list.
 
 ---
 
     Code
       recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = 1,
-        unordered = contr.treatment)) %>% prep()
+        unordered = "contr.treatment")) %>% prep()
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! The ordered element of `contracts` but be a function, not a number.
+      ! The ordered element of `contracts` must be a string, not a number.
 
 ---
 
     Code
-      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = contr.treatment,
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = "contr.treatment",
         unordered = 1)) %>% prep()
     Condition
       Error in `step_dummy()`:
       Caused by error in `prep()`:
-      ! The unordered element of `contracts` but be a function, not a number.
+      ! The unordered element of `contracts` must be a string, not a number.
 
 # getOption('contrasts') gives deprecation warning in step_dummy
 

--- a/tests/testthat/_snaps/dummy.md
+++ b/tests/testthat/_snaps/dummy.md
@@ -19,6 +19,54 @@
       x All columns selected for the step should be factor or ordered.
       * 1 integer variable found: `price`
 
+# make sure contrasts argument is checked
+
+    Code
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = TRUE) %>% prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! `contrasts` must be a function or list, not `TRUE`.
+
+---
+
+    Code
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list()) %>% prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! The list passed to `contrasts` must have the names "ordered" and "unordered".
+
+---
+
+    Code
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = contr.treatment)) %>%
+        prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! The names of list passed to `contrasts` must be "ordered" and "unordered", not "ordered".
+
+---
+
+    Code
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = 1,
+        unordered = contr.treatment)) %>% prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! The ordered element of `contracts` but be a function, not a number.
+
+---
+
+    Code
+      recipe(~Species, iris) %>% step_dummy(Species, contrasts = list(ordered = contr.treatment,
+        unordered = 1)) %>% prep()
+    Condition
+      Error in `step_dummy()`:
+      Caused by error in `prep()`:
+      ! The unordered element of `contracts` but be a function, not a number.
+
 # tests for NA values in factor
 
     Code

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -214,6 +214,35 @@ test_that("make sure contrasts argument work for ordered factors", {
   expect_identical(unname(dummy_pred), unname(exp_res))
 })
 
+test_that("make sure contrasts argument work non-base contrasts", {
+  library(hardhat)
+  rec <- recipe(
+    ~city,
+    data = sacr_fac,
+    strings_as_factors = FALSE
+  )
+  dummy <- rec %>% step_dummy(city, contrasts = "contr_one_hot", id = "")
+  dummy_trained <- prep(
+    dummy,
+    training = sacr_fac,
+    verbose = FALSE
+  )
+  dummy_pred <- bake(dummy_trained, new_data = sacr_fac)
+  dummy_pred <- as.data.frame(dummy_pred)
+  rownames(dummy_pred) <- NULL
+
+  pred <- "city"
+  tmp <- model.matrix(
+    as.formula(paste("~", pred, "+ 0")),
+    data = sacr_fac,
+    contrasts.arg = setNames(list(contr_one_hot), pred)
+  )
+  exp_res <- as.data.frame(tmp)
+  rownames(exp_res) <- NULL
+
+  expect_identical(unname(dummy_pred), unname(exp_res))
+})
+
 test_that("make sure contrasts argument is checked", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -30,9 +30,7 @@ test_that("dummy variables with factor inputs", {
     verbose = FALSE
   )
   dummy_pred <- bake(dummy_trained, new_data = sacr_fac, all_predictors())
-  glimpse(dummy_pred)
 
-  cat(dummy_pred[[1]])
   expect_false(any(colnames(dummy_pred) == "city"))
   expect_false(any(colnames(dummy_pred) == "zip"))
 
@@ -49,9 +47,6 @@ test_that("dummy variables with factor inputs", {
   exp_res <- as.data.frame(exp_res)
   rownames(exp_res) <- NULL
   expect_equal(dummy_pred, exp_res, ignore_attr = TRUE)
-
-  glimpse(exp_res)
-  cat(exp_res[[1]])
 
   dum_tibble <-
     tibble(terms = c("city", "zip"), columns = rep(rlang::na_chr, 2), id = "")
@@ -176,14 +171,9 @@ test_that("make sure contrasts argument work", {
     data = sacr_fac,
     contrasts.arg = setNames(list(contr.poly), pred)
   )
-  colnames(tmp) <- gsub(paste0("^", pred), paste0(pred, "_"), colnames(tmp))
   exp_res <- as_tibble(tmp %*% attr(tmp, "contrasts")[[pred]])
-  colnames(exp_res) <- paste0("city_", make.names(colnames(exp_res)))
 
-  # Make sure they have same order
-  exp_res <- exp_res[names(dummy_pred)]
-
-  expect_identical(dummy_pred, exp_res)
+  expect_identical(unname(dummy_pred), unname(exp_res))
 })
 
 test_that("make sure contrasts argument work for ordered factors", {

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -258,6 +258,20 @@ test_that("make sure contrasts argument is checked", {
   )
 })
 
+test_that("getOption('contrasts') gives deprecation warning in step_dummy", {
+  param <- getOption("contrasts")
+
+  go_helmert <- param
+  go_helmert["unordered"] <- "contr.helmert"
+  withr::local_options("contrasts" = go_helmert)
+
+  expect_snapshot(
+    tmp <- recipe(~., data = iris) %>%
+      step_dummy(Species) %>%
+      prep()
+  )
+})
+
 test_that("tests for issue #91", {
   rec <- recipe(~city, data = sacr)
   factors <- rec %>% step_dummy(city)

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -30,7 +30,9 @@ test_that("dummy variables with factor inputs", {
     verbose = FALSE
   )
   dummy_pred <- bake(dummy_trained, new_data = sacr_fac, all_predictors())
+  glimpse(dummy_pred)
 
+  cat(dummy_pred[[1]])
   expect_false(any(colnames(dummy_pred) == "city"))
   expect_false(any(colnames(dummy_pred) == "zip"))
 
@@ -47,6 +49,9 @@ test_that("dummy variables with factor inputs", {
   exp_res <- as.data.frame(exp_res)
   rownames(exp_res) <- NULL
   expect_equal(dummy_pred, exp_res, ignore_attr = TRUE)
+
+  glimpse(exp_res)
+  cat(exp_res[[1]])
 
   dum_tibble <-
     tibble(terms = c("city", "zip"), columns = rep(rlang::na_chr, 2), id = "")

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -269,15 +269,16 @@ test_that("getOption('contrasts') gives deprecation warning in step_dummy", {
 
 test_that("backwards compatible for contrasts", {
   rec <- recipe(~., data = iris) %>%
-    step_dummy(Species)
+    step_dummy(Species) %>%
+    prep()
 
-  exp_res <- prep(rec)
+  exp <- bake(rec, iris)
 
   rec$steps[[1]]$contrasts <- NULL
 
   expect_identical(
-    prep(rec),
-    exp_res
+    bake(rec, iris),
+    exp
   )
 })
 

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -267,6 +267,20 @@ test_that("getOption('contrasts') gives deprecation warning in step_dummy", {
   )
 })
 
+test_that("backwards compatible for contrasts", {
+  rec <- recipe(~., data = iris) %>%
+    step_dummy(Species)
+
+  exp_res <- prep(rec)
+
+  rec$steps[[1]]$contrasts <- NULL
+
+  expect_identical(
+    prep(rec),
+    exp_res
+  )
+})
+
 test_that("tests for issue #91", {
   rec <- recipe(~city, data = sacr)
   factors <- rec %>% step_dummy(city)

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -157,7 +157,7 @@ test_that("make sure contrasts argument work", {
     data = sacr_fac,
     strings_as_factors = FALSE
   )
-  dummy <- rec %>% step_dummy(city, contrasts = contr.poly, id = "")
+  dummy <- rec %>% step_dummy(city, contrasts = "contr.poly", id = "")
   dummy_trained <- prep(
     dummy,
     training = sacr_fac,
@@ -186,9 +186,10 @@ test_that("make sure contrasts argument work for ordered factors", {
   dummy <- rec %>%
     step_dummy(
       city,
+      one_hot = TRUE,
       contrasts = list(
-        unordered = contr.poly,
-        ordered = contr.treatment
+        unordered = "contr.poly",
+        ordered = "contr.treatment"
       ),
       id = ""
     )
@@ -198,14 +199,17 @@ test_that("make sure contrasts argument work for ordered factors", {
     verbose = FALSE
   )
   dummy_pred <- bake(dummy_trained, new_data = sacr_fac)
+  dummy_pred <- as.data.frame(dummy_pred)
+  rownames(dummy_pred) <- NULL
 
   pred <- "city"
   tmp <- model.matrix(
     as.formula(paste("~", pred, "+ 0")),
     data = sacr_fac,
-    contrasts.arg = setNames(list(contr.treatment), pred)
+    contrasts.arg = setNames(list("contr.treatment"), pred)
   )
-  exp_res <- as_tibble(tmp %*% attr(tmp, "contrasts")[[pred]])
+  exp_res <- as.data.frame(tmp)
+  rownames(exp_res) <- NULL
 
   expect_identical(unname(dummy_pred), unname(exp_res))
 })
@@ -228,7 +232,7 @@ test_that("make sure contrasts argument is checked", {
   expect_snapshot(
     error = TRUE,
     recipe(~Species, iris) %>%
-      step_dummy(Species, contrasts = list(ordered = contr.treatment)) %>%
+      step_dummy(Species, contrasts = list(ordered = "contr.treatment")) %>%
       prep()
   )
 
@@ -237,7 +241,7 @@ test_that("make sure contrasts argument is checked", {
     recipe(~Species, iris) %>%
       step_dummy(
         Species,
-        contrasts = list(ordered = 1, unordered = contr.treatment)
+        contrasts = list(ordered = 1, unordered = "contr.treatment")
       ) %>%
       prep()
   )
@@ -247,7 +251,7 @@ test_that("make sure contrasts argument is checked", {
     recipe(~Species, iris) %>%
       step_dummy(
         Species,
-        contrasts = list(ordered = contr.treatment, unordered = 1)
+        contrasts = list(ordered = "contr.treatment", unordered = 1)
       ) %>%
       prep()
   )
@@ -577,7 +581,7 @@ test_that("sparse = 'yes' works", {
 
 test_that("sparse = 'yes' will go back to 'no' on unsupported contrasts", {
   rec <- recipe(~., data = tibble(x = letters)) %>%
-    step_dummy(x, sparse = "yes", contrasts = contr.helmert) %>%
+    step_dummy(x, sparse = "yes", contrasts = "contr.helmert") %>%
     prep()
 
   res <- bake(rec, tibble(x = letters))

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -445,12 +445,8 @@ test_that("sparse = 'yes' works", {
 })
 
 test_that("sparse = 'yes' will go back to 'no' on unsupported contrasts", {
-  go_helmert <- getOption("contrasts")
-  go_helmert["unordered"] <- "contr.helmert"
-  withr::local_options(contrasts = go_helmert)
-
   rec <- recipe(~., data = tibble(x = letters)) %>%
-    step_dummy(x, sparse = "yes") %>%
+    step_dummy(x, sparse = "yes", contrasts = contr.helmert) %>%
     prep()
 
   res <- bake(rec, tibble(x = letters))

--- a/tests/testthat/test-dummy.R
+++ b/tests/testthat/test-dummy.R
@@ -215,6 +215,49 @@ test_that("make sure contrasts argument work for ordered factors", {
   expect_identical(unname(dummy_pred), unname(exp_res))
 })
 
+test_that("make sure contrasts argument is checked", {
+  expect_snapshot(
+    error = TRUE,
+    recipe(~Species, iris) %>%
+      step_dummy(Species, contrasts = TRUE) %>%
+      prep()
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~Species, iris) %>%
+      step_dummy(Species, contrasts = list()) %>%
+      prep()
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~Species, iris) %>%
+      step_dummy(Species, contrasts = list(ordered = contr.treatment)) %>%
+      prep()
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~Species, iris) %>%
+      step_dummy(
+        Species,
+        contrasts = list(ordered = 1, unordered = contr.treatment)
+      ) %>%
+      prep()
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(~Species, iris) %>%
+      step_dummy(
+        Species,
+        contrasts = list(ordered = contr.treatment, unordered = 1)
+      ) %>%
+      prep()
+  )
+})
+
 test_that("tests for issue #91", {
   rec <- recipe(~city, data = sacr)
   factors <- rec %>% step_dummy(city)

--- a/tests/testthat/test-skipping.R
+++ b/tests/testthat/test-skipping.R
@@ -50,6 +50,7 @@ test_that("check existing steps for `skip` arg", {
   step_check <- step_check[step_check != "check_bake_role_requirements"]
   step_check <- step_check[step_check != "check_step_check_args"]
   step_check <- step_check[step_check != "check_sparse_arg"]
+  step_check <- step_check[step_check != "check_contrasts_arg"]
   step_check <- step_check[step_check != "check_zv"]
 
   # R/import-standalone-types-check.R

--- a/vignettes/Dummies.Rmd
+++ b/vignettes/Dummies.Rmd
@@ -54,7 +54,7 @@ bake(ref_cell, new_data = NULL, original, starts_with("Species")) %>% distinct()
 
 Note that the column that was used to make the new columns (`Species`) is no longer there. See the section below on obtaining the entire set of _C_ columns. 
 
-There are different types of contrasts that can be used for different types of factors. The defaults are `contr.treatment()` for unordered and `contr.poly()` for ordered factors.
+There are different types of contrasts that can be used for different types of factors. The defaults are `"contr.treatment"` for unordered and `"contr.poly"` for ordered factors.
 
 Looking at `?contrast`, there are other options. One alternative is the little known Helmert contrast:
 
@@ -66,7 +66,7 @@ To get this encoding you can use the `contrasts` argument like so:, the global o
 # now make dummy variables with new parameterization
 helmert <- 
   iris_rec %>% 
-  step_dummy(Species, contrasts = contr.helmert) %>%
+  step_dummy(Species, contrasts = "contr.helmert") %>%
   prep(training = iris)
 summary(helmert)
 
@@ -196,7 +196,7 @@ hot_reference
 
 hot_helmert <- 
   iris_rec %>% 
-  step_dummy(Species, one_hot = TRUE, contrasts = contr.helmert) %>%
+  step_dummy(Species, one_hot = TRUE, contrasts = "contr.helmert") %>%
   prep(training = iris) %>%
   bake(original, new_data = NULL, starts_with("Species")) %>%
   distinct()

--- a/vignettes/Dummies.Rmd
+++ b/vignettes/Dummies.Rmd
@@ -54,36 +54,23 @@ bake(ref_cell, new_data = NULL, original, starts_with("Species")) %>% distinct()
 
 Note that the column that was used to make the new columns (`Species`) is no longer there. See the section below on obtaining the entire set of _C_ columns. 
 
-There are different types of contrasts that can be used for different types of factors. The defaults are:
-
-```{r defaults}
-param <- getOption("contrasts")
-param
-```
+There are different types of contrasts that can be used for different types of factors. The defaults are `contr.treatment()` for unordered and `contr.poly()` for ordered factors.
 
 Looking at `?contrast`, there are other options. One alternative is the little known Helmert contrast:
 
 > `contr.helmert` returns Helmert contrasts, which contrast the second level with the first, the third with the average of the first two, and so on. 
 
-To get this encoding, the global option for the contrasts can be changed and saved. [`step_dummy`](https://recipes.tidymodels.org/reference/step_dummy.html) picks up on this and makes the correct calculations:
+To get this encoding you can use the `contrasts` argument like so:, the global option for the contrasts can be changed and saved. [`step_dummy`](https://recipes.tidymodels.org/reference/step_dummy.html) picks up on this and makes the correct calculations:
 
 ```{r iris-helmert}
-# change it:
-go_helmert <- param
-go_helmert["unordered"] <- "contr.helmert"
-options(contrasts = go_helmert)
-
 # now make dummy variables with new parameterization
 helmert <- 
   iris_rec %>% 
-  step_dummy(Species) %>%
+  step_dummy(Species, contrasts = contr.helmert) %>%
   prep(training = iris)
 summary(helmert)
 
 bake(helmert, new_data = NULL, original, starts_with("Species")) %>% distinct()
-
-# Yuk; go back to the original method
-options(contrasts = param)
 ```
 
 Note that the column names do not reference a specific level of the species variable. This contrast function has columns that can involve multiple levels; level-specific columns wouldn't make sense. 
@@ -207,12 +194,9 @@ hot_reference <-
 
 hot_reference
 
-# from above
-options(contrasts = go_helmert)
-
 hot_helmert <- 
   iris_rec %>% 
-  step_dummy(Species, one_hot = TRUE) %>%
+  step_dummy(Species, one_hot = TRUE, contrasts = contr.helmert) %>%
   prep(training = iris) %>%
   bake(original, new_data = NULL, starts_with("Species")) %>%
   distinct()


### PR DESCRIPTION
To close https://github.com/tidymodels/recipes/issues/1349

This PR:

- Adds `contrasts` argument to `step_dummy()`. It takes a single contrast function or a a list of contrasts functions as input. I intentionally didn't allow string representation `c(unordered = "contr.treatment)` as it feels messy AND it would be annoying for parallel processing.
- Added a deprecation warning if someone sets `option(contrasts)` (by checking if it is different that default) to steer them towards using the explicit argument.
- Updated documentation to to reflect this both in function and dummies vignette.

## Revdepcheck

Ran clean

## Books/websites

Not used: https://github.com/search?q=org:tidymodels+getOption+contrasts&type=code