### PR TITLE
don't pick up tune() from parsnip objects in tune_args()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* Fixed bug where `tune_args()` would error if argument to step had a parsnip object with tuned arguments. ($1506)
+
 # recipes 1.3.0
 
 * Fixed printing for `step_geodist()` when no variables are selected. (#1423)

--- a/R/tune_args.R
+++ b/R/tune_args.R
@@ -147,6 +147,9 @@ find_tune_id <- function(x) {
   if (length(x) == 0L) {
     return(NA_character_)
   }
+  if (is.list(x) && !inherits(x, "list")) {
+    return(NA_character_)
+  }
 
   # turn quosures into expressions before continuing
   if (rlang::is_quosures(x)) {

--- a/tests/testthat/test-tune_args.R
+++ b/tests/testthat/test-tune_args.R
@@ -65,3 +65,21 @@ test_that("tune_args() doesn't error on namespaced selectors", {
     exp
   )
 })
+
+test_that("tune_args() wont detect tune() calls in parsnip objects (#1506)", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("rpart")
+
+  base_model <- parsnip::decision_tree(cost_complexity = hardhat::tune())
+
+  rec_empty <- recipe(mpg ~ ., data = mtcars) |>
+    step_testthat_helper(output = base_model)
+
+  rec_mod <- recipe(mpg ~ ., data = mtcars) |>
+    step_testthat_helper()
+
+  expect_identical(
+    extract_parameter_set_dials(rec_empty),
+    extract_parameter_set_dials(rec_mod)
+  )
+})


### PR DESCRIPTION
to close #1506 