### PR TITLE
add to docs missing zero padding in generated varnames #1505

### DIFF
--- a/man/rmd/num_comp.Rmd
+++ b/man/rmd/num_comp.Rmd
@@ -1,7 +1,7 @@
 ```{r}
 #| include: false
 low_range <- paste0("\`", prefix, 1, "\` - \`", prefix, 9, "\`")
-high_range <- paste0("\`", prefix, 001, "\` - \`", prefix, 101, "\`")
+high_range <- paste0("\`", prefix, "001", "\` - \`", prefix, "101", "\`")
 ```
 
 The argument `num_comp` controls the number of components that will be retained


### PR DESCRIPTION
Several functions generate new variable names using sequential numbers at the end of the new names (i.e., PS001 - PS105). The functions behave properly, but the documentation had the paste function to create these new variable names using the numeral 001 rather than string 001, rendering the documentation to label ranges for larger values to be "PS1 through PS101" rather than the expected "PS001 through PS101". Quotations added to the paste function around the numerals with leading zeroes that define the range to display these ranges properly in the documentation.