### PR TITLE
Allow step_count() and step_regex() to select multiple columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,13 @@
 
 * `check_new_values()`, `check_range()`, `step_bin2factor()`, `step_BoxCox()`, `step_center()`, `step_cut()`, `step_discretize()`, `step_factor2string()`, `step_hyperbolic()`, `step_impute_bag()`, `step_impute_knn()`, `step_impute_linear()`, `step_impute_lower()`, `step_impute_mean()`, `step_impute_median()`, `step_impute_mode()`, `step_impute_roll()`, `step_integer()`, `step_inverse()`, `step_invlogit()`, `step_log()`, `step_logit()`, `step_normalize()`, `step_novel()`, `step_num2factor()`, `step_ordinalscore()`, `step_other()`, `step_percentile()`, `step_range()`, `step_relevel()`, `step_scale()`, `step_shuffle()`, `step_sqrt()`, `step_string2factor()`, `step_unknown()`, `step_unorder()`, `step_window()`, and `step_YeoJohnson()` are now dramatically faster when baking data with many columns. (#1543)
 
+* `step_count()` now accepts selectors that resolve to more than one column. When more than one column is selected, the new columns are named `{column}_{result}`. (#1384)
+
 * `step_impute_bag()`, `step_impute_knn()`, and `step_impute_linear()` no longer error with "C stack usage is too close to the limit" when the data contains a survival outcome column. (#1517, #1542)
 
 * `step_num2factor()` no longer errors when more than one column is selected. (#1543)
+
+* `step_regex()` now accepts selectors that resolve to more than one column. When more than one column is selected, the new columns are named `{column}_{result}`. (#1384)
 
 # recipes 1.3.3
 

--- a/R/count.R
+++ b/R/count.R
@@ -7,9 +7,8 @@
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @inheritParams step_dummy
-#' @param ... A single selector function to choose which variable will be
-#'   searched for the regex pattern. The selector should resolve to a single
-#'   variable. See [selections()] for more details.
+#' @param ... One or more selector functions to choose which variables will be
+#'   searched for the regex pattern. See [selections()] for more details.
 #' @param pattern A character string containing a regular expression (or
 #'   character string for `fixed = TRUE`) to be matched in the given character
 #'   vector. Coerced by `as.character` to a character string if possible.
@@ -18,9 +17,10 @@
 #' @param options A list of options to [gregexpr()] that should not include `x`
 #'   or `pattern`.
 #' @param result A single character value for the name of the new variable. It
-#'   should be a valid column name.
-#' @param input A single character value for the name of the variable being
-#'   searched. This is `NULL` until computed by [prep()].
+#'   should be a valid column name. If the selection resolves to more than one
+#'   variable, the new variables are named `{variable}_{result}` instead.
+#' @param input The names of the variables being searched. This is `NULL` until
+#'   computed by [prep()].
 #' @template step-return
 #' @details
 #'
@@ -56,6 +56,15 @@
 #'
 #' tidy(rec, number = 1)
 #' tidy(rec2, number = 1)
+#'
+#' # When more than one variable is selected, the new variables are named
+#' # `{variable}_{result}`
+#' covers$description2 <- rev(covers$description)
+#'
+#' recipe(~., covers) |>
+#'   step_count(description, description2, pattern = "rock", result = "rocks") |>
+#'   prep() |>
+#'   bake(new_data = NULL)
 step_count <- function(
   recipe,
   ...,
@@ -84,21 +93,10 @@ step_count <- function(
     )
   }
 
-  terms <- enquos(...)
-  if (length(terms) > 1) {
-    cli::cli_abort(
-      c(
-        x = "For this step, only a single selector can be used.",
-        i = "The following {length(terms)} selectors were used: \\
-          {.var {as.character(terms)}}."
-      )
-    )
-  }
-
   add_step(
     recipe,
     step_count_new(
-      terms = terms,
+      terms = enquos(...),
       role = role,
       trained = trained,
       pattern = pattern,
@@ -148,8 +146,8 @@ step_count_new <-
 
 #' @export
 prep.step_count <- function(x, training, info = NULL, ...) {
-  col_name <- recipes_eval_select(x$terms, training, info)
-  check_type(training[, col_name], types = c("string", "factor", "ordered"))
+  col_names <- recipes_eval_select(x$terms, training, info)
+  check_type(training[, col_names], types = c("string", "factor", "ordered"))
   check_string(x$pattern, allow_empty = TRUE, arg = "pattern")
   check_string(x$result, allow_empty = FALSE, arg = "result")
   check_bool(x$normalize, arg = "normalize")
@@ -163,7 +161,7 @@ prep.step_count <- function(x, training, info = NULL, ...) {
     pattern = x$pattern,
     normalize = x$normalize,
     options = x$options,
-    input = col_name,
+    input = col_names,
     result = x$result,
     sparse = x$sparse,
     keep_original_cols = get_keep_original_cols(x),
@@ -174,52 +172,56 @@ prep.step_count <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_count <- function(object, new_data, ...) {
-  col_name <- names(object$input)
-  check_new_data(col_name, object, new_data)
+  col_names <- names(object$input)
+  check_new_data(col_names, object, new_data)
 
-  if (length(col_name) == 0L) {
+  if (length(col_names) == 0L) {
     return(new_data)
   }
 
-  ## sub in options
-  regex <- expr(
-    gregexpr(
-      text = new_data[[col_name]],
-      pattern = object$pattern,
-      ignore.case = FALSE,
-      perl = FALSE,
-      fixed = FALSE,
-      useBytes = FALSE
+  new_names <- multi_result_names(col_names, object$result)
+
+  cols <- list()
+
+  for (i in seq_along(col_names)) {
+    ## sub in options
+    regex <- expr(
+      gregexpr(
+        text = new_data[[col_names[i]]],
+        pattern = object$pattern,
+        ignore.case = FALSE,
+        perl = FALSE,
+        fixed = FALSE,
+        useBytes = FALSE
+      )
     )
-  )
-  if (length(object$options) > 0) {
-    regex <- rlang::call_modify(regex, !!!object$options)
-  }
-
-  new_values <- tibble::tibble(
-    !!object$result := vapply(eval(regex), counter, integer(1))
-  )
-
-  if (object$normalize) {
-    totals <- nchar(as.character(new_data[[col_name]]))
-    new_values[[object$result]] <- new_values[[object$result]] / totals
-  }
-
-  if (sparse_is_yes(object$sparse)) {
-    if (object$normalize) {
-      new_values[[object$result]] <- sparsevctrs::as_sparse_double(
-        new_values[[object$result]]
-      )
-    } else {
-      new_values[[object$result]] <- sparsevctrs::as_sparse_integer(
-        new_values[[object$result]]
-      )
+    if (length(object$options) > 0) {
+      regex <- rlang::call_modify(regex, !!!object$options)
     }
+
+    res <- vapply(eval(regex), counter, integer(1))
+
+    if (object$normalize) {
+      totals <- nchar(as.character(new_data[[col_names[i]]]))
+      res <- res / totals
+    }
+
+    if (sparse_is_yes(object$sparse)) {
+      if (object$normalize) {
+        res <- sparsevctrs::as_sparse_double(res)
+      } else {
+        res <- sparsevctrs::as_sparse_integer(res)
+      }
+    }
+
+    cols[[new_names[i]]] <- res
   }
 
-  new_values <- check_name(new_values, new_data, object, object$result)
-  new_data <- vec_cbind(new_data, new_values, .name_repair = "minimal")
-  new_data <- remove_original_cols(new_data, object, col_name)
+  cols <- tibble::new_tibble(cols, nrow = nrow(new_data))
+
+  cols <- check_name(cols, new_data, object, new_names)
+  new_data <- vec_cbind(new_data, cols, .name_repair = "minimal")
+  new_data <- remove_original_cols(new_data, object, col_names)
   new_data
 }
 
@@ -236,17 +238,17 @@ print.step_count <-
 #' @rdname tidy.recipe
 #' @export
 tidy.step_count <- function(x, ...) {
-  term_names <- sel2char(x$terms)
-  p <- length(term_names)
   if (is_trained(x)) {
+    col_names <- names(x$input)
     res <- tibble(
-      terms = term_names,
-      result = rep(x$result, p)
+      terms = col_names,
+      result = multi_result_names(col_names, unname(x$result))
     )
   } else {
+    term_names <- sel2char(x$terms)
     res <- tibble(
       terms = term_names,
-      result = rep(na_chr, p)
+      result = rep(na_chr, length(term_names))
     )
   }
   res$id <- x$id
@@ -255,10 +257,8 @@ tidy.step_count <- function(x, ...) {
 
 #' @export
 .recipes_estimate_sparsity.step_count <- function(x, data, ...) {
-  lapply(1, function(n_lvl) {
-    c(
-      n_cols = n_lvl,
-      sparsity = 0.5
-    )
-  })
+  lapply(
+    seq_len(ncol(data)),
+    function(x) c(n_cols = 1, sparsity = 0.5)
+  )
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -125,6 +125,17 @@ dummy_names <- function(var, lvl, ordinal = FALSE, sep = "_") {
   nms
 }
 
+# Used by step_count() and step_regex(), which create a single new column per
+# selected column. A single selection keeps the bare `result` name for
+# backwards compatibility.
+multi_result_names <- function(col_names, result) {
+  if (length(col_names) == 1L) {
+    result
+  } else {
+    paste0(col_names, "_", result)
+  }
+}
+
 #' @export
 #' @rdname names0
 dummy_extract_names <- function(var, lvl, ordinal = FALSE, sep = "_") {

--- a/R/regex.R
+++ b/R/regex.R
@@ -7,18 +7,18 @@
 #' @inheritParams step_pca
 #' @inheritParams step_center
 #' @inheritParams step_dummy
-#' @param ... A single selector function to choose which variable will be
-#'   searched for the regex pattern. The selector should resolve to a single
-#'   variable. See [selections()] for more details.
+#' @param ... One or more selector functions to choose which variables will be
+#'   searched for the regex pattern. See [selections()] for more details.
 #' @param pattern A character string containing a regular expression (or
 #'   character string for `fixed = TRUE`) to be matched in the given character
 #'   vector. Coerced by `as.character` to a character string if possible.
 #' @param options A list of options to [grepl()] that should not include `x` or
 #'   `pattern`.
 #' @param result A single character value for the name of the new variable. It
-#'   should be a valid column name.
-#' @param input A single character value for the name of the variable being
-#'   searched. This is `NULL` until computed by [prep()].
+#'   should be a valid column name. If the selection resolves to more than one
+#'   variable, the new variables are named `{variable}_{result}` instead.
+#' @param input The names of the variables being searched. This is `NULL` until
+#'   computed by [prep()].
 #' @template step-return
 #' @details
 #'
@@ -53,6 +53,15 @@
 #' with_dummies
 #' tidy(rec, number = 1)
 #' tidy(rec2, number = 1)
+#'
+#' # When more than one variable is selected, the new variables are named
+#' # `{variable}_{result}`
+#' covers$description2 <- rev(covers$description)
+#'
+#' recipe(~., covers) |>
+#'   step_regex(description, description2, pattern = "rock", result = "rocks") |>
+#'   prep() |>
+#'   bake(new_data = NULL)
 step_regex <- function(
   recipe,
   ...,
@@ -78,21 +87,10 @@ step_regex <- function(
     )
   }
 
-  terms <- enquos(...)
-  if (length(terms) > 1) {
-    cli::cli_abort(
-      c(
-        x = "For this step, only a single selector can be used.",
-        i = "The following {length(terms)} selectors were used: \\
-          {.var {as.character(terms)}}."
-      )
-    )
-  }
-
   add_step(
     recipe,
     step_regex_new(
-      terms = terms,
+      terms = enquos(...),
       role = role,
       trained = trained,
       pattern = pattern,
@@ -139,8 +137,8 @@ step_regex_new <-
 
 #' @export
 prep.step_regex <- function(x, training, info = NULL, ...) {
-  col_name <- recipes_eval_select(x$terms, training, info)
-  check_type(training[, col_name], types = c("string", "factor", "ordered"))
+  col_names <- recipes_eval_select(x$terms, training, info)
+  check_type(training[, col_names], types = c("string", "factor", "ordered"))
   check_string(x$pattern, arg = "pattern", allow_empty = FALSE)
   check_sparse_arg(x$sparse)
   check_options(x$options, exclude = c("x", "pattern"))
@@ -151,7 +149,7 @@ prep.step_regex <- function(x, training, info = NULL, ...) {
     trained = TRUE,
     pattern = x$pattern,
     options = x$options,
-    input = col_name,
+    input = col_names,
     result = x$result,
     sparse = x$sparse,
     keep_original_cols = get_keep_original_cols(x),
@@ -162,39 +160,47 @@ prep.step_regex <- function(x, training, info = NULL, ...) {
 
 #' @export
 bake.step_regex <- function(object, new_data, ...) {
-  col_name <- names(object$input)
-  if (length(col_name) == 0) {
+  col_names <- names(object$input)
+  if (length(col_names) == 0) {
     return(new_data)
   }
 
-  check_new_data(col_name, object, new_data)
+  check_new_data(col_names, object, new_data)
 
-  ## sub in options
-  regex <- expr(
-    grepl(
-      x = new_data[[col_name]],
-      pattern = object$pattern,
-      ignore.case = FALSE,
-      perl = FALSE,
-      fixed = FALSE,
-      useBytes = FALSE
+  new_names <- multi_result_names(col_names, object$result)
+
+  cols <- list()
+
+  for (i in seq_along(col_names)) {
+    ## sub in options
+    regex <- expr(
+      grepl(
+        x = new_data[[col_names[i]]],
+        pattern = object$pattern,
+        ignore.case = FALSE,
+        perl = FALSE,
+        fixed = FALSE,
+        useBytes = FALSE
+      )
     )
-  )
-  if (length(object$options) > 0) {
-    regex <- rlang::call_modify(regex, !!!object$options)
+    if (length(object$options) > 0) {
+      regex <- rlang::call_modify(regex, !!!object$options)
+    }
+
+    res <- ifelse(eval(regex), 1L, 0L)
+
+    if (sparse_is_yes(object$sparse)) {
+      res <- sparsevctrs::as_sparse_integer(res)
+    }
+
+    cols[[new_names[i]]] <- res
   }
 
-  new_values <- tibble::tibble(!!object$result := ifelse(eval(regex), 1L, 0L))
+  cols <- tibble::new_tibble(cols, nrow = nrow(new_data))
 
-  if (sparse_is_yes(object$sparse)) {
-    new_values[[object$result]] <- sparsevctrs::as_sparse_integer(
-      new_values[[object$result]]
-    )
-  }
-
-  new_values <- check_name(new_values, new_data, object, object$result)
-  new_data <- vec_cbind(new_data, new_values, .name_repair = "minimal")
-  new_data <- remove_original_cols(new_data, object, col_name)
+  cols <- check_name(cols, new_data, object, new_names)
+  new_data <- vec_cbind(new_data, cols, .name_repair = "minimal")
+  new_data <- remove_original_cols(new_data, object, col_names)
   new_data
 }
 
@@ -211,17 +217,17 @@ print.step_regex <-
 #' @rdname tidy.recipe
 #' @export
 tidy.step_regex <- function(x, ...) {
-  term_names <- sel2char(x$terms)
-  p <- length(term_names)
   if (is_trained(x)) {
+    col_names <- names(x$input)
     res <- tibble(
-      terms = term_names,
-      result = rep(unname(x$result), p)
+      terms = col_names,
+      result = multi_result_names(col_names, unname(x$result))
     )
   } else {
+    term_names <- sel2char(x$terms)
     res <- tibble(
       terms = term_names,
-      result = rep(na_chr, p)
+      result = rep(na_chr, length(term_names))
     )
   }
   res$id <- x$id
@@ -230,10 +236,8 @@ tidy.step_regex <- function(x, ...) {
 
 #' @export
 .recipes_estimate_sparsity.step_regex <- function(x, data, ...) {
-  lapply(1, function(n_lvl) {
-    c(
-      n_cols = n_lvl,
-      sparsity = 0.5
-    )
-  })
+  lapply(
+    seq_len(ncol(data)),
+    function(x) c(n_cols = 1, sparsity = 0.5)
+  )
 }

--- a/man/step_count.Rd
+++ b/man/step_count.Rd
@@ -24,9 +24,8 @@ step_count(
 \item{recipe}{A recipe object. The step will be added to the sequence of
 operations for this recipe.}
 
-\item{...}{A single selector function to choose which variable will be
-searched for the regex pattern. The selector should resolve to a single
-variable. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose which variables will be
+searched for the regex pattern. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
 they be assigned? By default, the new columns created by this step from the
@@ -46,10 +45,11 @@ number of characters in the string?.}
 or \code{pattern}.}
 
 \item{result}{A single character value for the name of the new variable. It
-should be a valid column name.}
+should be a valid column name. If the selection resolves to more than one
+variable, the new variables are named \verb{\{variable\}_\{result\}} instead.}
 
-\item{input}{A single character value for the name of the variable being
-searched. This is \code{NULL} until computed by \code{\link[=prep]{prep()}}.}
+\item{input}{The names of the variables being searched. This is \code{NULL} until
+computed by \code{\link[=prep]{prep()}}.}
 
 \item{sparse}{A single string. Should the columns produced be sparse vectors.
 Can take the values \code{"yes"}, \code{"no"}, and \code{"auto"}. If \code{sparse = "auto"}
@@ -121,6 +121,15 @@ count_values
 
 tidy(rec, number = 1)
 tidy(rec2, number = 1)
+
+# When more than one variable is selected, the new variables are named
+# `{variable}_{result}`
+covers$description2 <- rev(covers$description)
+
+recipe(~., covers) |>
+  step_count(description, description2, pattern = "rock", result = "rocks") |>
+  prep() |>
+  bake(new_data = NULL)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/step_regex.Rd
+++ b/man/step_regex.Rd
@@ -23,9 +23,8 @@ step_regex(
 \item{recipe}{A recipe object. The step will be added to the sequence of
 operations for this recipe.}
 
-\item{...}{A single selector function to choose which variable will be
-searched for the regex pattern. The selector should resolve to a single
-variable. See \code{\link[=selections]{selections()}} for more details.}
+\item{...}{One or more selector functions to choose which variables will be
+searched for the regex pattern. See \code{\link[=selections]{selections()}} for more details.}
 
 \item{role}{For model terms created by this step, what analysis role should
 they be assigned? By default, the new columns created by this step from the
@@ -42,10 +41,11 @@ vector. Coerced by \code{as.character} to a character string if possible.}
 \code{pattern}.}
 
 \item{result}{A single character value for the name of the new variable. It
-should be a valid column name.}
+should be a valid column name. If the selection resolves to more than one
+variable, the new variables are named \verb{\{variable\}_\{result\}} instead.}
 
-\item{input}{A single character value for the name of the variable being
-searched. This is \code{NULL} until computed by \code{\link[=prep]{prep()}}.}
+\item{input}{The names of the variables being searched. This is \code{NULL} until
+computed by \code{\link[=prep]{prep()}}.}
 
 \item{sparse}{A single string. Should the columns produced be sparse vectors.
 Can take the values \code{"yes"}, \code{"no"}, and \code{"auto"}. If \code{sparse = "auto"}
@@ -116,6 +116,15 @@ with_dummies <- bake(rec2, new_data = covers)
 with_dummies
 tidy(rec, number = 1)
 tidy(rec2, number = 1)
+
+# When more than one variable is selected, the new variables are named
+# `{variable}_{result}`
+covers$description2 <- rev(covers$description)
+
+recipe(~., covers) |>
+  step_regex(description, description2, pattern = "rock", result = "rocks") |>
+  prep() |>
+  bake(new_data = NULL)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -1,15 +1,6 @@
 # bad selector(s)
 
     Code
-      step_count(rec, description, rows, pattern = "(rock|stony)")
-    Condition
-      Error in `step_count()`:
-      x For this step, only a single selector can be used.
-      i The following 2 selectors were used: `~description` and `~rows`.
-
----
-
-    Code
       prep(rec2, training = covers)
     Condition
       Error in `step_count()`:

--- a/tests/testthat/_snaps/regex.md
+++ b/tests/testthat/_snaps/regex.md
@@ -1,15 +1,6 @@
 # bad selector(s)
 
     Code
-      step_regex(rec, description, rows, pattern = "(rock|stony)")
-    Condition
-      Error in `step_regex()`:
-      x For this step, only a single selector can be used.
-      i The following 2 selectors were used: `~description` and `~rows`.
-
----
-
-    Code
       prep(rec4, training = covers)
     Condition
       Error in `step_regex()`:
@@ -26,15 +17,6 @@
       Caused by error in `bake()`:
       ! Name collision occurred. The following variable names already exist:
       * `Sepal.Width`
-
-# error on multiple selections
-
-    Code
-      step_regex(recipe(~., data = mtcars), vs, am)
-    Condition
-      Error in `step_regex()`:
-      x For this step, only a single selector can be used.
-      i The following 2 selectors were used: `~vs` and `~am`.
 
 # checks for grepl arguments
 

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -8,8 +8,12 @@ covers$ch_rows <- paste(1:nrow(covers))
 
 rec <- recipe(~ description + rows + ch_rows, covers)
 
-counts <- gregexpr(pattern = "(rock|stony)", text = covers$description)
-counts <- vapply(counts, function(x) length(x[x > 0]), integer(1))
+count_pattern <- function(text, pattern) {
+  matches <- gregexpr(pattern = pattern, text = text)
+  vapply(matches, function(x) length(x[x > 0]), integer(1))
+}
+
+counts <- count_pattern(covers$description, "(rock|stony)")
 chars <- nchar(covers$description)
 
 test_that("default options", {
@@ -47,12 +51,121 @@ test_that("nondefault options", {
 })
 
 test_that("bad selector(s)", {
-  expect_snapshot(
-    error = TRUE,
-    rec |> step_count(description, rows, pattern = "(rock|stony)")
-  )
   rec2 <- rec |> step_count(rows, pattern = "(rock|stony)")
   expect_snapshot(error = TRUE, prep(rec2, training = covers))
+})
+
+test_that("multiple selections work", {
+  res <- rec |>
+    step_count(description, ch_rows, pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_equal(res$description_ones, count_pattern(covers$description, "1"))
+  expect_equal(res$ch_rows_ones, count_pattern(covers$ch_rows, "1"))
+})
+
+test_that("a single selection is named with `result` alone", {
+  res <- rec |>
+    step_count(description, pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_equal(res$ones, count_pattern(covers$description, "1"))
+})
+
+test_that("a selector resolving to multiple columns works", {
+  res <- recipe(~ description + ch_rows, covers) |>
+    step_count(all_string_predictors(), pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_named(
+    res,
+    c("description", "ch_rows", "description_ones", "ch_rows_ones")
+  )
+})
+
+test_that("normalize works with multiple selections", {
+  res <- rec |>
+    step_count(
+      description,
+      ch_rows,
+      pattern = "1",
+      result = "ones",
+      normalize = TRUE
+    ) |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_equal(
+    res$description_ones,
+    count_pattern(covers$description, "1") / nchar(covers$description)
+  )
+  expect_equal(
+    res$ch_rows_ones,
+    count_pattern(covers$ch_rows, "1") / nchar(covers$ch_rows)
+  )
+})
+
+test_that("tidy method works with multiple selections", {
+  rec1 <- rec |>
+    step_count(description, ch_rows, pattern = "1", result = "ones") |>
+    prep(training = covers)
+
+  expect_identical(
+    tidy(rec1, number = 1),
+    tibble(
+      terms = c("description", "ch_rows"),
+      result = c("description_ones", "ch_rows_ones"),
+      id = rec1$steps[[1]]$id
+    )
+  )
+})
+
+test_that("keep_original_cols works with multiple selections", {
+  res <- rec |>
+    step_count(
+      description,
+      ch_rows,
+      pattern = "1",
+      result = "ones",
+      keep_original_cols = FALSE
+    ) |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_named(res, c("rows", "description_ones", "ch_rows_ones"))
+})
+
+test_that("sparse = 'yes' works with multiple selections", {
+  rec1 <- recipe(~ description + ch_rows, covers)
+
+  suppressWarnings({
+    dense <- rec1 |>
+      step_count(
+        description,
+        ch_rows,
+        pattern = "stony",
+        sparse = "no",
+        keep_original_cols = FALSE
+      ) |>
+      prep() |>
+      bake(NULL)
+    sparse <- rec1 |>
+      step_count(
+        description,
+        ch_rows,
+        pattern = "stony",
+        sparse = "yes",
+        keep_original_cols = FALSE
+      ) |>
+      prep() |>
+      bake(NULL)
+  })
+
+  expect_identical(dense, sparse)
+  expect_all_true(vapply(sparse, sparsevctrs::is_sparse_vector, logical(1)))
 })
 
 test_that("check_name() is used", {

--- a/tests/testthat/test-regex.R
+++ b/tests/testthat/test-regex.R
@@ -37,10 +37,6 @@ test_that("nondefault options", {
 })
 
 test_that("bad selector(s)", {
-  expect_snapshot(
-    error = TRUE,
-    rec |> step_regex(description, rows, pattern = "(rock|stony)")
-  )
   rec4 <- rec |> step_regex(rows, pattern = "(rock|stony)")
   expect_snapshot(error = TRUE, prep(rec4, training = covers))
 })
@@ -57,15 +53,104 @@ test_that("check_name() is used", {
   )
 })
 
-test_that("error on multiple selections", {
-  mtcars$vs <- as.character(mtcars$vs)
-  mtcars$am <- as.character(mtcars$am)
+test_that("multiple selections work", {
+  res <- rec |>
+    step_regex(description, ch_rows, pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
 
-  expect_snapshot(
-    error = TRUE,
-    recipe(~., data = mtcars) |>
-      step_regex(vs, am)
+  expect_equal(
+    res$description_ones,
+    as.integer(grepl("1", covers$description))
   )
+  expect_equal(
+    res$ch_rows_ones,
+    as.integer(grepl("1", covers$ch_rows))
+  )
+})
+
+test_that("a single selection is named with `result` alone", {
+  res <- rec |>
+    step_regex(description, pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_equal(
+    res$ones,
+    as.integer(grepl("1", covers$description))
+  )
+})
+
+test_that("a selector resolving to multiple columns works", {
+  res <- recipe(~ description + ch_rows, covers) |>
+    step_regex(all_string_predictors(), pattern = "1", result = "ones") |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_named(
+    res,
+    c("description", "ch_rows", "description_ones", "ch_rows_ones")
+  )
+})
+
+test_that("tidy method works with multiple selections", {
+  rec1 <- rec |>
+    step_regex(description, ch_rows, pattern = "1", result = "ones") |>
+    prep(training = covers)
+
+  expect_identical(
+    tidy(rec1, number = 1),
+    tibble(
+      terms = c("description", "ch_rows"),
+      result = c("description_ones", "ch_rows_ones"),
+      id = rec1$steps[[1]]$id
+    )
+  )
+})
+
+test_that("keep_original_cols works with multiple selections", {
+  res <- rec |>
+    step_regex(
+      description,
+      ch_rows,
+      pattern = "1",
+      result = "ones",
+      keep_original_cols = FALSE
+    ) |>
+    prep(training = covers) |>
+    bake(new_data = covers)
+
+  expect_named(res, c("rows", "description_ones", "ch_rows_ones"))
+})
+
+test_that("sparse = 'yes' works with multiple selections", {
+  rec1 <- recipe(~ description + ch_rows, covers)
+
+  suppressWarnings({
+    dense <- rec1 |>
+      step_regex(
+        description,
+        ch_rows,
+        pattern = "stony",
+        sparse = "no",
+        keep_original_cols = FALSE
+      ) |>
+      prep() |>
+      bake(NULL)
+    sparse <- rec1 |>
+      step_regex(
+        description,
+        ch_rows,
+        pattern = "stony",
+        sparse = "yes",
+        keep_original_cols = FALSE
+      ) |>
+      prep() |>
+      bake(NULL)
+  })
+
+  expect_identical(dense, sparse)
+  expect_all_true(vapply(sparse, sparsevctrs::is_sparse_vector, logical(1)))
 })
 
 test_that("checks for grepl arguments", {


### PR DESCRIPTION
Both steps were limited to a single variable, so `step_regex(description, rows)` errored in the constructor and a selector like `all_string_predictors()` that happened to resolve to several columns died later with an opaque tibble subscript error. They now create one new column per selected column.

Naming depends on the size of the selection: a single selected column keeps the bare `result` name it has today, so existing recipes and existing code are unaffected, while two or more produce `{column}_{result}`.

Closes #1384.