### PR TITLE
Fix imputation steps erroring on data with survival outcomes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ Suggests:
     rsample,
     RSpectra,
     splines2,
+    survival,
     testthat (>= 3.3.0),
     workflows,
     xml2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # recipes (development version)
 
-* `step_impute_bag()`, `step_impute_knn()`, and `step_impute_linear()` no longer error with "C stack usage is too close to the limit" when the data contains a survival outcome column. (#1542)
+* `step_impute_bag()`, `step_impute_knn()`, and `step_impute_linear()` no longer error with "C stack usage is too close to the limit" when the data contains a survival outcome column. (#1517, #1542)
 
 # recipes 1.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # recipes (development version)
 
+* `step_impute_bag()`, `step_impute_knn()`, and `step_impute_linear()` no longer error with "C stack usage is too close to the limit" when the data contains a survival outcome column. (#1542)
+
 # recipes 1.3.3
 
 * Specify mixOmics as a suggested package. (#1544)

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -297,7 +297,7 @@ bake.step_impute_bag <- function(object, new_data, ...) {
   col_names <- names(object$models)
   check_new_data(col_names, object, new_data)
 
-  missing_rows <- !vec_detect_complete(new_data)
+  missing_rows <- !vec_detect_complete(new_data[, col_names])
   if (!any(missing_rows)) {
     return(new_data)
   }

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -225,7 +225,7 @@ bake.step_impute_knn <- function(object, new_data, ...) {
   all_cols <- unique(unlist(object$columns, recursive = TRUE))
   check_new_data(all_cols, object, new_data)
 
-  missing_rows <- !vec_detect_complete(new_data)
+  missing_rows <- !vec_detect_complete(new_data[, col_names])
   if (!any(missing_rows)) {
     return(new_data)
   }

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -202,7 +202,7 @@ bake.step_impute_linear <- function(object, new_data, ...) {
   col_names <- names(object$models)
   check_new_data(col_names, object, new_data)
 
-  missing_rows <- !vec_detect_complete(new_data)
+  missing_rows <- !vec_detect_complete(new_data[, col_names])
   if (!any(missing_rows)) {
     return(new_data)
   }

--- a/tests/testthat/test-impute_bag.R
+++ b/tests/testthat/test-impute_bag.R
@@ -126,6 +126,21 @@ test_that("non-factor imputation", {
   expect_true(is.character(bake(rec, NULL, Location)[[1]]))
 })
 
+test_that("step_impute_bag() works with survival outcomes (#1542)", {
+  skip_if_not_installed("survival")
+
+  dat <- mtcars
+  dat$mpg[1] <- NA
+  dat$outcome <- survival::Surv(seq_len(nrow(dat)), rep(0:1, 16))
+
+  res <- recipe(outcome ~ ., data = dat) |>
+    step_impute_bag(mpg, impute_with = c(disp, hp, drat)) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(sum(is.na(res$mpg)), 0)
+})
+
 test_that("impute_with errors with nothing selected", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-impute_knn.R
+++ b/tests/testthat/test-impute_knn.R
@@ -246,6 +246,23 @@ test_that("step_impute_knn() can prep with character vectors (#926)", {
   )
 })
 
+test_that("step_impute_knn() works with survival outcomes (#1542)", {
+  skip_if_not_installed("survival")
+
+  dat <- tibble(
+    outcome = survival::Surv(1:20, rep(0:1, 10)),
+    x = c(NA, 2:20),
+    y = 1:20
+  )
+
+  res <- recipe(outcome ~ ., data = dat) |>
+    step_impute_knn(all_predictors()) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(sum(is.na(res$x)), 0)
+})
+
 test_that("check_options() is used", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-impute_linear.R
+++ b/tests/testthat/test-impute_linear.R
@@ -177,6 +177,23 @@ test_that("errors if there are no rows without missing values", {
   )
 })
 
+test_that("step_impute_linear() works with survival outcomes (#1542)", {
+  skip_if_not_installed("survival")
+
+  dat <- tibble(
+    outcome = survival::Surv(1:20, rep(0:1, 10)),
+    x = c(NA, 2:20),
+    y = 1:20
+  )
+
+  res <- recipe(outcome ~ ., data = dat) |>
+    step_impute_linear(x, impute_with = y) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(res$x, as.numeric(1:20))
+})
+
 test_that("recipes_argument_select() is used", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
Using `step_impute_bag()`, `step_impute_knn()`, or `step_impute_linear()` on data with a `Surv()` outcome failed with "C stack usage is too close to the limit", because their `bake()` methods scanned the whole of `new_data` for missing values and `vctrs::vec_detect_complete()` recurses infinitely on a `Surv` column. Narrowing that early-exit check to just the columns being imputed fixes it, and is more correct anyway: missingness in an untouched outcome column has no bearing on whether the step has work to do.

Fixes #1542.