### PR TITLE
Fix unrelated R-CMD-check failures on old R and macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,11 +49,14 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+          # P3M's macOS binaries are built with OpenMP enabled, but the runners
+          # have no libomp, so e.g. gower fails to load. CRAN's own macOS
+          # binaries are built without it, so use those instead.
+          use-public-rspm: ${{ matrix.config.os != 'macos-latest' }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, igraph=?ignore-before-r=4.2.0
+          extra-packages: any::rcmdcheck, igraph=?ignore-before-r=4.2.0, mixOmics=?ignore-before-r=4.4.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
R-CMD-check is currently red on `main`-based branches for two reasons, neither related to package code. Both showed up on #1552, which only touches `bake()`.

**`ubuntu-latest (oldrel-3)`, `ubuntu-latest (oldrel-4)`, `windows-latest (oldrel-4)`** fail in `setup-r-dependencies`, before the package is even built:

```
! Could not solve package dependencies:
* deps::.: Can't install dependency mixOmics
* mixOmics: Can't find package called mixOmics.
```

The Bioconductor repos for those R versions now 404 (`bioconductor.posit.co/packages/3.18/...`), so pak can't resolve the suggested mixOmics package (a Suggests since #1544). This ignores mixOmics below R 4.4.0, exactly as igraph is already handled on the same line. Everything that uses it (`step_pls()` and friends) is guarded by `skip_if_not_installed("mixOmics")`, so the older jobs just skip those tests.

**`macos-latest (release)`** fails installing recipes:

```
unable to load shared object '.../gower/libs/gower.so':
  symbol not found in flat namespace '___kmpc_barrier'
```

`___kmpc_barrier` is an OpenMP runtime symbol. The job installs the P3M binary (`packagemanager.posit.co/cran/latest/bin/macosx/sonoma-arm64/contrib/4.6/gower_1.0.2.tgz`), which is built with OpenMP, but the runner has no libomp available for the flat-namespace lookup. CRAN's own macOS binaries are built without OpenMP, so this turns `use-public-rspm` off for the macOS job only; the other jobs are unaffected.

The macOS half is a hypothesis I can't verify locally, so it's worth watching this PR's own macOS job before merging. The mixOmics half is well understood.
