### PR TITLE
fix: typo in `step_select` deprecation message

### DIFF
--- a/R/select.R
+++ b/R/select.R
@@ -86,7 +86,7 @@ step_select <- function(
   lifecycle::deprecate_warn(
     when = "1.3.0",
     what = "step_select()",
-    details = "See `?select_select()` for recommended alternatives."
+    details = "See `?step_select()` for recommended alternatives."
   )
   add_step(
     recipe,


### PR DESCRIPTION
fixes a typo in `step_select` deprecation warning