### PR TITLE
Use recipes_map_cols() in the remaining in-place steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * New `recipes_map_cols()` helper for use in `bake()` methods of steps that transform columns in place. It applies a function to the selected columns and assigns the results in bulk, avoiding the quadratic cost of assigning one column at a time. (#1543)
 
-* `step_bin2factor()`, `step_BoxCox()`, `step_center()`, `step_cut()`, `step_discretize()`, `step_factor2string()`, `step_hyperbolic()`, `step_impute_mean()`, `step_impute_median()`, `step_impute_mode()`, `step_integer()`, `step_inverse()`, `step_invlogit()`, `step_log()`, `step_logit()`, `step_normalize()`, `step_num2factor()`, `step_ordinalscore()`, `step_percentile()`, `step_range()`, `step_relevel()`, `step_scale()`, `step_shuffle()`, `step_sqrt()`, `step_string2factor()`, `step_unorder()`, and `step_YeoJohnson()` are now dramatically faster when baking data with many columns. (#1543)
+* `check_new_values()`, `check_range()`, `step_bin2factor()`, `step_BoxCox()`, `step_center()`, `step_cut()`, `step_discretize()`, `step_factor2string()`, `step_hyperbolic()`, `step_impute_bag()`, `step_impute_knn()`, `step_impute_linear()`, `step_impute_lower()`, `step_impute_mean()`, `step_impute_median()`, `step_impute_mode()`, `step_impute_roll()`, `step_integer()`, `step_inverse()`, `step_invlogit()`, `step_log()`, `step_logit()`, `step_normalize()`, `step_novel()`, `step_num2factor()`, `step_ordinalscore()`, `step_other()`, `step_percentile()`, `step_range()`, `step_relevel()`, `step_scale()`, `step_shuffle()`, `step_sqrt()`, `step_string2factor()`, `step_unknown()`, `step_unorder()`, `step_window()`, and `step_YeoJohnson()` are now dramatically faster when baking data with many columns. (#1543)
 
 * `step_num2factor()` no longer errors when more than one column is selected. (#1543)
 

--- a/R/impute_bag.R
+++ b/R/impute_bag.R
@@ -302,39 +302,49 @@ bake.step_impute_bag <- function(object, new_data, ...) {
     return(new_data)
   }
 
-  old_data <- new_data
-  for (col_name in col_names) {
-    missing_rows <- !vec_detect_complete(new_data[[col_name]])
-    if (!any(missing_rows)) {
-      next
-    }
-    preds <- object$models[[col_name]]$..imp_vars
-    imp_data <- old_data[missing_rows, preds, drop = FALSE]
+  models <- object$models[col_names]
 
-    imp_data_all_missing <- vctrs::vec_detect_missing(imp_data)
-
-    if (any(imp_data_all_missing)) {
-      offenders <- which(missing_rows)[imp_data_all_missing]
-      missing_rows[offenders] <- FALSE
-
-      cli::cli_warn(
-        "The {.arg impute_with} variables for {.col {col_name}} only contains
-        missing values for row: {offenders}. Cannot impute for those rows.",
-      )
-
-      imp_data <- imp_data[!imp_data_all_missing, , drop = FALSE]
-
-      if (nrow(imp_data) == 0) {
-        next
+  # `new_data` is not modified while mapping, so the predictors are always read
+  # from the unimputed data.
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i, col_name) {
+      missing_rows <- !vec_detect_complete(x)
+      if (!any(missing_rows)) {
+        return(x)
       }
+
+      preds <- models[[i]]$..imp_vars
+      imp_data <- new_data[missing_rows, preds, drop = FALSE]
+
+      imp_data_all_missing <- vctrs::vec_detect_missing(imp_data)
+
+      if (any(imp_data_all_missing)) {
+        offenders <- which(missing_rows)[imp_data_all_missing]
+        missing_rows[offenders] <- FALSE
+
+        cli::cli_warn(
+          "The {.arg impute_with} variables for {.col {col_name}} only contains
+          missing values for row: {offenders}. Cannot impute for those rows.",
+        )
+
+        imp_data <- imp_data[!imp_data_all_missing, , drop = FALSE]
+
+        if (nrow(imp_data) == 0) {
+          return(x)
+        }
+      }
+
+      pred_vals <- predict(models[[i]], imp_data)
+
+      # For an ipred bug reported on 2021-09-14:
+      pred_vals <- cast(pred_vals, models[[i]]$y)
+      x[missing_rows] <- pred_vals
+      x
     }
+  )
 
-    pred_vals <- predict(object$models[[col_name]], imp_data)
-
-    # For an ipred bug reported on 2021-09-14:
-    pred_vals <- cast(pred_vals, object$models[[col_name]]$y)
-    new_data[missing_rows, col_name] <- pred_vals
-  }
   new_data
 }
 

--- a/R/impute_knn.R
+++ b/R/impute_knn.R
@@ -232,57 +232,66 @@ bake.step_impute_knn <- function(object, new_data, ...) {
 
   names(object$columns) <- col_names
 
-  old_data <- new_data
-  for (col_name in col_names) {
-    missing_rows <- !vec_detect_complete(new_data[, col_name])
-    if (!any(missing_rows)) {
-      next
-    }
-    preds <- object$columns[[col_name]]$x
-    imp_data <- old_data[missing_rows, preds, drop = FALSE]
+  columns <- object$columns[col_names]
 
-    imp_data_all_missing <- vctrs::vec_detect_missing(imp_data)
-
-    if (any(imp_data_all_missing)) {
-      offenders <- which(missing_rows)[imp_data_all_missing]
-      missing_rows[offenders] <- FALSE
-
-      cli::cli_warn(
-        "The {.arg impute_with} variables for {.col {col_name}} only contains
-        missing values for row: {offenders}. Cannot impute for those rows.",
-      )
-
-      imp_data <- imp_data[!imp_data_all_missing, , drop = FALSE]
-
-      if (nrow(imp_data) == 0) {
-        next
+  # `new_data` is not modified while mapping, so the predictors are always read
+  # from the unimputed data.
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i, col_name) {
+      missing_rows <- !vec_detect_complete(x)
+      if (!any(missing_rows)) {
+        return(x)
       }
-    }
-    # make sure imp_data as same types as ref_data
-    imp_data <- vctrs::tib_cast(
-      imp_data,
-      select(object$ref_data, names(imp_data))
-    )
+      preds <- columns[[i]]$x
+      imp_data <- new_data[missing_rows, preds, drop = FALSE]
 
-    imp_var_complete <- !is.na(object$ref_data[[col_name]])
-    nn_ind <- nn_index(
-      object$ref_data[imp_var_complete, ],
-      imp_data,
-      preds,
-      object$neighbors,
-      object$options
-    )
-    pred_vals <-
-      apply(
-        nn_ind,
-        2,
-        nn_pred,
-        dat = object$ref_data[imp_var_complete, col_name]
+      imp_data_all_missing <- vctrs::vec_detect_missing(imp_data)
+
+      if (any(imp_data_all_missing)) {
+        offenders <- which(missing_rows)[imp_data_all_missing]
+        missing_rows[offenders] <- FALSE
+
+        cli::cli_warn(
+          "The {.arg impute_with} variables for {.col {col_name}} only contains
+        missing values for row: {offenders}. Cannot impute for those rows.",
+        )
+
+        imp_data <- imp_data[!imp_data_all_missing, , drop = FALSE]
+
+        if (nrow(imp_data) == 0) {
+          return(x)
+        }
+      }
+      # make sure imp_data as same types as ref_data
+      imp_data <- vctrs::tib_cast(
+        imp_data,
+        select(object$ref_data, names(imp_data))
       )
-    pred_vals <- cast(pred_vals, object$ref_data[[col_name]])
-    new_data[[col_name]] <- vec_cast(new_data[[col_name]], pred_vals)
-    new_data[missing_rows, col_name] <- pred_vals
-  }
+
+      imp_var_complete <- !is.na(object$ref_data[[col_name]])
+      nn_ind <- nn_index(
+        object$ref_data[imp_var_complete, ],
+        imp_data,
+        preds,
+        object$neighbors,
+        object$options
+      )
+      pred_vals <-
+        apply(
+          nn_ind,
+          2,
+          nn_pred,
+          dat = object$ref_data[imp_var_complete, col_name]
+        )
+      pred_vals <- cast(pred_vals, object$ref_data[[col_name]])
+      x <- vec_cast(x, pred_vals)
+      x[missing_rows] <- pred_vals
+      x
+    }
+  )
+
   new_data
 }
 

--- a/R/impute_linear.R
+++ b/R/impute_linear.R
@@ -207,28 +207,38 @@ bake.step_impute_linear <- function(object, new_data, ...) {
     return(new_data)
   }
 
-  old_data <- new_data
-  for (col_name in col_names) {
-    missing_rows <- !vec_detect_complete(new_data[[col_name]])
-    if (!any(missing_rows)) {
-      next
-    }
+  models <- object$models[col_names]
 
-    preds <- object$models[[col_name]]$..imp_vars
-    pred_data <- old_data[missing_rows, preds, drop = FALSE]
-    ## do a better job of checking this:
-    if (anyNA(pred_data)) {
-      cli::cli_warn(
-        "There were missing values in the predictor(s) used to impute; \\
-        imputation did not occur."
-      )
-    } else {
-      pred_vals <- predict(object$models[[col_name]], pred_data)
-      pred_vals <- cast(pred_vals, new_data[[col_name]])
-      new_data[[col_name]] <- vec_cast(new_data[[col_name]], pred_vals)
-      new_data[missing_rows, col_name] <- pred_vals
+  # `new_data` is not modified while mapping, so the predictors are always read
+  # from the unimputed data.
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i) {
+      missing_rows <- !vec_detect_complete(x)
+      if (!any(missing_rows)) {
+        return(x)
+      }
+
+      preds <- models[[i]]$..imp_vars
+      pred_data <- new_data[missing_rows, preds, drop = FALSE]
+      ## do a better job of checking this:
+      if (anyNA(pred_data)) {
+        cli::cli_warn(
+          "There were missing values in the predictor(s) used to impute; \\
+          imputation did not occur."
+        )
+        return(x)
+      }
+
+      pred_vals <- predict(models[[i]], pred_data)
+      pred_vals <- cast(pred_vals, x)
+      x <- vec_cast(x, pred_vals)
+      x[missing_rows] <- pred_vals
+      x
     }
-  }
+  )
+
   new_data
 }
 

--- a/R/impute_lower.R
+++ b/R/impute_lower.R
@@ -134,17 +134,22 @@ bake.step_impute_lower <- function(object, new_data, ...) {
   col_names <- names(object$threshold)
   check_new_data(col_names, object, new_data)
 
-  for (col_name in col_names) {
-    threshold <- object$threshold[[col_name]]
-    affected <- which(new_data[[col_name]] <= threshold)
+  thresholds <- object$threshold[col_names]
 
-    if (length(affected) > 0) {
-      new_data[[col_name]][affected] <- runif(
-        length(affected),
-        max = threshold
-      )
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i) {
+      threshold <- thresholds[[i]]
+      affected <- which(x <= threshold)
+
+      if (length(affected) > 0) {
+        x[affected] <- runif(length(affected), max = threshold)
+      }
+
+      x
     }
-  }
+  )
 
   new_data
 }

--- a/R/impute_roll.R
+++ b/R/impute_roll.R
@@ -190,14 +190,24 @@ bake.step_impute_roll <- function(object, new_data, ...) {
   missing_ind <- missing_ind[has_missing]
   roll_ind <- lapply(missing_ind, get_rolling_ind, n = n, k = object$window)
 
-  for (col_name in col_names) {
-    estimates <- impute_rolling(
-      roll_ind[[col_name]],
-      new_data[[col_name]],
-      object$statistic
-    )
-    new_data[missing_ind[[col_name]], col_name] <- estimates
-  }
+  # `missing_ind` and `roll_ind` only hold the columns that have missing values
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i, col_name) {
+      rows <- missing_ind[[col_name]]
+      if (is.null(rows)) {
+        return(x)
+      }
+
+      x[rows] <- impute_rolling(
+        roll_ind[[col_name]],
+        x,
+        object$statistic
+      )
+      x
+    }
+  )
 
   new_data
 }

--- a/R/newvalues.R
+++ b/R/newvalues.R
@@ -145,11 +145,15 @@ bake.check_new_values <- function(object, new_data, ...) {
   col_names <- names(object$values)
   check_new_data(col_names, object, new_data)
 
-  for (col_name in col_names) {
+  # Subset once rather than looking up each column by name in turn
+  columns <- unclass(new_data)[col_names]
+  values <- object$values[col_names]
+
+  for (i in seq_along(col_names)) {
     new_values_func(
-      new_data[[col_name]],
-      object$values[[col_name]],
-      col_name,
+      columns[[i]],
+      values[[i]],
+      col_names[[i]],
       ignore_NA = object$ignore_NA
     )
   }

--- a/R/novel.R
+++ b/R/novel.R
@@ -152,22 +152,27 @@ bake.step_novel <- function(object, new_data, ...) {
   col_names <- names(object$objects)
   check_new_data(col_names, object, new_data)
 
-  for (col_name in col_names) {
-    new_data[[col_name]] <- ifelse(
-      # Preserve NA values by adding them to the list of existing
-      # possible values
-      !(new_data[[col_name]] %in% c(object$object[[col_name]], NA)),
-      object$new_level,
-      as.character(new_data[[col_name]])
-    )
+  objects <- object$object[col_names]
 
-    new_data[[col_name]] <-
-      factor(
-        new_data[[col_name]],
-        levels = c(object$object[[col_name]], object$new_level),
-        ordered = attributes(object$object[[col_name]])$is_ordered
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i) {
+      x <- ifelse(
+        # Preserve NA values by adding them to the list of existing
+        # possible values
+        !(x %in% c(objects[[i]], NA)),
+        object$new_level,
+        as.character(x)
       )
-  }
+
+      factor(
+        x,
+        levels = c(objects[[i]], object$new_level),
+        ordered = attributes(objects[[i]])$is_ordered
+      )
+    }
+  )
 
   new_data
 }

--- a/R/other.R
+++ b/R/other.R
@@ -200,33 +200,30 @@ bake.step_other <- function(object, new_data, ...) {
   col_names <- names(object$objects)
   check_new_data(col_names, object, new_data)
 
-  for (col_name in col_names) {
-    if (!object$objects[[col_name]]$collapse) {
-      next
-    }
-    tmp <- new_data[[col_name]]
+  objects <- object$objects[col_names]
 
-    if (!is.character(tmp)) {
-      tmp <- as.character(tmp)
-    }
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i) {
+      if (!objects[[i]]$collapse) {
+        return(x)
+      }
 
-    tmp <- ifelse(
-      !(tmp %in% object$objects[[col_name]]$keep) & !is.na(tmp),
-      object$objects[[col_name]]$other,
-      tmp
-    )
+      if (!is.character(x)) {
+        x <- as.character(x)
+      }
 
-    # assign other factor levels other here too.
-    tmp <- factor(
-      tmp,
-      levels = c(
-        object$objects[[col_name]]$keep,
-        object$objects[[col_name]]$other
+      x <- ifelse(
+        !(x %in% objects[[i]]$keep) & !is.na(x),
+        objects[[i]]$other,
+        x
       )
-    )
 
-    new_data[[col_name]] <- tmp
-  }
+      # assign other factor levels other here too.
+      factor(x, levels = c(objects[[i]]$keep, objects[[i]]$other))
+    }
+  )
 
   new_data
 }

--- a/R/range_check.R
+++ b/R/range_check.R
@@ -192,16 +192,22 @@ bake.check_range <- function(object, new_data, ...) {
     return(new_data)
   }
 
-  for (col_name in col_names) {
+  # Subset once rather than looking up each column by name in turn
+  columns <- unclass(new_data)[col_names]
+  lower <- object$lower[col_names]
+  upper <- object$upper[col_names]
+
+  for (i in seq_along(col_names)) {
     range_check_func(
-      new_data[[col_name]],
-      object$lower[col_name],
-      object$upper[col_name],
+      columns[[i]],
+      lower[[i]],
+      upper[[i]],
       object$slack_prop,
       object$warn,
-      col_name
+      col_names[[i]]
     )
   }
+
   new_data
 }
 

--- a/R/unknown.R
+++ b/R/unknown.R
@@ -125,32 +125,34 @@ bake.step_unknown <- function(object, new_data, ...) {
   col_names <- names(object$objects)
   check_new_data(col_names, object, new_data)
 
-  for (col_name in col_names) {
-    new_data[[col_name]] <- ifelse(
-      is.na(new_data[[col_name]]),
-      object$new_level,
-      as.character(new_data[[col_name]])
-    )
+  objects <- object$object[col_names]
 
-    new_levels <- c(object$object[[col_name]], object$new_level)
+  new_data <- recipes_map_cols(
+    new_data,
+    col_names,
+    function(x, i, col_name) {
+      x <- ifelse(is.na(x), object$new_level, as.character(x))
 
-    if (!all(new_data[[col_name]] %in% new_levels)) {
-      warn_new_levels(
-        new_data[[col_name]],
-        new_levels,
-        column = col_name,
-        step = "step_unknown",
-        c("*" = "New levels will be coerced to `NA` by {.fn step_unknown}.")
+      new_levels <- c(objects[[i]], object$new_level)
+
+      if (!all(x %in% new_levels)) {
+        warn_new_levels(
+          x,
+          new_levels,
+          column = col_name,
+          step = "step_unknown",
+          c("*" = "New levels will be coerced to `NA` by {.fn step_unknown}.")
+        )
+      }
+
+      factor(
+        x,
+        levels = new_levels,
+        ordered = attributes(objects[[i]])$is_ordered
       )
     }
+  )
 
-    new_data[[col_name]] <-
-      factor(
-        new_data[[col_name]],
-        levels = new_levels,
-        ordered = attributes(object$object[[col_name]])$is_ordered
-      )
-  }
   new_data
 }
 

--- a/R/window.R
+++ b/R/window.R
@@ -274,9 +274,11 @@ bake.step_window <- function(object, new_data, ...) {
   }
 
   if (is.null(object$names)) {
-    for (col_name in col_names) {
-      new_data[[col_name]] <- new_values[[col_name]]
-    }
+    new_data <- recipes_map_cols(
+      new_data,
+      col_names,
+      \(x, i) new_values[[i]]
+    )
   } else {
     names(new_values) <- object$names
     new_values <- tibble::new_tibble(new_values)


### PR DESCRIPTION
Converts the rest of the steps that transform columns in place, the ones whose per-column work needs more context than a scalar parameter: the factor level steps, the model-based imputation steps, and `step_window()`. Baking 8,000 factor columns through `step_other()` drops from 5.14s to 1.26s and through `step_novel()` from 7.86s to 3.28s. The two check functions don't assign anything, so they just subset their columns once instead of looking each one up by name.

`step_impute_bag()`, `step_impute_knn()`, and `step_impute_linear()` each kept an `old_data <- new_data` copy so that predictors were read from unimputed data. Since the data is no longer modified while mapping, that copy is gone and the predictors are read from `new_data` directly.

Targets #1556 rather than main, since it builds on `recipes_map_cols()`. Refs #1543.