### PR TITLE
Document step_interact formula unquoting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # recipes (development version)
 
+* `step_interact()` now documents how to pass interaction formulas stored in
+  separate objects (#1530).
+
 # recipes 1.3.3
 
 * Specify mixOmics as a suggested package. (#1544)

--- a/R/interact.R
+++ b/R/interact.R
@@ -29,6 +29,10 @@
 #' contains terms other than interactions (e.g. `(A+B+C)^3`) only the
 #' interaction terms are retained for the design matrix.
 #'
+#' If the interaction formula is stored in a separate object, unquote it when
+#' passing it to `terms`, e.g. `int_terms <- ~ A:B` followed by
+#' `step_interact(terms = !!int_terms)`.
+#'
 #' The separator between the variables defaults to "`_x_`" so that the three way
 #' interaction shown previously would generate a column named `A_x_B_x_C`. This
 #' can be changed using the `sep` argument.

--- a/man/step_interact.Rd
+++ b/man/step_interact.Rd
@@ -69,6 +69,10 @@ used to make a three way interaction between the variables. If the formula
 contains terms other than interactions (e.g. \code{(A+B+C)^3}) only the
 interaction terms are retained for the design matrix.
 
+If the interaction formula is stored in a separate object, unquote it when
+passing it to \code{terms}, e.g. \code{int_terms <- ~ A:B} followed by
+\code{step_interact(terms = !!int_terms)}.
+
 The separator between the variables defaults to "\verb{_x_}" so that the three way
 interaction shown previously would generate a column named \code{A_x_B_x_C}. This
 can be changed using the \code{sep} argument.


### PR DESCRIPTION
Fixes #1530.

This documents the `step_interact()` quirk discussed in the issue: when an interaction formula is stored in a separate object, it should be unquoted when passed to `terms`, e.g. `step_interact(terms = !!int_terms)`.

Checks:
- Focused check that `step_interact(rec, terms = !!int_terms)` constructs the step successfully
- `Rscript -e 'tools::checkRd("man/step_interact.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/tune-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests recipes_1.3.3.9000.tar.gz`