### PR TITLE
Add stop_at argument to bake()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* `bake()` gained a `stop_at` argument, which takes a step number or step id and applies only the steps up to and including that step. This is useful for diagnostics such as visualizing the effect of each step. (#1551)
+
 # recipes 1.3.3
 
 * Specify mixOmics as a suggested package. (#1544)

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -892,16 +892,22 @@ resolve_stop_at <- function(stop_at, object, call = caller_env()) {
     )
   }
 
-  if (is.character(stop_at)) {
-    check_string(stop_at, arg = "stop_at", call = call)
+  if (length(stop_at) != 1 || is.na(stop_at)) {
+    cli::cli_abort(
+      "{.arg stop_at} must be a single step number or step id, \\
+      not {.obj_type_friendly {stop_at}}.",
+      call = call
+    )
+  }
 
+  if (is.character(stop_at)) {
     ids <- map_chr(object$steps, \(x) x$id)
     loc <- which(ids == stop_at)
 
     if (length(loc) == 0) {
       cli::cli_abort(
         c(
-          "x" = "{.arg stop_at} must be a step number or step id, \\
+          "x" = "{.arg stop_at} must be a single step number or step id, \\
                  not {.val {stop_at}}.",
           "i" = "The step ids of {.arg object} are {.or {.val {ids}}}."
         ),
@@ -914,20 +920,23 @@ resolve_stop_at <- function(stop_at, object, call = caller_env()) {
 
   if (!is.numeric(stop_at)) {
     cli::cli_abort(
-      "{.arg stop_at} must be a whole number or a string, \\
+      "{.arg stop_at} must be a single step number or step id, \\
       not {.obj_type_friendly {stop_at}}.",
       call = call
     )
   }
 
-  check_number_whole(stop_at, min = 1, arg = "stop_at", call = call)
-
-  if (stop_at > n_steps) {
+  if (!is.finite(stop_at) || stop_at != trunc(stop_at)) {
     cli::cli_abort(
-      c(
-        "x" = "{.arg stop_at} must be a step number, not {stop_at}.",
-        "i" = "{.arg object} has {n_steps} step{?s}."
-      ),
+      "{.arg stop_at} must be a whole step number, not {stop_at}.",
+      call = call
+    )
+  }
+
+  if (stop_at < 1 || stop_at > n_steps) {
+    cli::cli_abort(
+      "{.arg stop_at} must be a step number between 1 and {n_steps}, \\
+      not {stop_at}.",
       call = call
     )
   }

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -934,13 +934,11 @@ resolve_stop_at <- function(stop_at, object, call = caller_env()) {
   }
 
   if (stop_at < 1 || stop_at > n_steps) {
-    allowed <- if (n_steps == 1) "1" else paste0("between 1 and ", n_steps)
-
     cli::cli_abort(
       c(
         "x" = "{.arg stop_at} must be a step number, not {stop_at}.",
         "i" = "{.arg object} has {n_steps} step{?s}, so {.arg stop_at} must \\
-               be {allowed}."
+               be {cli::qty(n_steps)}{?/between 1 and }{n_steps}."
       ),
       call = call
     )

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -664,6 +664,10 @@ prep.recipe <-
 #'   `new_data`, the pre-processed _training data_ will be returned (assuming
 #'   that `prep(retain = TRUE)` was used). See [sparse_data] for more
 #'   information about use of sparse data.
+#' @param stop_at A single step number or step `id` (as returned by
+#'   [tidy.recipe()]). If supplied, only the steps up to and including that
+#'   step are applied to `new_data`. The default, `NULL`, applies all steps.
+#'   Cannot be used with `new_data = NULL`.
 #' @param composition Either `"tibble"`, `"matrix"`, `"data.frame"`, or
 #'   `"dgCMatrix"``for the format of the processed data set. Also, note that
 #'   this argument should be called **after** any selectors and the selectors
@@ -687,6 +691,13 @@ prep.recipe <-
 #' Also, any steps with `skip = TRUE` will not be applied to the data when
 #' [bake()] is invoked with a data set in `new_data`. `bake(object, new_data =
 #' NULL)` will always have all of the steps applied.
+#'
+#' The `stop_at` argument returns the data as it exists partway through the
+#' recipe, which is useful for diagnostics such as visualizing the effect of
+#' each step. It cannot be used with `new_data = NULL` since the intermediate
+#' versions of the training set are not retained by [prep()]; pass the training
+#' data to `new_data` instead. Steps with `skip = TRUE` are still skipped, but
+#' they are counted when numbering steps.
 #'
 #' @return
 #'
@@ -718,6 +729,9 @@ prep.recipe <-
 #' # only return selected variables:
 #' bake(ames_rec, new_data = head(ames), all_numeric_predictors())
 #' bake(ames_rec, new_data = head(ames), starts_with(c("Longitude", "Latitude")))
+#'
+#' # only apply the first two steps:
+#' bake(ames_rec, new_data = head(ames), stop_at = 2)
 #' @export
 bake <- function(object, ...) {
   UseMethod("bake")
@@ -725,7 +739,13 @@ bake <- function(object, ...) {
 
 #' @rdname bake
 #' @export
-bake.recipe <- function(object, new_data, ..., composition = "tibble") {
+bake.recipe <- function(
+  object,
+  new_data,
+  ...,
+  stop_at = NULL,
+  composition = "tibble"
+) {
   if (rlang::is_missing(new_data)) {
     cli::cli_abort(
       "{.arg new_data} must be either a data frame or NULL. \\
@@ -734,6 +754,17 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   }
 
   if (is.null(new_data)) {
+    if (!is.null(stop_at)) {
+      cli::cli_abort(
+        c(
+          "x" = "{.arg stop_at} cannot be used with {.code new_data = NULL}.",
+          "i" = "Intermediate versions of the training set are not retained \\
+                 by {.fun prep}; pass the training data to {.arg new_data} \\
+                 instead."
+        )
+      )
+    }
+
     return(juice(object, ..., composition = composition))
   }
 
@@ -782,7 +813,16 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   bakeable_names <- intersect(original_training_names, original_names)
   new_data <- new_data[, bakeable_names]
 
-  n_steps <- length(object$steps)
+  n_steps <- resolve_stop_at(stop_at, object)
+
+  # `last_term_info` describes the data after *all* steps, so it cannot be used
+  # when only some of the steps are applied. Instead, the term information is
+  # tracked as each step is applied, mirroring what `prep()` does.
+  partial <- !is.null(stop_at)
+  if (partial) {
+    info <- object$var_info
+    seen_vars <- info$variable
+  }
 
   for (i in seq_len(n_steps)) {
     step <- object$steps[[i]]
@@ -804,13 +844,16 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
         )
       )
     }
+
+    if (partial) {
+      info <- update_term_info(info, new_data, step, seen_vars)
+      seen_vars <- union(seen_vars, info$variable)
+    }
   }
 
-  # Use `last_term_info`, which maintains info on all columns that got added
-  # and removed from the training data. This is important for skipped steps
-  # which might have resulted in columns not being added/removed in the test
-  # set.
-  info <- object$last_term_info
+  if (!partial) {
+    info <- object$last_term_info
+  }
 
   # Handle old grouped data.frames
   if (!is.null(attr(info, "vars"))) {
@@ -833,6 +876,81 @@ bake.recipe <- function(object, new_data, ..., composition = "tibble") {
   new_data <- hardhat::recompose(new_data, composition = composition)
 
   new_data
+}
+
+resolve_stop_at <- function(stop_at, object, call = caller_env()) {
+  n_steps <- length(object$steps)
+
+  if (is.null(stop_at)) {
+    return(n_steps)
+  }
+
+  if (n_steps == 0) {
+    cli::cli_abort(
+      "{.arg stop_at} cannot be used with a recipe that has no steps.",
+      call = call
+    )
+  }
+
+  if (is.character(stop_at)) {
+    check_string(stop_at, arg = "stop_at", call = call)
+
+    ids <- map_chr(object$steps, \(x) x$id)
+    loc <- which(ids == stop_at)
+
+    if (length(loc) == 0) {
+      cli::cli_abort(
+        c(
+          "x" = "{.arg stop_at} must be a step number or step id, \\
+                 not {.val {stop_at}}.",
+          "i" = "The step ids of {.arg object} are {.or {.val {ids}}}."
+        ),
+        call = call
+      )
+    }
+
+    return(loc[[1]])
+  }
+
+  if (!is.numeric(stop_at)) {
+    cli::cli_abort(
+      "{.arg stop_at} must be a whole number or a string, \\
+      not {.obj_type_friendly {stop_at}}.",
+      call = call
+    )
+  }
+
+  check_number_whole(stop_at, min = 1, arg = "stop_at", call = call)
+
+  if (stop_at > n_steps) {
+    cli::cli_abort(
+      c(
+        "x" = "{.arg stop_at} must be a step number, not {stop_at}.",
+        "i" = "{.arg object} has {n_steps} step{?s}."
+      ),
+      call = call
+    )
+  }
+
+  as.integer(stop_at)
+}
+
+# Update the term information after a single step has been applied, using the
+# same rules as `prep()`. `seen_vars` are all of the variables that have been
+# seen up to this point, so that newly created columns can be identified.
+update_term_info <- function(info, new_data, step, seen_vars) {
+  info <- merge_term_info(get_types(new_data), info)
+
+  if (!is.na(step$role)) {
+    pos_new_var <- !info$variable %in% seen_vars
+    pos_new_and_na_role <- pos_new_var & is.na(info$role)
+    pos_new_and_na_source <- pos_new_var & is.na(info$source)
+
+    info$role[pos_new_and_na_role] <- step$role
+    info$source[pos_new_and_na_source] <- "derived"
+  }
+
+  info
 }
 
 turn_strings_to_factors <- function(object, new_data) {

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -934,9 +934,14 @@ resolve_stop_at <- function(stop_at, object, call = caller_env()) {
   }
 
   if (stop_at < 1 || stop_at > n_steps) {
+    allowed <- if (n_steps == 1) "1" else paste0("between 1 and ", n_steps)
+
     cli::cli_abort(
-      "{.arg stop_at} must be a step number between 1 and {n_steps}, \\
-      not {stop_at}.",
+      c(
+        "x" = "{.arg stop_at} must be a step number, not {stop_at}.",
+        "i" = "{.arg object} has {n_steps} step{?s}, so {.arg stop_at} must \\
+               be {allowed}."
+      ),
       call = call
     )
   }

--- a/man/bake.Rd
+++ b/man/bake.Rd
@@ -7,7 +7,7 @@
 \usage{
 bake(object, ...)
 
-\method{bake}{recipe}(object, new_data, ..., composition = "tibble")
+\method{bake}{recipe}(object, new_data, ..., stop_at = NULL, composition = "tibble")
 }
 \arguments{
 \item{object}{A trained object such as a \code{\link[=recipe]{recipe()}} with at least one
@@ -22,6 +22,11 @@ package for whom the preprocessing will be applied. If \code{NULL} is given to
 \code{new_data}, the pre-processed \emph{training data} will be returned (assuming
 that \code{prep(retain = TRUE)} was used). See \link{sparse_data} for more
 information about use of sparse data.}
+
+\item{stop_at}{A single step number or step \code{id} (as returned by
+\code{\link[=tidy.recipe]{tidy.recipe()}}). If supplied, only the steps up to and including that
+step are applied to \code{new_data}. The default, \code{NULL}, applies all steps.
+Cannot be used with \code{new_data = NULL}.}
 
 \item{composition}{Either \code{"tibble"}, \code{"matrix"}, \code{"data.frame"}, or
 \verb{"dgCMatrix"``for the format of the processed data set. Also, note that this argument should be called **after** any selectors and the selectors should only resolve to numeric columns if }composition\verb{is set to}"matrix"\code{or}"dgCMatrix"\verb{. If the data contains sparse columns they will be perseved for }"tibble"\code{and}"data.frame"\verb{, and efficiently used for }"dgCMatrix"`.}
@@ -46,6 +51,13 @@ free.
 
 Also, any steps with \code{skip = TRUE} will not be applied to the data when
 \code{\link[=bake]{bake()}} is invoked with a data set in \code{new_data}. \code{bake(object, new_data = NULL)} will always have all of the steps applied.
+
+The \code{stop_at} argument returns the data as it exists partway through the
+recipe, which is useful for diagnostics such as visualizing the effect of
+each step. It cannot be used with \code{new_data = NULL} since the intermediate
+versions of the training set are not retained by \code{\link[=prep]{prep()}}; pass the training
+data to \code{new_data} instead. Steps with \code{skip = TRUE} are still skipped, but
+they are counted when numbering steps.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) withAutoprint(\{ # examplesIf}
@@ -71,6 +83,9 @@ bake(ames_rec, new_data = head(ames))
 # only return selected variables:
 bake(ames_rec, new_data = head(ames), all_numeric_predictors())
 bake(ames_rec, new_data = head(ames), starts_with(c("Longitude", "Latitude")))
+
+# only apply the first two steps:
+bake(ames_rec, new_data = head(ames), stop_at = 2)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/tests/testthat/_snaps/bake.md
+++ b/tests/testthat/_snaps/bake.md
@@ -1,0 +1,67 @@
+# bake() errors on bad stop_at
+
+    Code
+      bake(car_rec, mtcars, stop_at = 2)
+    Condition
+      Error in `bake()`:
+      x `stop_at` must be a step number, not 2.
+      i `object` has 1 step.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = 0)
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a whole number larger than or equal to 1, not the number 0.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = 1.5)
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a whole number, not the number 1.5.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = "nope")
+    Condition
+      Error in `bake()`:
+      x `stop_at` must be a step number or step id, not "nope".
+      i The step ids of `object` are "center".
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = TRUE)
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a whole number or a string, not `TRUE`.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = c(1, 1))
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a whole number, not a double vector.
+
+---
+
+    Code
+      bake(car_rec, new_data = NULL, stop_at = 1)
+    Condition
+      Error in `bake()`:
+      x `stop_at` cannot be used with `new_data = NULL`.
+      i Intermediate versions of the training set are not retained by `prep()`; pass the training data to `new_data` instead.
+
+---
+
+    Code
+      bake(prep(recipe(cyl ~ ., mtcars)), mtcars, stop_at = 1)
+    Condition
+      Error in `bake()`:
+      ! `stop_at` cannot be used with a recipe that has no steps.
+

--- a/tests/testthat/_snaps/bake.md
+++ b/tests/testthat/_snaps/bake.md
@@ -4,7 +4,8 @@
       bake(car_rec, mtcars, stop_at = 2)
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a step number between 1 and 1, not 2.
+      x `stop_at` must be a step number, not 2.
+      i `object` has 1 step, so `stop_at` must be 1.
 
 ---
 
@@ -12,7 +13,8 @@
       bake(car_rec, mtcars, stop_at = 0)
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a step number between 1 and 1, not 0.
+      x `stop_at` must be a step number, not 0.
+      i `object` has 1 step, so `stop_at` must be 1.
 
 ---
 
@@ -21,6 +23,15 @@
     Condition
       Error in `bake()`:
       ! `stop_at` must be a whole step number, not 1.5.
+
+---
+
+    Code
+      bake(multi_rec, mtcars, stop_at = 9)
+    Condition
+      Error in `bake()`:
+      x `stop_at` must be a step number, not 9.
+      i `object` has 2 steps, so `stop_at` must be between 1 and 2.
 
 ---
 

--- a/tests/testthat/_snaps/bake.md
+++ b/tests/testthat/_snaps/bake.md
@@ -4,8 +4,7 @@
       bake(car_rec, mtcars, stop_at = 2)
     Condition
       Error in `bake()`:
-      x `stop_at` must be a step number, not 2.
-      i `object` has 1 step.
+      ! `stop_at` must be a step number between 1 and 1, not 2.
 
 ---
 
@@ -13,7 +12,7 @@
       bake(car_rec, mtcars, stop_at = 0)
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a whole number larger than or equal to 1, not the number 0.
+      ! `stop_at` must be a step number between 1 and 1, not 0.
 
 ---
 
@@ -21,7 +20,7 @@
       bake(car_rec, mtcars, stop_at = 1.5)
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a whole number, not the number 1.5.
+      ! `stop_at` must be a whole step number, not 1.5.
 
 ---
 
@@ -29,7 +28,7 @@
       bake(car_rec, mtcars, stop_at = "nope")
     Condition
       Error in `bake()`:
-      x `stop_at` must be a step number or step id, not "nope".
+      x `stop_at` must be a single step number or step id, not "nope".
       i The step ids of `object` are "center".
 
 ---
@@ -38,7 +37,7 @@
       bake(car_rec, mtcars, stop_at = TRUE)
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a whole number or a string, not `TRUE`.
+      ! `stop_at` must be a single step number or step id, not `TRUE`.
 
 ---
 
@@ -46,7 +45,23 @@
       bake(car_rec, mtcars, stop_at = c(1, 1))
     Condition
       Error in `bake()`:
-      ! `stop_at` must be a whole number, not a double vector.
+      ! `stop_at` must be a single step number or step id, not a double vector.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = NA)
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a single step number or step id, not `NA`.
+
+---
+
+    Code
+      bake(car_rec, mtcars, stop_at = integer(0))
+    Condition
+      Error in `bake()`:
+      ! `stop_at` must be a single step number or step id, not an empty integer vector.
 
 ---
 

--- a/tests/testthat/test-bake.R
+++ b/tests/testthat/test-bake.R
@@ -108,6 +108,14 @@ test_that("bake() errors on bad stop_at", {
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 2))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 0))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 1.5))
+
+  multi_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    step_scale(all_predictors()) |>
+    prep()
+
+  expect_snapshot(error = TRUE, bake(multi_rec, mtcars, stop_at = 9))
+
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = "nope"))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = TRUE))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = c(1, 1)))

--- a/tests/testthat/test-bake.R
+++ b/tests/testthat/test-bake.R
@@ -111,6 +111,8 @@ test_that("bake() errors on bad stop_at", {
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = "nope"))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = TRUE))
   expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = c(1, 1)))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = NA))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = integer(0)))
   expect_snapshot(error = TRUE, bake(car_rec, new_data = NULL, stop_at = 1))
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-bake.R
+++ b/tests/testthat/test-bake.R
@@ -25,6 +25,99 @@ test_that("can use tidyselect ops in bake() and juice() column selection", {
   expect_named(y, "carb")
 })
 
+test_that("bake() can stop after a given step number", {
+  car_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    step_pca(all_predictors(), num_comp = 2) |>
+    prep()
+
+  first_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    prep()
+
+  expect_identical(
+    bake(car_rec, mtcars, stop_at = 1),
+    bake(first_rec, mtcars)
+  )
+  expect_identical(
+    bake(car_rec, mtcars, stop_at = 2),
+    bake(car_rec, mtcars)
+  )
+})
+
+test_that("bake() can stop after a given step id", {
+  car_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    step_pca(all_predictors(), num_comp = 2) |>
+    prep()
+
+  expect_identical(
+    bake(car_rec, mtcars, stop_at = car_rec$steps[[1]]$id),
+    bake(car_rec, mtcars, stop_at = 1)
+  )
+})
+
+test_that("bake() with stop_at works with selectors and composition", {
+  car_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    step_pca(all_predictors(), num_comp = 2) |>
+    prep()
+
+  expect_named(
+    bake(car_rec, mtcars, all_numeric_predictors(), stop_at = 2),
+    c("PC1", "PC2")
+  )
+  expect_named(
+    bake(car_rec, mtcars, starts_with("d"), stop_at = 1),
+    c("disp", "drat")
+  )
+  expect_s4_class(
+    bake(
+      car_rec,
+      mtcars,
+      all_predictors(),
+      stop_at = 1,
+      composition = "dgCMatrix"
+    ),
+    "dgCMatrix"
+  )
+})
+
+test_that("bake() with stop_at still skips steps with skip = TRUE", {
+  car_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors()) |>
+    step_filter(mpg > 0, skip = TRUE) |>
+    step_scale(all_predictors()) |>
+    prep()
+
+  expect_identical(
+    bake(car_rec, mtcars, stop_at = 2),
+    bake(car_rec, mtcars, stop_at = 1)
+  )
+  expect_identical(
+    bake(car_rec, mtcars, stop_at = 3),
+    bake(car_rec, mtcars)
+  )
+})
+
+test_that("bake() errors on bad stop_at", {
+  car_rec <- recipe(cyl ~ ., mtcars) |>
+    step_center(all_predictors(), id = "center") |>
+    prep()
+
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 2))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 0))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = 1.5))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = "nope"))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = TRUE))
+  expect_snapshot(error = TRUE, bake(car_rec, mtcars, stop_at = c(1, 1)))
+  expect_snapshot(error = TRUE, bake(car_rec, new_data = NULL, stop_at = 1))
+  expect_snapshot(
+    error = TRUE,
+    bake(prep(recipe(cyl ~ ., mtcars)), mtcars, stop_at = 1)
+  )
+})
+
 test_that("bake() and juice() doens't turn strings into factors #317", {
   exp_data <- tibble(f1 = factor(1), f2 = "1", c1 = "1")
 


### PR DESCRIPTION
Closes #1551.

Adds a `stop_at` argument to `bake()` so users can see the data as it exists partway through a prepped recipe, which is handy for visual diagnostics.

```r
rec <- recipe(cyl ~ ., mtcars) |>
  step_center(all_predictors()) |>
  step_pca(all_predictors(), num_comp = 2) |>
  prep()

bake(rec, mtcars, stop_at = 1)              # by step number
bake(rec, mtcars, stop_at = "center_zo5Cx") # by step id
```

Details:

* `stop_at` sits after `...`, so it is named-only and can't be confused with tidyselect terms. The `bake()` generic is `function(object, ...)`, so it needed no change. Default `NULL` keeps the current behavior.
* Steps with `skip = TRUE` keep their existing semantics and still count toward the numbering, so numbers line up with `tidy(rec)`.
* `stop_at` errors with `new_data = NULL`. That path returns `object$template`, the fully processed training set, and `prep()` does not retain the raw training data, so intermediate stages can't be reconstructed. The message points users at passing the training data to `new_data`.
* The post-loop column selection normally uses `last_term_info`, which describes the data after *all* steps and so is wrong for a partial bake. Deriving the info from the intermediate data alone wasn't enough: roles for derived columns were lost, and `all_numeric_predictors()` selected nothing after `step_pca()`. Instead `update_term_info()` tracks the term info as each step is applied, mirroring the logic in `prep()`. It only runs when `stop_at` is supplied, so the default path is unaffected.

Tests cover step numbers, step ids, selectors, `composition = "dgCMatrix"`, a mid-recipe `skip = TRUE` step, and snapshot errors for out-of-range numbers, non-whole numbers, unknown ids, wrong types, length > 1, `new_data = NULL`, and a recipe with no steps.

`devtools::check()` is clean: 0 errors, 0 warnings, 0 notes.
